### PR TITLE
address 404 Error (ng-table/pager.html) by fixing an import bug …

### DIFF
--- a/bakery_cli/report/index.py
+++ b/bakery_cli/report/index.py
@@ -26,7 +26,7 @@ from fontaine.font import FontFactory
 from bakery_cli.scripts.vmet import get_metric_view
 from bakery_cli.utils import UpstreamDirectory
 from bakery_cli.report import utils as report_utils
-
+from bakery_cli.fonts_public_pb2 import FamilyProto
 
 TAB = 'Index'
 TEMPLATE_DIR = op.join(op.dirname(__file__), 'templates')

--- a/bakery_cli/report/review.py
+++ b/bakery_cli/report/review.py
@@ -21,6 +21,7 @@ import os.path as op
 from markdown import markdown
 from bakery_cli.report import utils as report_utils
 from bakery_cli.utils import UpstreamDirectory
+from bakery_cli.fonts_public_pb2 import FamilyProto
 from fontaine.cmap import Library
 from fontaine.font import FontFactory
 


### PR DESCRIPTION
…related to the recent migration to Protobuffers (as described at https://github.com/googlefonts/fontbakery/issues/611#issuecomment-184903664 )