### PR TITLE
check-ttf.py: Fixed IOError for function check_with_msfontvalidator.

### DIFF
--- a/fontbakery-check-ttf.py
+++ b/fontbakery-check-ttf.py
@@ -1767,27 +1767,26 @@ def check_with_msfontvalidator(fb, font_file):
                   "-all-tables",
                   "-report-in-font-dir"]
       subprocess.check_output(fval_cmd, stderr=subprocess.STDOUT)
+      xml_report = open("{}.report.xml".format(font_file), "r").read()
+      doc = defusedxml.lxml.fromstring(xml_report)
+      for report in doc.iter('Report'):
+        if report.get("ErrorType") == "P":
+          fb.ok("MS-FonVal: {}".format(report.get("Message")))
+        elif report.get("ErrorType") == "E":
+          fb.error("MS-FonVal: {} DETAILS: {}".format(report.get("Message"),
+                                                      report.get("Details")))
+        elif report.get("ErrorType") == "W":
+          fb.warning("MS-FonVal: {} DETAILS: {}".format(report.get("Message"),
+                                                        report.get("Details")))
+        else:
+          fb.info("MS-FontVal: {}".format(report.get("Message")))
     except subprocess.CalledProcessError, e:
       fb.info(("Microsoft Font Validator returned an error code."
                " Output follows :\n\n{}\n").format(e.output))
-    except OSError:
+    except OSError, IOError:
       fb.warning("Mono runtime and/or "
                  "Microsoft Font Validator are not available!")
       return
-
-    xml_report = open("{}.report.xml".format(font_file), "r").read()
-    doc = defusedxml.lxml.fromstring(xml_report)
-    for report in doc.iter('Report'):
-      if report.get("ErrorType") == "P":
-        fb.ok("MS-FonVal: {}".format(report.get("Message")))
-      elif report.get("ErrorType") == "E":
-        fb.error("MS-FonVal: {} DETAILS: {}".format(report.get("Message"),
-                                                    report.get("Details")))
-      elif report.get("ErrorType") == "W":
-        fb.warning("MS-FonVal: {} DETAILS: {}".format(report.get("Message"),
-                                                      report.get("Details")))
-      else:
-        fb.info("MS-FontVal: {}".format(report.get("Message")))
 
 
 def check_fontforge_outputs_error_msgs(fb, font_file):


### PR DESCRIPTION
If the user doesn't have MS Font Validator installed, the file report.xml
will not be generated. The variable xml_report will not be able to load this
file. By adding this variable and subsequent statements to the try and accept
block, it will run the exception and not crash the script, if the user does
not have MS Validator installed.

Just for further clarity, here's the traceback:

```
Traceback (most recent call last):
  File "fontbakery-check-ttf.py", line 4261, in <module>
    fontbakery_check_ttf(config)
  File "fontbakery-check-ttf.py", line 4047, in fontbakery_check_ttf
    check_with_msfontvalidator(fb, target.fullpath)
  File "fontbakery-check-ttf.py", line 1778, in check_with_msfontvalidator
    xml_report = open("{}.report.xml".format(font_file), "r").read()
IOError: [Errno 2] No such file or directory: '/Users/marc/Documents/googlefonts/fonts/ofl/amaticsc/AmaticSC-Bold.ttf.report.xml'
```