### PR TITLE
give up parsing effort when failing to parse version string

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -1875,9 +1875,12 @@ def main():
                   rounded_string = round(float(v), 3)
 
                   name_version = name.string.decode(name.getEncoding())
-                  if " " in name_version:
-                    name_version = name_version.split(" ")[1]
-                  name_version = round(float(name_version), 3)
+                  try:
+                    if " " in name_version:
+                      name_version = name_version.split(" ")[1]
+                    name_version = round(float(name_version), 3)
+                  except:
+                    pass  # give up. it's definitely bad :(
 
                   if name_version != rounded_string:
                     fixes.append(("NAMEID_VERSION_STRING "


### PR DESCRIPTION
issue #896

Current code breaks with version strings such as "Version 4.5.1"
So here we fallback to failing the check (as the string is clearly different that what we're looging for in a successful check)
instead of crashing the tool.