### PR TITLE
make the "em size==1000?" check warning-only and

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -2882,12 +2882,15 @@ def main():
 
     # ----------------------------------------------------
     fb.new_check("Is font em size (ideally) equal to 1000?")
-    upm_height = font['head'].unitsPerEm
-    if upm_height != 1000:
-      fb.error(("font em size ({}) is not"
-                " equal to 1000.").format(upm_height))
+    if args.skip:
+      fb.skip("Skipping this Google-Fonts specific check.")
     else:
-      fb.ok("Font em size is equal to 1000.")
+      upm_height = font['head'].unitsPerEm
+      if upm_height != 1000:
+        fb.warning(("font em size ({}) is not"
+                    " equal to 1000.").format(upm_height))
+      else:
+        fb.ok("Font em size is equal to 1000.")
 
 ##########################################################
 ##  Checks ported from:                                 ##

--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -2040,7 +2040,8 @@ def main():
           name_version = name.string.decode(name.getEncoding())
           # change Version 1.007 -> 1.007
           version_stripped = r'(?<=[V|v]ersion )([0-9]{1,4}\.[0-9]{1,5})'
-          version_without_comments = re.search(version_stripped, name_version).group(0)
+          version_without_comments = re.search(version_stripped,
+                                               name_version).group(0)
           comments = re.split(r'(?<=[0-9]{1})[;\s]', name_version)[-1]
           if version_without_comments != expected_str:
             # maybe the version strings differ only


### PR DESCRIPTION
google-fonts specific so that it can be skipped with -s/--skip
(issue #1009)