### PR TITLE
check-ttf.py: Added "Amatica SC" to "FAMILY_WITH_SPACES_EXCEPTIONS".

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -1017,7 +1017,8 @@ def check_main_entries_in_the_name_table(fb, font, font_file):
   def family_with_spaces(value):
     FAMILY_WITH_SPACES_EXCEPTIONS = {'VT323': 'VT323',
                                      'PressStart2P': 'Press Start 2P',
-                                     'AmaticSC': 'Amatic SC'}
+                                     'AmaticSC': 'Amatic SC',
+                                     'AmaticaSC': 'Amatica SC'}
     if value in FAMILY_WITH_SPACES_EXCEPTIONS.keys():
       return FAMILY_WITH_SPACES_EXCEPTIONS[value]
     result = ''


### PR DESCRIPTION
Currently, I'm releasing a companion font for Amatic SC, called Amatica SC.

It has the same problem with the 'SC' suffix. FB wants 'S C', so we have to add it to the FAMILY_WITH_SPACES_EXCEPTIONS list.

Cheers,
Marc