### PR TITLE
If font is not monospaced, don't run monospace checks

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -2954,9 +2954,7 @@ def main():
     fb.new_check("Monospace font has hhea.advanceWidthMax"
                  " equal to each glyph's advanceWidth ?")
     if monospace_detected:
-      fb.skip("Skipping monospace-only check.")
-    else:
-     # hhea:advanceWidthMax is treated as source of truth here.
+      # hhea:advanceWidthMax is treated as source of truth here.
       max_advw = font['hhea'].advanceWidthMax
       outliers = 0
       for glyph_id in font['glyf'].glyphs:
@@ -2973,6 +2971,8 @@ def main():
       else:
         fb.ok("hhea.advanceWidthMax is equal"
               " to all glyphs' advanceWidth in this monospaced font.")
+    else:
+      fb.skip("Skipping monospace-only check.")
 
 ##########################################################
 ## Metadata related checks:


### PR DESCRIPTION
Hey Felipe,

I'm testing Lobster with FB. I kept running into the following error:

`ERROR    This is a monospaced font, so advanceWidth value should be the same across all glyphs, but 99.9 % of them have a different value.`

Its clearly not a monospaced font.

It seems there was a switchup with one of the if statements. I swapped the if/else blocks and now get.

`INFO     SKIP: Skipping monospace-only check.`

Cheers,
Marc