### PR TITLE
nametable-from-filename: add name fields if they're missing

### DIFF
--- a/fontbakery-nametable-from-filename.py
+++ b/fontbakery-nametable-from-filename.py
@@ -111,6 +111,7 @@ def _unique_id(version, vendor_id, filename):
   # version;vendorID;filename
   return '%s;%s;%s' % (version, vendor_id, filename)
 
+
 def _version(text):
   return re.search(r'[0-9]{1,4}\.[0-9]{1,8}', text).group(0)
 
@@ -183,9 +184,9 @@ def nametable_from_filename(filepath):
   font_version = font['name'].getName(5, 3, 1, 1033)
   font_version = str(font_version).decode('utf_16_be')
   vendor_id = font['OS/2'].achVendID
-  
+
   # SET MAC NAME FIELDS
-  #---------------------
+  # -------------------
   # Copyright
   old_cp = old_table.getName(0, 3, 1, 1033).string.decode('utf_16_be')
   new_table.setName(old_cp.encode('mac_roman'), 0, 1, 0, 0)
@@ -197,7 +198,7 @@ def nametable_from_filename(filepath):
   # Unique ID
   unique_id = _unique_id(_version(font_version), vendor_id, filename)
   mac_unique_id = unique_id.encode('mac_roman')
-  new_table.setName(mac_unique_id, 3,  1, 0, 0)
+  new_table.setName(mac_unique_id, 3, 1, 0, 0)
   # Full name
   fullname = _full_name(family_name, style_name)
   mac_fullname = fullname.encode('mac_roman')
@@ -211,11 +212,12 @@ def nametable_from_filename(filepath):
   new_table.setName(mac_ps_name, 6, 1, 0, 0)
 
   # SET WIN NAME FIELDS
-  #--------------------
+  # -------------------
   # Copyright
   new_table.setName(old_cp, 0, 3, 1, 1033)
   # Font Family Name
-  win_family_name = _win_family_name(family_name, style_name).encode('utf_16_be')
+  win_family_name = _win_family_name(family_name, style_name)
+  win_family_name = win_family_name.encode('utf_16_be')
   new_table.setName(win_family_name, 1, 3, 1, 1033)
   # Subfamily Name
   win_subfamily_name = _win_subfamily_name(style_name).encode('utf_16_be')
@@ -238,12 +240,12 @@ def nametable_from_filename(filepath):
   for field in REQUIRED_FIELDS:
     text = None
     if new_table.getName(*field):
-      pass # Name has already been updated
+      pass  # Name has already been updated
     elif old_table.getName(*field):
       text = old_table.getName(*field).string
-    elif old_table.getName(field[0], 3, 1, 1033): # check if field exists for win
+    elif old_table.getName(field[0], 3, 1, 1033):
       text = old_table.getName(field[0], 3, 1, 1033).string.decode('utf_16_be')
-    elif old_table.getName(field[0], 1, 0, 0): # check if field exists for mac
+    elif old_table.getName(field[0], 1, 0, 0):  # check if field exists for mac
       text = old_table.getName(field[0], 3, 1, 1033).string.decode('mac_roman')
 
     if text:
@@ -253,7 +255,7 @@ def nametable_from_filename(filepath):
 
 
 parser = argparse.ArgumentParser(description=description,
-                 formatter_class=RawTextHelpFormatter)
+                                 formatter_class=RawTextHelpFormatter)
 parser.add_argument('fonts', nargs="+")
 
 

--- a/fontbakery-nametable-from-filename.py
+++ b/fontbakery-nametable-from-filename.py
@@ -222,7 +222,8 @@ def main():
     font_filename = ntpath.basename(font_path)
     font = TTFont(font_path)
     font_vendor = font['OS/2'].achVendID
-    font_version =  str(font['name'].getName(5, 1, 0, 0))
+    font_version = font['name'].getName(5, 3, 1, 1033)
+    font_version = str(font_version).decode(font_version.getEncoding())
     typo_enabled = typo_metrics_enabled(font['OS/2'].fsSelection)
     new_names = NameTableFromFilename(font_filename,
                                       font_version,

--- a/fontbakery-nametable-from-filename.py
+++ b/fontbakery-nametable-from-filename.py
@@ -211,7 +211,7 @@ def swap_name(field, font_name_field, new_name):
   '''Replace a font's name field with a new name'''
   enc = font_name_field.getName(*field).getEncoding()
   text = str(font_name_field.getName(*field)).decode(enc)
-  text = new_name
+  text = new_name.encode(enc)
   font_name_field.setName(text, *field)
 
 

--- a/fontbakery-nametable-from-filename.py
+++ b/fontbakery-nametable-from-filename.py
@@ -201,7 +201,8 @@ parser.add_argument('fonts', nargs="+")
 
 
 def typo_metrics_enabled(fsSelection):
-  if fsSelection >= 128:
+  fsSelection_on = fsSelection & 0b10000000
+  if fsSelection_on:
     return True
   return False
 

--- a/test_nametable-from-filename.py
+++ b/test_nametable-from-filename.py
@@ -23,9 +23,9 @@ script = __import__("fontbakery-nametable-from-filename")
 
 class NameTableFromTTFName(unittest.TestCase):
     def _font_renaming(self, f_path):
-        """Test the filename produces exactly the same name table as the
-        font's nametable. Only test against name fields which exist in
-        the font."""
+        """The test fonts have been generated from Glyphsapp and conform
+        to the googlefonts nametable spec. The test should pass if the new
+        nametable matches the test font's name table."""
         fonts_paths = [os.path.join(f_path, f) for f in os.listdir(f_path)
                        if '.ttf' in f]
 

--- a/test_nametable-from-filename.py
+++ b/test_nametable-from-filename.py
@@ -16,7 +16,6 @@
 # See AUTHORS.txt for the list of Authors and LICENSE.txt for the License.
 import unittest
 import os
-import ntpath
 from fontTools.ttLib import TTFont
 script = __import__("fontbakery-nametable-from-filename")
 
@@ -49,7 +48,7 @@ class NameTableFromTTFName(unittest.TestCase):
         self._font_renaming(f_path)
 
     def test_cabin_renaming(self):
-    #     """Cabin chosen because it has a seperate Condensed family"""
+        """Cabin chosen because it has a seperate Condensed family"""
         f_path = os.path.join('data', 'test', 'cabin')
         self._font_renaming(f_path)
 

--- a/test_nametable-from-filename.py
+++ b/test_nametable-from-filename.py
@@ -22,55 +22,43 @@ script = __import__("fontbakery-nametable-from-filename")
 
 
 class NameTableFromTTFName(unittest.TestCase):
-    def _font_renaming(self, fonts):
+    def _font_renaming(self, f_path):
         """Test the filename produces exactly the same name table as the
         font's nametable. Only test against name fields which exist in
         the font."""
-        for font in self.fonts:
-            font_filename = ntpath.basename(font)
-            font_vendor = self.fonts[font]['OS/2'].achVendID
-            font_version = str(self.fonts[font]['name'].getName(5, 1, 0, 0))
-            new_names = script.NameTableFromFilename(font_filename,
-                                                     font_version,
-                                                     font_vendor)
-            # print new_names.version
+        fonts_paths = [os.path.join(f_path, f) for f in os.listdir(f_path)
+                       if '.ttf' in f]
 
-            for name_field in new_names:
-                font_field = self.fonts[font]['name'].getName(*name_field)
-                new_name_field = new_names[name_field]
-                if font_field:  # Check the field is in the font
-                    enc = font_field.getEncoding()
-                    self.assertEqual(str(font_field).decode(enc),
-                                     new_name_field,
-                                     'ERROR %s: %s != %s' % (font,
-                                                             str(font_field),
-                                                             new_name_field))
-                    print '%s == %s' % (str(font_field).decode(enc),
-                                        new_name_field)
+        for font_path in fonts_paths:
+            font = TTFont(font_path)
+            old_nametable = font['name']
+            new_nametable = script.nametable_from_filename(font_path)
+
+            for field in script.REQUIRED_FIELDS:
+                if old_nametable.getName(*field):
+                    enc = old_nametable.getName(*field).getEncoding()
+                    self.assertEqual(
+                        str(old_nametable.getName(*field)).decode(enc),
+                        str(new_nametable.getName(*field)).decode(enc),
+                    )
 
     def test_nunito_renaming(self):
         """Nunito Chosen because it has another family Nunito Heavy and a lot
         of weights"""
         f_path = os.path.join('data', 'test', 'nunito')
-        self.fonts = {f: TTFont(os.path.join(f_path, f)) for f
-                      in os.listdir(f_path) if 'ttf' in f}
-        self._font_renaming(self.fonts)
+        self._font_renaming(f_path)
 
     def test_cabin_renaming(self):
-        """Cabin chosen because it has a seperate Condensed family"""
+    #     """Cabin chosen because it has a seperate Condensed family"""
         f_path = os.path.join('data', 'test', 'cabin')
-        self.fonts = {f: TTFont(os.path.join(f_path, f)) for f
-                      in os.listdir(f_path) if 'ttf' in f}
-        self._font_renaming(self.fonts)
+        self._font_renaming(f_path)
 
     def test_glyphsapp_family_sans_export(self):
         """The ultimate test. Can this naming tool repoduce Google Font's
         Naming schema.
         Source repo here: https://github.com/davelab6/glyphs-export"""
         f_path = os.path.join('data', 'test', 'familysans')
-        self.fonts = {f: TTFont(os.path.join(f_path, f)) for f
-                      in os.listdir(f_path) if 'ttf' in f}
-        self._font_renaming(self.fonts)
+        self._font_renaming(f_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In order to address issue https://github.com/google/fonts/issues/641, I've had to update this script.

The previous implementation only changed existing fields in the font's nametable. The new implementation will now add new fields if they don't already exist. Many fonts in our collection are missing the mac platform fields, these are now added automatically.

I also took the time to refactor the script to make it easier to understand.

The tests have also been refactored to use the new implementation.