### PR TITLE
build-ofl.py: generate an OFL.txt license

### DIFF
--- a/fontbakery-build-ofl.py
+++ b/fontbakery-build-ofl.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+# Copyright 2016 The Fontbakery Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import argparse
+import os
+import logging
+from fontTools.ttLib import TTFont
+
+OFL_HEAD = \
+'''
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+'''
+
+description = "Generate an OFL.txt license document"
+parser = argparse.ArgumentParser(description=description)
+parser.add_argument('folder',
+                    nargs=1,
+                    help="folder containing font family")
+
+
+log_format = '%(levelname)-8s %(message)s'
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+formatter = logging.Formatter(log_format)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+def fonts(folder):
+    return [TTFont(os.path.join(folder, f)) for f in os.listdir(folder)
+            if 'ttf' in f]
+
+
+def _consistent_copyright_string(fonts):
+    copyright_strings = []
+
+    for font in fonts:
+        font_c_string = font['name'].getName(0, 1, 0, 0)
+        copyright_strings.append(str(font_c_string))
+
+    if len(set(copyright_strings)) != 1:
+        logger.warning('Copyright strings not consistent across family')
+        return False
+    else:
+        return str(copyright_strings[0])
+
+
+def _correct_copyright_string(copyright_string):
+    if 'Project Authors' in copyright_string:
+        return True
+    logger.warning('Project Authors missing in copyright string')
+    return False
+
+
+def generate_ofl(fonts):
+    family_copyright_string = _consistent_copyright_string(fonts)
+    if family_copyright_string:
+        if _correct_copyright_string(family_copyright_string):
+            return ''.join([family_copyright_string, OFL_HEAD])
+    return False
+
+
+def main():
+    args = parser.parse_args()
+    folder = args.folder[0]
+
+    if 'OFL.txt' not in os.listdir(folder):
+        font_family = fonts(folder)
+
+        if font_family:
+            license_txt = generate_ofl(font_family)
+            ofl_path = os.path.join(folder, 'OFL.txt')
+
+            if license_txt:
+                with open(ofl_path, 'w') as ofl_doc:
+                    ofl_doc.write(license_txt)
+                    logger.info("Generated OFL, %s" % ofl_path)
+        else:
+            logger.warning('No .ttfs in folder')
+    else:
+        logger.warning('OFL.txt exists, aborting')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Generate an OFL.txt using the font family's copyright string. The following criteria must be fulfilled in order for the document to be generated:

- copyright string is consistent across all fonts in the family
- 'Project Authors' is included in the string
- OFL.txt doesn't exist already