### PR TITLE
fix-vertical-metrics.py: fixed linegaps arguments.

### DIFF
--- a/fontbakery-fix-vertical-metrics.py
+++ b/fontbakery-fix-vertical-metrics.py
@@ -265,6 +265,7 @@ def main():
   if options.ascents or \
      options.descents or \
      options.linegaps or \
+     options.linegaps  == 0 or \
      options.ascents_hhea or \
      options.ascents_typo or \
      options.ascents_win or \
@@ -272,7 +273,9 @@ def main():
      options.descents_typo or \
      options.descents_win or \
      options.linegaps_hhea or \
-     options.linegaps_typo:
+     options.linegaps_hhea == 0 or \
+     options.linegaps_typo or \
+     options.linegaps_typo == 0:
     for f in fonts:
       try:
         ttfont = ttLib.TTFont(f)
@@ -290,7 +293,7 @@ def main():
         ttfont['OS/2'].sTypoDescender = options.descents
         ttfont['OS/2'].usWinDescent = abs(options.descents)
 
-      if options.linegaps:
+      if options.linegaps or options.linegaps == 0:
         ttfont['hhea'].lineGap = options.linegaps
         ttfont['OS/2'].sTypoLineGap = options.linegaps
 
@@ -308,9 +311,9 @@ def main():
       if options.descents_win:
         ttfont['OS/2'].usWinDescent = abs(options.descents_win)
 
-      if options.linegaps_hhea:
+      if options.linegaps_hhea or options.linegaps_hhea == 0:
         ttfont['hhea'].lineGap = options.linegaps_hhea
-      if options.linegaps_typo:
+      if options.linegaps_typo or options.linegaps_typo == 0:
         ttfont['OS/2'].sTypoLineGap = options.linegaps_typo
 
       ttfont.save(f + '.fix')


### PR DESCRIPTION
 Previously, the script would not recoginise any linegap arguements, if their value was 0. This is because Python treats 0 as a False statement.