### PR TITLE
test_nametable-from-filename: add win nameIDs 16 and 17

### DIFF
--- a/fontbakery-nametable-from-filename.py
+++ b/fontbakery-nametable-from-filename.py
@@ -235,6 +235,13 @@ def nametable_from_filename(filepath):
   win_ps_name = filename.encode('utf_16_be')
   new_table.setName(win_ps_name, 6, 3, 1, 1033)
 
+  if style_name not in WIN_SAFE_STYLES:
+    # Preferred Family Name
+    new_table.setName(family_name.encode('utf_16_be'), 16, 3, 1, 1033)
+    # Preferred SubfamilyName
+    win_pref_subfam_name = _mac_subfamily_name(style_name).encode('utf_16_be')
+    new_table.setName(win_pref_subfam_name, 17, 3, 1, 1033)
+
   # PAD missing fields
   # ------------------
   for field in REQUIRED_FIELDS:


### PR DESCRIPTION
When a font's style is not Regular, Bold, Italic or Bold Italic. The Win nameIDs 16 and 17 must be used. When its one of the styles listed above, nameIDs 0-14 only. 

This was discovered in issue #1291 


**FamilySans-Bold.ttf**
```
Font                    platformID    encodingID    languageID    nameID  nameString
FamilySans-Bold.ttf             1             0             0         0  Copyright 2016 The Family Sans Project Authors
FamilySans-Bold.ttf             1             0             0         1  Family Sans
FamilySans-Bold.ttf             1             0             0         2  Bold
FamilySans-Bold.ttf             1             0             0         3  1.005;MRSD;FamilySans-Bold
FamilySans-Bold.ttf             1             0             0         4  Family Sans Bold
FamilySans-Bold.ttf             1             0             0         5  Version 1.005
FamilySans-Bold.ttf             1             0             0         6  FamilySans-Bold
FamilySans-Bold.ttf             1             0             0         7  Family Sans is a tradmark of Mrs Designer
FamilySans-Bold.ttf             1             0             0         8  Foundry Foundry
FamilySans-Bold.ttf             1             0             0         9  Mrs Designer
FamilySans-Bold.ttf             1             0             0        11  http://www.foundry.com
FamilySans-Bold.ttf             1             0             0        12  http://www.mrs-designer.com
FamilySans-Bold.ttf             1             0             0        13  This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL
FamilySans-Bold.ttf             1             0             0        14  http://scripts.sil.org/OFL
FamilySans-Bold.ttf             3             1          1033         0  Copyright 2016 The Family Sans Project Authors
FamilySans-Bold.ttf             3             1          1033         1  Family Sans
FamilySans-Bold.ttf             3             1          1033         2  Bold
FamilySans-Bold.ttf             3             1          1033         3  1.005;MRSD;FamilySans-Bold
FamilySans-Bold.ttf             3             1          1033         4  Family Sans Bold
FamilySans-Bold.ttf             3             1          1033         5  Version 1.005
FamilySans-Bold.ttf             3             1          1033         6  FamilySans-Bold
FamilySans-Bold.ttf             3             1          1033         7  Family Sans is a tradmark of Mrs Designer
FamilySans-Bold.ttf             3             1          1033         8  Foundry Foundry
FamilySans-Bold.ttf             3             1          1033         9  Mrs Designer
FamilySans-Bold.ttf             3             1          1033        11  http://www.foundry.com
FamilySans-Bold.ttf             3             1          1033        12  http://www.mrs-designer.com
FamilySans-Bold.ttf             3             1          1033        13  This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL
FamilySans-Bold.ttf             3             1          1033        14  http://scripts.sil.org/OFL
```

**FamilySans Light**
```
Font                    platformID    encodingID    languageID    nameID  nameString
FamilySans-Light.ttf             1             0             0         0  Copyright 2016 The Family Sans Project Authors
FamilySans-Light.ttf             1             0             0         1  Family Sans
FamilySans-Light.ttf             1             0             0         2  Light
FamilySans-Light.ttf             1             0             0         3  1.005;MRSD;FamilySans-Light
FamilySans-Light.ttf             1             0             0         4  Family Sans Light
FamilySans-Light.ttf             1             0             0         5  Version 1.005
FamilySans-Light.ttf             1             0             0         6  FamilySans-Light
FamilySans-Light.ttf             1             0             0         7  Family Sans is a tradmark of Mrs Designer
FamilySans-Light.ttf             1             0             0         8  Foundry Foundry
FamilySans-Light.ttf             1             0             0         9  Mrs Designer
FamilySans-Light.ttf             1             0             0        11  http://www.foundry.com
FamilySans-Light.ttf             1             0             0        12  http://www.mrs-designer.com
FamilySans-Light.ttf             1             0             0        13  This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL
FamilySans-Light.ttf             1             0             0        14  http://scripts.sil.org/OFL
FamilySans-Light.ttf             3             1          1033         0  Copyright 2016 The Family Sans Project Authors
FamilySans-Light.ttf             3             1          1033         1  Family Sans Light
FamilySans-Light.ttf             3             1          1033         2  Regular
FamilySans-Light.ttf             3             1          1033         3  1.005;MRSD;FamilySans-Light
FamilySans-Light.ttf             3             1          1033         4  Family Sans Light
FamilySans-Light.ttf             3             1          1033         5  Version 1.005
FamilySans-Light.ttf             3             1          1033         6  FamilySans-Light
FamilySans-Light.ttf             3             1          1033         7  Family Sans is a tradmark of Mrs Designer
FamilySans-Light.ttf             3             1          1033         8  Foundry Foundry
FamilySans-Light.ttf             3             1          1033         9  Mrs Designer
FamilySans-Light.ttf             3             1          1033        11  http://www.foundry.com
FamilySans-Light.ttf             3             1          1033        12  http://www.mrs-designer.com
FamilySans-Light.ttf             3             1          1033        13  This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL
FamilySans-Light.ttf             3             1          1033        14  http://scripts.sil.org/OFL
FamilySans-Light.ttf             3             1          1033        16  Family Sans
FamilySans-Light.ttf             3             1          1033        17  Light
```