### PR TITLE
improving/fixing the check-collection script

### DIFF
--- a/bin/fontbakery-check-collection.sh
+++ b/bin/fontbakery-check-collection.sh
@@ -14,6 +14,7 @@ RESULTS_FOLDER=$COLLECTION_FOLDER/check_results/
 mkdir $RESULTS_FOLDER -p
 rm $RESULTS_FOLDER/issues.txt -f
 rm $RESULTS_FOLDER/all_fonts.txt -f
+rm $COLLECTION_FOLDER/*/*/*fontbakery.*
 
 for f in $APACHE_FOLDERS $OFL_FOLDERS $UFL_FOLDERS
 do
@@ -25,10 +26,13 @@ do
     echo "Skipping '$f'"
   else
     echo "Processing '$f'..."
-    ./fontbakery-check-ttf.py "$f*.ttf" --json --ghm -vv
+    fontbakery check-ttf "$f*.ttf" --json --ghm --error
     mkdir -p $LOGDIR
-    cp $f*fontbakery.json $LOGDIR/
-    cp $f*.md $LOGDIR/ || echo "$f" >> $RESULTS_FOLDER/issues.txt
+    mv $f/CrossFamilyChecks.fontbakery.* $LOGDIR/ || echo "$f CrossFamilyChecks" >> $RESULTS_FOLDER/issues.txt
+    for font in $f/*.ttf
+    do
+      mv $(basename $font).fontbakery.* $LOGDIR/ || echo "$font" >> $RESULTS_FOLDER/issues.txt
+    done
   fi
 done
 


### PR DESCRIPTION
This pull request addresses the problems described at issue #1314 

The problem with the previous implementation was that it was enough for one single font file to output a fontbakery report for the script to consider that all was good. But there are tricky cases when one specific font file fails to generate a FB report while the remaining files in the family have their report files. This was shadowing the issue.

Now I explicitely check that every TTF has a corresponding .fontbakery.{json|md} report, otherwise, such font is reported on the issues.txt summary.