### PR TITLE
Refactored font version checks

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -506,10 +506,13 @@ def parse_version_string(s):
         substrings = s.split('.')
         minor = substrings[-1]
         if ' ' in substrings[-2]:
-            major = int(substrings[-2].split(' ')[-1])
+            major = substrings[-2].split(' ')[-1]
         else:
-            major = int(substrings[-2])
-        return major, minor, suffix
+            major = substrings[-2]
+        if suffix:
+          return major, minor, suffix
+        else:
+          return major, minor
     except:
         fb.error("Failed to detect major and minor"
                  " version numbers in '{}'".format(s))
@@ -2035,10 +2038,10 @@ def main():
       for name in font['name'].names:
         if name.nameID == NAMEID_VERSION_STRING:
           name_version = name.string.decode(name.getEncoding())
-          regex = re.search(r'(Version [^\s;]*)(\s*;)?(.*)?', name_version)
-          version_without_comments = regex.group(1)
-          comments = regex.group(3)
-
+          # change Version 1.007 -> 1.007
+          version_stripped = r'(?<=[V|v]ersion )([0-9]{1,4}\.[0-9]{1,5})'
+          version_without_comments = re.search(version_stripped, name_version).group(0)
+          comments = re.split(r'(?<=[0-9]{1})[;\s]', name_version)[-1]
           if version_without_comments != expected_str:
             # maybe the version strings differ only
             # on floating-point error, so let's
@@ -2061,7 +2064,7 @@ def main():
                 else:
                   fb.error(("NAMEID_VERSION_STRING value '{}'"
                             " does not match expected '{}'"
-                            "").format(name_version, fix))
+                          "").format(name_version, fix))
             except:
               failed = True  # give up. it's definitely bad :(
               fb.error("Unable to parse font version info"


### PR DESCRIPTION
Hey,

I found your regex expressions to strip 'Version 1.007' -> '1.007' with comments  to be faulty. It was hard to find due to the try and accept block. Instead of using regex.group(0), I've opted to use two different expressions with clearer syntax for each group.

Cheers,
Marc