### PR TITLE
fix flake8 error:

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -1735,8 +1735,8 @@ def main():
       ftx_data = plistlib.readPlistFromString(ftx_output)
       # we accept kATSFontTestSeverityInformation
       # and kATSFontTestSeverityMinorError
-      if 'kATSFontTestSeverityFatalError' not in \
-                                      ftx_data['kATSFontTestResultKey']:
+      if 'kATSFontTestSeverityFatalError' \
+         not in ftx_data['kATSFontTestResultKey']:
         fb.ok("ftxvalidator passed this file")
       else:
         ftx_cmd = ["ftxvalidator",


### PR DESCRIPTION
fontbakery-check-ttf.py:1739:39: E127 continuation line over-indented for visual indent
1     E127 continuation line over-indented for visual indent
(issue #1058)