### PR TITLE
Fixing broken font checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ brew install fontforge --with-extra-tools --HEAD ;
 easy_install pip;
 pip install --upgrade git+https://github.com/behdad/fontTools.git; 
 
+# install python dependencies
+pip install -r requirements.txt
+
 # install pyfontaine
 CFLAGS=-I/usr/local/opt/icu4c/include LDFLAGS=-L/usr/local/opt/icu4c/lib pip install pyicu;
 pip install --upgrade git+https://github.com/davelab6/pyfontaine.git; 
@@ -95,6 +98,9 @@ rm -rf ots;
 
 # install fonttools
 pip install --upgrade git+https://github.com/behdad/fontTools.git;
+
+# install python dependencies
+pip install -r requirements.txt
 
 # install fontbakery
 pip install --upgrade git+https://github.com/googlefonts/fontbakery.git; 

--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -2810,16 +2810,19 @@ def main():
         for name2 in font['name'].names:
           if ((name2.platformID == PLATFORM_ID_MACINTOSH) and
              (name2.langID == LANG_ID_MACINTOSH_ENGLISH)):
-             n1 = get_name_string(font,
-                                  name1.nameID,
-                                  name1.platformID,
-                                  name1.langID)
-             n2 = get_name_string(font,
-                                  name2.nameID,
-                                  name2.platformID,
-                                  name2.langID)
-             if len(n1) == 0 or len(n2) == 0 or n1[0] != n2[0]:
-               failed = True
+            if name1.nameID == name2.nameID:
+              n1 = get_name_string(font,
+                                   name1.nameID,
+                                   name1.platformID,
+                                   name1.platEncID,
+                                   name1.langID)
+              n2 = get_name_string(font,
+                                   name2.nameID,
+                                   name2.platformID,
+                                   name2.platEncID,
+                                   name2.langID)
+            if len(n1) == 0 or len(n2) == 0 or n1[0] != n2[0]:
+              failed = True
     if failed:
       fb.error('Entries in "name" table are not'
                ' the same across specific platforms.')

--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -2632,7 +2632,8 @@ def main():
     if 'CFF ' in font:
       fb.skip("This check does not support CFF fonts.")
     else:
-      expected = len(font['loca'])
+      # -1 because https://www.microsoft.com/typography/otspec/loca.htm
+      expected = len(font['loca']) - 1
       actual = len(font['glyf'])
       diff = actual - expected
 

--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -506,10 +506,13 @@ def parse_version_string(s):
         substrings = s.split('.')
         minor = substrings[-1]
         if ' ' in substrings[-2]:
-            major = int(substrings[-2].split(' ')[-1])
+            major = substrings[-2].split(' ')[-1]
         else:
-            major = int(substrings[-2])
-        return major, minor, suffix
+            major = substrings[-2]
+        if suffix:
+          return major, minor, suffix
+        else:
+          return major, minor
     except:
         fb.error("Failed to detect major and minor"
                  " version numbers in '{}'".format(s))
@@ -2035,10 +2038,10 @@ def main():
       for name in font['name'].names:
         if name.nameID == NAMEID_VERSION_STRING:
           name_version = name.string.decode(name.getEncoding())
-          regex = re.search(r'(Version [^\s;]*)(\s*;)?(.*)?', name_version)
-          version_without_comments = regex.group(1)
-          comments = regex.group(3)
-
+          # change Version 1.007 -> 1.007
+          version_stripped = r'(?<=[V|v]ersion )([0-9]{1,4}\.[0-9]{1,5})'
+          version_without_comments = re.search(version_stripped, name_version).group(0)
+          comments = re.split(r'(?<=[0-9]{1})[;\s]', name_version)[-1]
           if version_without_comments != expected_str:
             # maybe the version strings differ only
             # on floating-point error, so let's

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+beautifulsoup4==4.5.1
+bs4==0.0.1
+defusedxml==0.4.1
+fontaine==1.3.12
+fonttools==3.0
+lxml==3.4.2
+protobuf==3.0.0
+PyICU==1.9.3
+python-magic==0.4.12
+requests==2.11.1
+six==1.10.0
+tabulate==0.7.5
+Unidecode==0.4.19
+wheel==0.24.0


### PR DESCRIPTION
Hey,

I've fixed some more tests today. I just rebased these, since you just fixed the magiccode issue. It should all merge just fine. Please review each of these commits.

**Refactored font version checks**
I found your regex expressions to strip 'Version 1.007' -> '1.007' with comments to be faulty. It was hard to find due to the try and accept block. Instead of using regex.group(0), I've opted to use two different expressions with clearer syntax for each group.

**Fixed Font names are consistent across platforms**
The Windows names were not parsing correctly.

**Is there any unused data at the end of the glyf table?**
According to the MS Spec. The loca table is always 1 item higher than the glyf table. [ https://www.microsoft.com/typography/otspec/loca.htm]( https://www.microsoft.com/typography/otspec/loca.htm). I thought this was an error in FT but I was wrong, [#663](https://github.com/behdad/fonttools/issues/663)

**pip requirements**
I found the installation instructions on the README lacked dependencies. Imo, this is still not a perfect solution.

Cheers,
Marc