### PR TITLE
use unicode literals with fontTools setName

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -211,9 +211,9 @@ LANG_ID_ENGLISH_USA = 0x0409
 LANG_ID_MACINTOSH_ENGLISH = 0
 
 PLACEHOLDER_LICENSING_TEXT = {
-    'OFL.txt': u'This Font Software is licensed under the SIL Open Font License'
-               ', Version 1.1. This license is available with a FAQ at: '
-               'http://scripts.sil.org/OFL',
+    'OFL.txt': u'This Font Software is licensed under the SIL Open Font '
+               'License, Version 1.1. This license is available with a FAQ '
+               'at: http://scripts.sil.org/OFL',
     'LICENSE.txt': u'Licensed under the Apache License, Version 2.0'
 }
 

--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -211,20 +211,20 @@ LANG_ID_ENGLISH_USA = 0x0409
 LANG_ID_MACINTOSH_ENGLISH = 0
 
 PLACEHOLDER_LICENSING_TEXT = {
-    'OFL.txt': 'This Font Software is licensed under the SIL Open Font License'
+    'OFL.txt': u'This Font Software is licensed under the SIL Open Font License'
                ', Version 1.1. This license is available with a FAQ at: '
                'http://scripts.sil.org/OFL',
-    'LICENSE.txt': 'Licensed under the Apache License, Version 2.0'
+    'LICENSE.txt': u'Licensed under the Apache License, Version 2.0'
 }
 
 LICENSE_URL = {
-    'OFL.txt': 'http://scripts.sil.org/OFL',
-    'LICENSE.txt': 'http://www.apache.org/licenses/LICENSE-2.0'
+    'OFL.txt': u'http://scripts.sil.org/OFL',
+    'LICENSE.txt': u'http://www.apache.org/licenses/LICENSE-2.0'
 }
 
 LICENSE_NAME = {
-    'OFL.txt': 'Open Font',
-    'LICENSE.txt': 'Apache'
+    'OFL.txt': u'Open Font',
+    'LICENSE.txt': u'Apache'
 }
 
 REQUIRED_TABLES = set(['cmap', 'head', 'hhea', 'hmtx', 'maxp', 'name',


### PR DESCRIPTION
This is to prevent fontbakery from writing gibberish to the name table (e.g. an (ascii) byte string `b"cosimo"` being decoded as an (utf-16be) `u'捯獩浯'`), following a change in upstream fonttools:

https://github.com/fonttools/fonttools/pull/688

See my comments here: https://github.com/googlefonts/fontbakery/commit/965bb96b55cf201d28e48887a72807bfd4797e0e#commitcomment-19299810

Note that I haven't checked all the strings elsewhere in the library; I noticed these ones in particular because they are been fed to `NameRecord.setName`, or are compared against other name strings.

Using `from __future__ import unicode_literals` at the top could be the quickest solution to the unicode/bytes confusion, but you will need to check that it doesn't produce other issues with other libraries (sometimes even from the stdlib) which might not support unicode strings properly on Python 2.