### PR TITLE
nametable-from-filename.py: fixed fsselection bit

### DIFF
--- a/bin/fontbakery-nametable-from-filename.py
+++ b/bin/fontbakery-nametable-from-filename.py
@@ -171,6 +171,9 @@ def set_fsSelection(fsSelection, style):
   else:
     bits &= ~0b1
 
+  if not bits:
+    bits = 0b1000000
+
   return bits
 
 


### PR DESCRIPTION
This will fix #1366.

The implementation of the fsSelection and macStyle bits is a little messy here imo (I originally wrote it :-)). I rewrote this in my [hotfix repo](https://github.com/m4rc1e/gf-hotfix/blob/master/fontbakery/gfspec.py#L50-L89). We should really start grouping this stuff into a decent library.