### PR TITLE
fix issue #994: In order to make Travis Builds faster,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - "pip install git+https://github.com/behdad/fonttools.git"
   - "pip install git+https://github.com/googlei18n/glyphsLib.git"
 script:
+  - flake8 --statistics fontbakery-check-ttf.py --ignore=E111,E114,E701,E121,E266,E221,E226,E126
   - python fontbakery-check-ttf.py data/test/cousine/*.ttf
   - python fontbakery-check-ttf.py data/test/mada/*.ttf
   - python fontbakery-check-ttf.py data/test/merriweather/*.ttf
-  - flake8 --statistics fontbakery-check-ttf.py --ignore=E111,E114,E701,E121,E266,E221,E226,E126
   - python test_args.py


### PR DESCRIPTION
run flake8 before the other font checks