### PR TITLE
copied xAvgCharWidth implementation from

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -1683,9 +1683,7 @@ def main():
       if count == 0:
         fb.error("CRITICAL: Found no glyph width data!")
       else:
-        # we add 0.5 in order to round the
-        # expected_value to the closest integer:
-        expected_value = int(float(width_sum)/count + 0.5)
+        expected_value = int(round(width_sum) / count)
         if font['OS/2'].xAvgCharWidth == expected_value:
           fb.ok("xAvgCharWidth is correct.")
         else:


### PR DESCRIPTION
Hey again,

Script was calculating Lobster's average character width to be 1220. I checked your implementation and compared it against Khaled's approach in a FontTools [commit](https://github.com/behdad/fonttools/commit/9e148a409dde9de693da648d9670267bd3f07602). His approach seem correct to me. 

Adding +0.5 to a float, then converting to int seems a bit dangerous to me. 

With my pr, I now get 1219 and it passes ;) 