### PR TITLE
Copy helper files to sources dir as well

### DIFF
--- a/bakery_cli/pipe/copy.py
+++ b/bakery_cli/pipe/copy.py
@@ -46,7 +46,7 @@ class Pipe(object):
                 args = [op.join(self.project_root, self.filename),
                         self.builddir]
                 copy_single_file(op.join(self.project_root, self.filename),
-                                 self.builddir)
+                                 op.join(self.builddir, 'sources'))
             except:
                 logger.debug('Unable to copy files')
                 raise
@@ -189,7 +189,7 @@ class CopyLicense(Pipe):
             #  See: CopyLicense.supported_licenses attribute
             for lic in self.supported_licenses:
                 src = op.join(self.project_root, lic)
-                dest = op.join(self.builddir, lic)
+                dest = op.join(self.builddir, 'sources', lic)
                 if os.path.exists(src):
                     shellutil.copy(src, dest)
                     pipedata['license_file'] = lic


### PR DESCRIPTION
These files were not being copied to the sources subdir, but instead to its parent dir. This is causing the build to fail due to the missing files.