### PR TITLE
issue #1195: use 80% of the window width for the table...

### DIFF
--- a/webapp/app/static/index.html
+++ b/webapp/app/static/index.html
@@ -13,7 +13,7 @@
             font-family: Raleway, sans-serif;
         }
         article {
-            width: 600px;
+            width: 80%;
             margin: 0 auto;
         }
 


### PR DESCRIPTION
...and, actually for everything on the page. This gives us
more room for viewing the check-results log messages.

This pull request addresses the problems described at issue #1195 
