### PR TITLE
fix issue #615: "test_ttf.py TTFTestCase.test_ots() fails"

### DIFF
--- a/bakery_lint/fonttests/test_ttf.py
+++ b/bakery_lint/fonttests/test_ttf.py
@@ -377,8 +377,7 @@ class TTFTestCase(TestCase):
     def test_ots(self):
         """ Is TTF file correctly sanitized for Firefox and Chrome """
         stdout = run('{0} {1}'.format('ot-sanitise', self.operator.path),
-                     os.path.dirname(self.operator.path),
-                     log=self.operator.logger)
+                     os.path.dirname(self.operator.path))
         self.assertEqual('', stdout.strip())
 
     @autofix('bakery_cli.fixers.CreateDSIGFixer')


### PR DESCRIPTION
Remove the logger parameter to the invokation of the run method (a wrapper around popen). It was a left-over from an incomplete refactoring at commit https://github.com/googlefonts/fontbakery/commit/1bcd61a83b915c529bdd36695b6b56f1a6f2a8b4