### PR TITLE
delete a leftover "TODO:URGENT" comment from the sources

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -1308,11 +1308,6 @@ def main():
       log_results("post table italicAngle matches style name")
 
     # ----------------------------------------------------
-    # https://github.com/googlefonts/fontbakery/issues/932
-    # TODO: checker for proper italic names in name table
-    # DC THIS IS URGENT!
-
-    # ----------------------------------------------------
     fb.new_check("Checking fsSelection ITALIC bit")
     check_bit_entry(font, "OS/2", "fsSelection",
                     "Italic" in style,


### PR DESCRIPTION
as the described issue was already addressed earlier
at the "Assure valid format for the main entries in
the name table" check. See issue #932