### PR TITLE
Temporarily disabling a broken pyfontaine code snippet…

### DIFF
--- a/bakery_cli/report/index.py
+++ b/bakery_cli/report/index.py
@@ -301,8 +301,11 @@ def generate(config):
 
     fonts_serialized = dict([(str(path), font_factory_instance_to_dict(fontaine)) for path, fontaine in fonts])
     report_app.summary_page.dump_file(fonts_serialized, 'fontaine_fonts.json')
-    fonts_orthography = get_orthography(fonts)
-    report_app.summary_page.dump_file({'fonts_list': fonts_orthography[0],
+
+    #Temporarily remove this broken piece of code
+    if False:
+        fonts_orthography = get_orthography(fonts)
+        report_app.summary_page.dump_file({'fonts_list': fonts_orthography[0],
                                        'coverage_averages': fonts_orthography[1],
                                        'fonts_info': fonts_orthography[2]},
                                       'fonts_orthography.json')

--- a/bakery_cli/report/review.py
+++ b/bakery_cli/report/review.py
@@ -86,6 +86,9 @@ def generate(config, outfile='review.html'):
                       'meta': f})
 
     report_app = report_utils.BuildInfo(config)
-    fonts_orthography = get_orthography(fonts)
+    
+    #temporarily disable broken orthography code
+    if False:
+        fonts_orthography = get_orthography(fonts)
 
-    report_app.review_page.dump_file(fonts_orthography, 'orthography.json')
+        report_app.review_page.dump_file(fonts_orthography, 'orthography.json')


### PR DESCRIPTION
…that deals with the get_orthographies method. It seems that this code is using a deprecated API method implementation. We gotta figure out what is the new way of implementing this, so that we can bring the feature back.