### PR TITLE
check-ttf: Added "Heavy" font styles

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -60,6 +60,7 @@ STYLE_NAMES = ["Thin",
                "Bold",
                "ExtraBold",
                "Black",
+               "Heavy",
                "Thin Italic",
                "ExtraLight Italic",
                "Light Italic",
@@ -68,7 +69,8 @@ STYLE_NAMES = ["Thin",
                "SemiBold Italic",
                "Bold Italic",
                "ExtraBold Italic",
-               "Black Italic"]
+               "Black Italic",
+               "Heavy Italic"]
 
 RIBBI_STYLE_NAMES = ["Regular",
                      "Italic",
@@ -84,7 +86,8 @@ WEIGHTS = {"Thin": 250,
            "SemiBold": 600,
            "Bold": 700,
            "ExtraBold": 800,
-           "Black": 900}
+           "Black": 900,
+           "Heavy": 950}
 
 # code-points for all "whitespace" chars:
 WHITESPACE_CHARACTERS = [


### PR DESCRIPTION
Hey folks,

Black was not enough for some folks over on the GF team. We now have Heavy ;)

![screen shot 2016-09-28 at 14 17 24](https://cloud.githubusercontent.com/assets/7525512/18913110/4ff7ecd2-8586-11e6-8726-41e6a1a17411.png)

I've added the style name and set its weight to 950. 

Please do not merge this if it's going to cause problems. @davelab6 & @felipesanches what are your thoughts on this?

Cheers,
Marc