### PR TITLE
This code block is iterating the webFontStyles, so if for a specific …

### DIFF
--- a/tools/fontbakery-metadata-vs-api.py
+++ b/tools/fontbakery-metadata-vs-api.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
                     log_messages.append([variant, 'ER', '"{}" checksum mismatch, file in API does not match file in git'.format(repoFileName)])
 
             except ValueError:
-                log_messages.append([variant, 'ER', '"{}" available in git but not in API'.format(font.filename)])
+                log_messages.append([variant, 'ER', '"{}" available in API but not in git'.format(font.filename)])
 
         for font in metadata.fonts:
             variant = getVariantName(font)


### PR DESCRIPTION
…style there's an error while looking for its corresponding font in git, then it means it it "available in API but not in git".