### PR TITLE
build-contributors.py

### DIFF
--- a/fontbakery-build-contributors.py
+++ b/fontbakery-build-contributors.py
@@ -1,0 +1,48 @@
+'''Generate a CONTRIBUTORS.txt document from a repository's git history.'''
+import git
+import sys
+import os
+import re
+
+
+CONTRIBUTORS_HEAD = \
+'''# This is the list of people who have contributed to this project,
+# and includes those not listed in AUTHORS.txt because they are not
+# copyright authors. For example, company employees may be listed
+# here because their company holds the copyright and is listed there.
+#
+# When adding J Random Contributor's name to this file, either J's
+# name or J's organization's name should be added to AUTHORS.txt
+#
+# Names should be added to this file as:
+# Name <email address>
+
+'''
+
+
+def main(folder):
+    log = git.Git(folder).log()
+    commit_list = re.findall(r'(?<=Author: ).*', log)
+    contributors = []
+    # Add contributors in reverse. Should mean project creator is first
+    for contributor in commit_list[::-1]:
+        if contributor not in contributors:
+            contributors.append(contributor)
+
+    contrib_file = os.path.join(folder, 'CONTRIBUTORS.txt')
+    if os.path.isfile(contrib_file):
+        print "CONTRIBUTORS.txt already exists, adding '_copy' suffix\n"
+        contrib_file = os.path.join(folder, 'CONTRIBUTORS_copy.txt')
+
+    with open(os.path.join(folder, contrib_file), 'w') as doc:
+        doc.write(CONTRIBUTORS_HEAD)
+        doc.write('\n'.join(contributors))
+    print 'Finished generating CONTRIBUTORS.txts. File saved at %s' % (folder)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print 'ERROR: please add one source folder which contains git commits'
+    else:
+        folder = sys.argv[-1]
+        main(folder)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six==1.10.0
 tabulate==0.7.5
 Unidecode==0.4.19
 wheel==0.24.0
+GitPython==0.3.2rc1


### PR DESCRIPTION
Hey,

We should be generating the CONTRIBUTORS.txt files for Google Font repositories from the git logs.

This script will order the contributers by the earliest date first. Theoretically, this means the project creator should be first. 

Two caveats with this approach:
1. If a repository was not originally a git repo, then the author will not be listed. 
2. Many github users don't give their real name. We may have entries like space-nutz10 <space@nutz10.com>

In both cases I recommend a tidyup and check after generation. This is how we have to approach generating the METADATA.pb  as well.