### PR TITLE
fix Apache licensing text string that we expect to see at the font fi…

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -200,9 +200,7 @@ PLACEHOLDER_LICENSING_TEXT = {
     'OFL.txt': 'This Font Software is licensed under the SIL Open Font License'
                ', Version 1.1. This license is available with a FAQ at: '
                'http://scripts.sil.org/OFL',
-    'LICENSE.txt': 'This Font Software is licensed under the Apache License, '
-                   'Version 2.0. This license is available with a FAQ at '
-                   'www.apache.org/foundation/license-faq.html'
+    'LICENSE.txt': 'Licensed under the Apache License, Version 2.0'
 }
 
 REQUIRED_TABLES = set(['cmap', 'head', 'hhea', 'hmtx', 'maxp', 'name',


### PR DESCRIPTION
…les name table

There are roughtly 3 hundred fonts at Google Fonts git repo using this wording, so that'll be our normative reference. (fixes issue #843)