### PR TITLE
Fix "space has ink"

### DIFF
--- a/bakery_cli/fixers.py
+++ b/bakery_cli/fixers.py
@@ -494,10 +494,10 @@ class NbspAndSpaceSameWidth(Fixer):
 
         space = self.getGlyph(0x0020)
         nbsp = self.getGlyph(0x00A0)
-        if space != "space":
-            logger.error('ER: {}: Glyph 0x0020 is called "{}": Change to "space"'.format(fontfile, space))
-        if nbsp != "nbsp":
-            logger.error('ER: {}: Glyph 0x00A0 is called "{}": Change to "nbsp"'.format(fontfile, nbsp))
+        if space not in ["space", "uni0020"]:
+            logger.error('ER: {}: Glyph 0x0020 is called "{}": Change to "space" or "uni0020"'.format(fontfile, space))
+        if nbsp not in ["nbsp", "uni00A0"]:
+            logger.error('ER: {}: Glyph 0x00A0 is called "{}": Change to "nbsp" or "uni00A0"'.format(fontfile, nbsp))
 
         isNbspAdded = isSpaceAdded = False
         if not nbsp:


### PR DESCRIPTION
issue #610 

```bash
felipe@guarana:~/devel/github_google/fonts$ fontbakery-fix-nbsp.py ofl/voces/Voces-Regular.ttf
ER: Voces-Regular.ttf: Glyph "uni00A0" has ink. Delete any contours or components
ER: Voces-Regular.ttf space 290 nbsp 614: Change space advanceWidth to 614
```

```bash
felipe@guarana:~/devel/github_google/fonts$ fontbakery-fix-nbsp.py ofl/voces/Voces-Regular.ttf --autofix
ER: Voces-Regular.ttf: Glyph "uni00A0" has ink. Fixed: Overwritten by an empty glyph
ER: Voces-Regular.ttf space 290 nbsp 614: Fixed space advanceWidth to 614
```

```bash
felipe@guarana:~/devel/github_google/fonts$ fontbakery-fix-nbsp.py ofl/atomicage/AtomicAge-Regular.ttf
ER: AtomicAge-Regular.ttf: Glyph 0x00A0 is called "dagger": Change to "nbsp" or "uni00A0"
ER: AtomicAge-Regular.ttf: Glyph "dagger" has ink. Delete any contours or components
```

```bash
felipe@guarana:~/devel/github_google/fonts$ fontbakery-fix-nbsp.py ofl/atomicage/AtomicAge-Regular.ttf --autofix
ER: AtomicAge-Regular.ttf: Glyph 0x00A0 is called "dagger": Change to "nbsp" or "uni00A0"
ER: AtomicAge-Regular.ttf: Glyph "dagger" has ink. Fixed: Overwritten by an empty glyph
```
