### PR TITLE
fix-fsselection: fsSelection bit 7 (Use Typo Metrics) flag can now be…

### DIFF
--- a/fontbakery-fix-fsselection.py
+++ b/fontbakery-fix-fsselection.py
@@ -25,6 +25,7 @@ parser = argparse.ArgumentParser(description='Print out fsSelection'
                                              ' bitmask of the fonts')
 parser.add_argument('font', nargs="+")
 parser.add_argument('--csv', default=False, action='store_true')
+parser.add_argument('--usetypometrics', default=False, action='store_true')
 parser.add_argument('--autofix', default=False, action='store_true')
 
 STYLE_NAMES = ["Thin",
@@ -145,6 +146,12 @@ def main():
         ttfont['OS/2'].fsSelection |= 0b1
       else:
         ttfont['OS/2'].fsSelection &= ~0b1
+
+      if args.usetypometrics:
+        ttfont['OS/2'].version = 4
+        ttfont['OS/2'].fsSelection |= 0b10000000
+      else:
+        ttfont['OS/2'].fsSelection &= ~0b10000000
 
       if ttfont['OS/2'].fsSelection != initial_value:
         fixed_fonts.append(font)


### PR DESCRIPTION
@felipesanches @davelab6 Since I need to hotfix [Lato](https://github.com/google/fonts/issues/6). I've decided to add some capabilities to FB in order for me to do this.

The hotfix script should just be a shell script, which relies on scripts from FB, imo. This means I can recycle better for future hotfix projects :-)

This pr will simply add the 'Use Typo Metrics' flag bit to the [fs selection](https://www.microsoft.com/typography/OTSpec/os2.htm#fss).
Cheers,
Marc