### PR TITLE
updating repository URLs to point to the new GitHub address of the AngularJS app…

### DIFF
--- a/bakery_cli/report/utils.py
+++ b/bakery_cli/report/utils.py
@@ -28,7 +28,7 @@ def render_template(templatename, *args, **kwargs):
 
 
 def _build_repo_url(base_url, *chunks, **kwargs):
-    repo_slug = os.environ.get('TRAVIS_REPO_SLUG', 'fontdirectory/dummy')
+    repo_slug = os.environ.get('TRAVIS_REPO_SLUG', 'googlefonts/dummy')
     if kwargs:
         return '{}?{}'.format(op.join(base_url, repo_slug, *chunks), urllib_parse(kwargs))
     return op.join(base_url, repo_slug, *chunks)
@@ -148,7 +148,7 @@ class ReviewPage(ReportPageBase):
 class BuildInfo(six.with_metaclass(Singleton, object)):
     def __init__(self, config, **kwargs):
         self.config = config
-        self.repo_slug = os.environ.get('TRAVIS_REPO_SLUG', 'fontdirectory/dummy')
+        self.repo_slug = os.environ.get('TRAVIS_REPO_SLUG', 'googlefonts/dummy')
         self.source_dir = kwargs.get('source_dir', BUILD_INFO_DIR)
         self.build_dir = kwargs.get('build_dir', self.config['path'])
         self.target_dir = kwargs.get('target_dir', op.join(self.config['path'], 'build_info'))
@@ -252,7 +252,7 @@ class BuildInfo(six.with_metaclass(Singleton, object)):
         <!DOCTYPE html>
         <html>
         <head>
-            <meta http-equiv="refresh" content="0; url=http://fontdirectory.github.io/collection/#/{slug}/" />"
+            <meta http-equiv="refresh" content="0; url=http://googlefonts.github.io/fontbakery/#/{slug}/" />"
             <title>{title}</title>
         </head>
         <body>
@@ -261,7 +261,7 @@ class BuildInfo(six.with_metaclass(Singleton, object)):
         self.write_file(tmpl, op.join(self.build_dir, 'index.html'))
 
     def write_readme_file(self):
-        tmpl = '[{}](http://fontdirectory.github.io/collection/#/{}/)'.format(self.repo_slug, self.repo_slug)
+        tmpl = '[{}](http://googlefonts.github.io/fontbakery/#/{}/)'.format(self.repo_slug, self.repo_slug)
         self.write_file(tmpl, op.join(self.build_dir, 'README.md'))
 
     def copy_ttf_fonts(self):


### PR DESCRIPTION
… (instead of the old jinja2 app at GoogleCode) This addresses issue #575