### PR TITLE
fix fb-build-fontmetadata crash when all fonts blacklisted

### DIFF
--- a/fontbakery-build-fontmetadata.py
+++ b/fontbakery-build-fontmetadata.py
@@ -243,6 +243,10 @@ def main():
   # analyse fonts
   fontinfo = analyse_fonts(files_to_process)
 
+  if fontinfo == {}:
+    print("All specified fonts are blacklisted!")
+    sys.exit()
+
   # normalise weights
   weights = []
   for key in sorted(fontinfo.keys()):


### PR DESCRIPTION
issue #1013