### PR TITLE
remove TTX file that was mistakenly declared in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,6 @@ setup(
                  'data/test/merriweather/FONTLOG.txt',
                  'data/test/merriweather/Merriweather-BlackItalic.ttf',
                  'data/test/merriweather/Merriweather-Black.ttf',
-                 'data/test/merriweather/Merriweather-Black.ttx',
                  'data/test/merriweather/Merriweather-BoldItalic.ttf',
                  'data/test/merriweather/Merriweather-Bold.ttf',
                  'data/test/merriweather/Merriweather-Italic.ttf',


### PR DESCRIPTION
This pull request addresses the problems described at issue #1115 