### PR TITLE
Added PiFont.PiFontFontTools.get_contours_count method

### DIFF
--- a/Lib/fontbakery/pifont.py
+++ b/Lib/fontbakery/pifont.py
@@ -208,7 +208,23 @@ class PiFontFontTools:
             return None
 
     def get_contours_count(self, glyphname):
-        return 0
+        """ Retrieves count of glyph points in contours
+
+        >>> f = PiFont('tests/fixtures/src/Font-Italic.ufo')
+        >>> f.get_points_count('AEacute')
+        24
+        """
+        contour_count = 0
+        items = [self.font['glyf'][glyphname]]
+
+        while items:
+            g = items.pop(0)
+            if g.isComposite():
+                for comp in g.components:
+                    items.append(self.font['glyf'][comp.glyphName])
+            if g.numberOfContours != -1:
+                contour_count += g.numberOfContours
+        return contour_count
 
     def get_points_count(self, glyphname):
         return 0

--- a/tests/pifont_test.py
+++ b/tests/pifont_test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# coding: utf-8
+# Copyright 2013,2017 The Font Bakery Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# See AUTHORS.txt for the list of Authors and LICENSE.txt for the License.
+import unittest
+import os
+
+from fontbakery.pifont import PiFont
+
+
+class PiFontTest(unittest.TestCase):
+
+    def setUp(self):
+        self.font = PiFont('data/test/cousine/Cousine-Bold.ttf')
+
+    def test_get_contours_count(self):
+        self.assertEqual(
+            self.font.get_contours_count('a'),
+            2
+        )
+        self.assertEqual(
+            self.font.get_contours_count('aacute'),
+            3
+        )
+        self.assertEqual(
+            self.font.get_contours_count('adieresis'),
+            4
+        )        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hey folks,

So I've been browsing the new architecture and its going in the right direction. In pr #1387, @graphicore mentioned the generation script for the glyph_data.json file should be included, I agree with this. 

This pr is adding some of the necessary functionality to make it happen. I previously had a function to count the contours in a glyph but I see @felipesanches has already put in place some of these in the PiFont module. This pr will add the contour count method to the PiFontFontTools class.

I think it's a wise incentive to add unit tests for methods now rather than later so I thought I'd get the ball rolling. Personally, I would prefer the test data to be .ttx files which get converted to fonts upon running the tests. However, we already have [ttfs](https://github.com/googlefonts/fontbakery/tree/master/data/test) in the repo.

Also, the names of functions/methods/classes could be improved imo. Why name it PiFont for instance?