### PR TITLE
issue #597: Correction to the message displayed by fontbakery-fix-nbsp.py

### DIFF
--- a/bakery_cli/fixers.py
+++ b/bakery_cli/fixers.py
@@ -503,7 +503,7 @@ class NbspAndSpaceSameWidth(Fixer):
                     msg = 'ER: {} space None nbsp {}: Added space with advanceWidth {}'
                 logger.error(msg.format(fontfile, nbspWidth, nbspWidth))
                 
-            if nbspWidth > spaceWidth:
+            if nbspWidth > spaceWidth and spaceWidth >= 0:
                 if check:
                     msg = 'ER: {} space {} nbsp {}: Change space advanceWidth to {}'
                 else:


### PR DESCRIPTION
... when a space value is negative. (See https://github.com/googlefonts/fontbakery/issues/597#issuecomment-166557108)