### PR TITLE
check-font-version.py added.

### DIFF
--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -99,13 +99,12 @@ def parse_version_string(fb, s):
 def parse_version_head(fonts):
     """Return a family's version number. Ideally, each font in the
     family should have the same version number. If not, return the highest
-    version number."""
+    version number. This function can also work on single fonts."""
     versions = []
-    if isinstance(fonts, list):
-      for font in fonts:
-        versions.append(float(font['head'].fontRevision))
-    else:
-      versions.append(float(fonts['head'].fontRevision))
+    if not isinstance(fonts, list):
+        fonts = [fonts]
+    for font in fonts:
+      versions.append(float(font['head'].fontRevision))
     return max(versions)
 
 

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -251,10 +251,10 @@ def download_family_from_GoogleFontDirectory(family_name):
     """Return a zipfile containing a font family hosted on fonts.google.com"""
     url_prefix = 'https://fonts.google.com/download?family='
     url = '%s%s' % (url_prefix, family_name.replace(' ', '+'))
-    return download_family_zip(url)
+    return download_zip(url)
 
 
-def download_family_zip(url):
+def download_zip(url):
   """Return a zipfile from a url"""
   request = urlopen(url)
   return ZipFile(StringIO(request.read()))

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -96,6 +96,19 @@ def parse_version_string(fb, s):
                  " version numbers in '{}'".format(s))
 
 
+def parse_version_head(fonts):
+    """Return a family's version number. Ideally, each font in the
+    family should have the same version number. If not, return the highest
+    version number."""
+    versions = []
+    if isinstance(fonts, list):
+      for font in fonts:
+        versions.append(float(font['head'].fontRevision))
+    else:
+      versions.append(float(fonts['head'].fontRevision))
+    return max(versions)
+
+
 def getGlyph(font, uchar):
     for table in font['cmap'].tables:
         if table.platformID == PLATFORM_ID_WINDOWS and\
@@ -238,9 +251,13 @@ def download_family_from_GoogleFontDirectory(family_name):
     """Return a zipfile containing a font family hosted on fonts.google.com"""
     url_prefix = 'https://fonts.google.com/download?family='
     url = '%s%s' % (url_prefix, family_name.replace(' ', '+'))
-    request = urlopen(url)
-    # print(request.text)
-    return ZipFile(StringIO(request.read()))
+    return download_family_zip(url)
+
+
+def download_family_zip(url):
+  """Return a zipfile from a url"""
+  request = urlopen(url)
+  return ZipFile(StringIO(request.read()))
 
 
 def fonts_from_zip(zipfile):

--- a/bin/fontbakery-check-font-version.py
+++ b/bin/fontbakery-check-font-version.py
@@ -1,0 +1,85 @@
+"""
+fontbakery-check-font-version.py:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Check the version number of a family hosted on fonts.google.com.
+
+`fontbakery check-font-version.py "Roboto"`
+
+
+Comparison against a local family can be made using the -lc argument:
+
+`fontbakery check-font-version.py "Roboto" -lc [/dir/Roboto-Regular.ttf, ...]`
+
+
+Comparison against a url containing a zipped family can be made using
+the -wc argument:
+
+`fontbakery check-font-version.py "Roboto" -wc=http://roboto.com/roboto.zip`
+
+"""
+from __future__ import print_function
+from argparse import ArgumentParser
+from fontTools.ttLib import TTFont
+from ntpath import basename
+
+from fontbakery.utils import (
+  download_family_from_GoogleFontDirectory,
+  download_family_zip,
+  fonts_from_zip,
+  parse_version_head,
+)
+
+def main():
+  parser = ArgumentParser(description=__doc__)
+  parser.add_argument('family',
+            help='Name of font family')
+  parser.add_argument('-wc', '--web-compare',
+                      help='Compare against a web url .zip family')
+  parser.add_argument('-lc', '--local-compare', nargs='+',
+                      help='Compare against a set of local ttfs')
+  args = parser.parse_args()
+
+  google_family_zip = download_family_from_GoogleFontDirectory(args.family)
+  google_family_fonts = [f[1] for f in fonts_from_zip(google_family_zip)]
+  google_family_version = parse_version_head(google_family_fonts)
+
+  if args.web_compare:
+    if args.web_compare.endswith('.zip'):
+      web_family_zip = download_family_zip(args.web_compare)
+      web_family = fonts_from_zip(web_family_zip)
+      web_family_fonts = [f[1] for f in web_family]
+      web_family_name = set(f[0].split('-')[0] for f in web_family)
+      web_family_version = parse_version_head(web_family_fonts)
+    print('Google Fonts Version of %s is v%s' % (
+      args.family,
+      google_family_version
+    ))
+    print('Web Version of %s is v%s' % (
+      ', '.join(web_family_name),
+      web_family_version
+    ))
+
+  elif args.local_compare:
+    local_family = [TTFont(f) for f in args.local_compare]
+    local_family_version = parse_version_head(local_family)
+    local_fonts_name = set(basename(f.split('-')[0]) for f in
+                           args.local_compare)
+    print('Google Fonts Version of %s is v%s' % (
+      args.family,
+      google_family_version
+    ))
+    print('Local Version of %s is v%s' % (
+      ','.join(local_fonts_name),
+      local_family_version
+    ))
+
+  else:
+    print('Google Fonts Version of %s is v%s' % (
+      args.family,
+      google_family_version
+    ))
+
+
+if __name__ == '__main__':
+  main()

--- a/bin/fontbakery-check-font-version.py
+++ b/bin/fontbakery-check-font-version.py
@@ -25,7 +25,7 @@ from ntpath import basename
 
 from fontbakery.utils import (
   download_family_from_GoogleFontDirectory,
-  download_family_zip,
+  download_zip,
   fonts_from_zip,
   parse_version_head,
 )
@@ -46,7 +46,7 @@ def main():
 
   if args.web_compare:
     if args.web_compare.endswith('.zip'):
-      web_family_zip = download_family_zip(args.web_compare)
+      web_family_zip = download_zip(args.web_compare)
       web_family = fonts_from_zip(web_family_zip)
       web_family_fonts = [f[1] for f in web_family]
       web_family_name = set(f[0].split('-')[0] for f in web_family)

--- a/bin/fontbakery-check-font-version.py
+++ b/bin/fontbakery-check-font-version.py
@@ -4,18 +4,18 @@ fontbakery-check-font-version.py:
 
 Check the version number of a family hosted on fonts.google.com.
 
-`fontbakery check-font-version.py "Roboto"`
+`fontbakery check-font-version "Roboto"`
 
 
 Comparison against a local family can be made using the -lc argument:
 
-`fontbakery check-font-version.py "Roboto" -lc [/dir/Roboto-Regular.ttf, ...]`
+`fontbakery check-font-version "Roboto" -lc [/dir/Roboto-Regular.ttf, ...]`
 
 
 Comparison against a url containing a zipped family can be made using
 the -wc argument:
 
-`fontbakery check-font-version.py "Roboto" -wc=http://roboto.com/roboto.zip`
+`fontbakery check-font-version "Roboto" -wc=http://roboto.com/roboto.zip`
 
 """
 from __future__ import print_function

--- a/bin/fontbakery-check-noto-version.sh
+++ b/bin/fontbakery-check-noto-version.sh
@@ -1,0 +1,2 @@
+python bin/fontbakery-check-font-version.py "Noto Sans" -wc='http://noto-website.storage.googleapis.com/pkgs/NotoSans-unhinted.zip'
+python bin/fontbakery-check-font-version.py "Noto Serif" -wc='https://noto-website.storage.googleapis.com/pkgs/NotoSerif-unhinted.zip'


### PR DESCRIPTION
Check the version number of a family hosted on fonts.google.com.

```
$ fontbakery check-font-version.py "Roboto"
Google Fonts version is v2.37
````

Comparison against a local family can be made using the -lc argument:

```
$ fontbakery check-font-version.py "Roboto" -lc [/dir/Roboto-Regular.ttf, ...]
Google Fonts Version of Roboto is v2.37
Local Version of Roboto is v2.38
```

Comparison against a url containing a zipped family can be made using
the -wc argument:

```
$ fontbakery check-font-version.py "Roboto" -wc=http://roboto.com/roboto.zip
Google Fonts Version of Roboto is v2.37
Web Version of Roboto is v2.38
```

@davelab6 Use `sh bin/fontbakery-check-noto-version.sh` to see if the GF versions of Noto are in sync with the latest releases.
