### PR TITLE
fix issue #751: filter nameIDs in test_check_names_are_ascii_only to …

### DIFF
--- a/bakery_lint/fonttests/test_ttf.py
+++ b/bakery_lint/fonttests/test_ttf.py
@@ -287,10 +287,13 @@ class TTFTestCase(TestCase):
         font = Font.get_ttfont(self.operator.path)
 
         for name in font.names:
-            string = Font.bin2unistring(name)
-            marks = CharacterSymbolsFixer.unicode_marks(string)
-            if marks:
-                self.fail('Contains {}'.format(marks))
+            # Items with NameID > 18 are expressly for localising
+            # the ASCII-only IDs into Hindi / Arabic / etc.
+            if name.nameID >= 0 and name.nameID <= 18:
+                string = Font.bin2unistring(name)
+                marks = CharacterSymbolsFixer.unicode_marks(string)
+                if marks:
+                    self.fail('Contains {}'.format(marks))
 
     def test_fontname_is_equal_to_macstyle(self):
         """ Is fontname identical to macstyle flags? """


### PR DESCRIPTION
…only consider the ones in the inclusive range from 0 to 18