### PR TITLE
check-bbox.py: Check glyphs across a collection of fonts 

### DIFF
--- a/fontbakery-check-bbox.py
+++ b/fontbakery-check-bbox.py
@@ -14,19 +14,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-#
-# bbox.py: A FontForge python script for printing bounding boxes
-# to stdout in this format:
-#
-#   glyphname xmin ymin xmax ymax
-#
-# Usage:
-#
-#   $ python bbox.py Font.ttf 2> /dev/null
-#   A 42.0 -32.0 782.0 1440.0
-#   B 46.0 -72.0 752.0 1478.0
-#   C 53.0 -26.0 821.0 1442.0
-#   D 77.0 -26.0 773.0 1442.0
 
 import argparse
 import csv
@@ -34,7 +21,18 @@ import fontforge, sys
 from fontTools.ttLib import TTFont
 import tabulate
 
-description = "A Python script for printing bounding boxes to stdout"
+description = """
+A Python script for printing bounding boxes to stdout.
+Users can either check a collection of fonts bounding boxes (--family) or
+the bounding box for each glyph in the collection of fonts (--glyphs).
+
+Check bounding boxes of fonts in collection:
+python fontbakery-check-bbox.py --family [fonts]
+
+Check bounding boxes of glyphs in fonts collection:
+python fontbakery-check-bbox.py --glyphs [fonts]
+
+"""
 parser = argparse.ArgumentParser(description=description)
 parser.add_argument('fonts',
                     nargs="+",
@@ -44,7 +42,6 @@ group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument('--glyphs', default=False, action="store_true")
 group.add_argument('--family', default=False, action="store_true",
                    help='Return the bounds for a family of fonts')
-
 
 
 def printInfo(rows, save=False):

--- a/fontbakery-check-bbox.py
+++ b/fontbakery-check-bbox.py
@@ -30,25 +30,44 @@
 
 import argparse
 import fontforge, sys
+from fontTools.ttLib import TTFont
 
-description = "A FontForge python script for printing bounding boxes to stdout"
+description = "A Python script for printing bounding boxes to stdout"
 parser = argparse.ArgumentParser(description=description)
-parser.add_argument('font',
-                    nargs=1,
-                    help="Font in OpenType (TTF/OTF) format")
+parser.add_argument('fonts',
+                    nargs="+",
+                    help="Fonts in OpenType (TTF/OTF) format")
+group = parser.add_mutually_exclusive_group()
+group.add_argument('--glyphs', default=False, action="store_true")
+group.add_argument('--family', default=False, action="store_true",
+                   help='Return the bounds for a family of fonts')
 
 
 def main():
     args = parser.parse_args()
-    font_in = args.font[0]
-    font = fontforge.open(font_in)
-    for g in fontforge.activeFont().glyphs():
-        bbox = g.boundingBox()
-        print str(g.glyphname),
-        print str(bbox[0]),
-        print str(bbox[1]),
-        print str(bbox[2]),
-        print str(bbox[3])
+
+    for font in args.fonts:
+        font_path = font
+        if args.glyphs:
+            font = fontforge.open(font)
+            for g in fontforge.activeFont().glyphs():
+                bbox = g.boundingBox()
+                print font_path,
+                print str(g.glyphname),
+                print str(bbox[0]),
+                print str(bbox[1]),
+                print str(bbox[2]),
+                print str(bbox[3])
+
+        elif args.family:
+            print font_path
+            font = TTFont(font_path)
+            print font_path,
+            print font['head'].xMin,
+            print font['head'].yMin,
+            print font['head'].xMax,
+            print font['head'].yMax
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Hey folks,

I needed a way to calculate the yMin and yMax to get [Lato](https://github.com/google/fonts/issues/6) out the door. In order to find these extremes, I thought it would be a good idea to improve our existing check-bbox.py script.

It previously only returned the bboxes for glyphs in 1 font. My improvement allows users to check either the bboxes for glyphs in a collection of fonts, or the bboxes in a collection of fonts.

I've added another arg to return just the extremes. 

Csv and tabular output also included. 

![screen shot 2016-11-22 at 13 47 13](https://cloud.githubusercontent.com/assets/7525512/20524310/3983b152-b0ba-11e6-87e0-33a99bf75e43.png)

Also, I've included the type of doc string/description I would love to see for all of these scripts:

