### PR TITLE
fix setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     author_email='dave@lab6.com',
     scripts=['fontbakery-build-font2ttf.py',
              'fontbakery-build-fontmetadata.py',
-             'fontbakery-build-metadata.py',
+#             'fontbakery-build-metadata.py',
              'fontbakery-check-description.py',
              'fontbakery-check-ttf.py',
              'fontbakery-check-upstream.py',


### PR DESCRIPTION
remove missing file from list in setup.py
```
    error: file '/tmp/pip-CXkkOo-build/fontbakery-build-metadata.py' does not exist
````