### PR TITLE
check-bbox.py: fixed find_extremes yMin and xMin values.

### DIFF
--- a/fontbakery-check-bbox.py
+++ b/fontbakery-check-bbox.py
@@ -85,7 +85,7 @@ def find_extremes(rows):
             if k not in extremes:
                 extremes[k] = int(v)
             else:
-                if abs(int(v)) > extremes[k]:
+                if abs(int(v)) > abs(extremes[k]):
                     extremes[k] = v
     return [extremes.items()]
 


### PR DESCRIPTION
It turns out I wasn't returning the smallest yMin and xMin correctly. This is because I forgot to compare it against an abs value. e.g:

previous:
```
>>> current = -10
>>> new = -5
>>> if abs(new) > current:
...     current = new
...
>>> current
-5
```


new:
```
>>> current = -10
>>> new = -5
>>> if abs(new) > abs(current):
...     current = new
...
>>> current
-10
```


