### PR TITLE
bin/fontbakery-fix-nameids --drop-superflous-mac-names added

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Print out nameID strings of the fonts
 ```
 usage: fontbakery fix-nameids [-h] [--autofix] [--csv] [--id ID]
                               [--platform PLATFORM]
+                              [--drop-superfluous-mac-names]
                               font [font ...]
 
 positional arguments:
@@ -520,6 +521,8 @@ optional arguments:
   --csv                 Output data in comma-separate-values (CSV) file format
   --id ID, -i ID
   --platform PLATFORM, -p PLATFORM
+  --drop-superfluous-mac-names, -m
+                        Drop superfluous Mac names
 ```
 
 ### fontbakery fix-nonhinting

--- a/bin/fontbakery-fix-nameids.py
+++ b/bin/fontbakery-fix-nameids.py
@@ -118,4 +118,4 @@ def main():
 
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/bin/fontbakery-fix-nameids.py
+++ b/bin/fontbakery-fix-nameids.py
@@ -97,24 +97,24 @@ def main():
     print(tabulate.tabulate(rows, header, tablefmt="pipe"))
 
     for path in args.font:
+        font = ttLib.TTFont(path)
+        saveit = False
+
         if args.autofix:
-            font = ttLib.TTFont(path)
-            saveit = False
             for name in font['name'].names:
                 if name.platformID != 1:
                     saveit = True
                     del name
-            if saveit:
-                font.save(path + ".fix")
 
-    if args.drop_superfluous_mac_names:
-        for path in args.font:
-            font = ttLib.TTFont(path)
+        if args.drop_superfluous_mac_names:
             if has_mac_names(font):
                 drop_superfluous_mac_names(font)
-                font.save(path + ".fix")
+                saveit = True
             else:
                 print('font %s has no mac nametable' % path)
+
+        if saveit:
+                font.save(path + ".fix")
 
 
 if __name__ == '__main__':

--- a/bin/fontbakery-fix-nameids.py
+++ b/bin/fontbakery-fix-nameids.py
@@ -14,6 +14,49 @@ parser.add_argument('--csv', default=False, action='store_true',
                          " (CSV) file format")
 parser.add_argument('--id', '-i', default='all')
 parser.add_argument('--platform', '-p', type=int, default=3)
+parser.add_argument('--drop-superflous-mac-names', '-m', default=False,
+                    action='store_true',
+                    help='Drop superflous Mac names')
+
+
+def has_mac_names(ttfont):
+    """Check if a font has Mac names. Mac names have the following
+    field values:
+    platformID: 1, encodingID: 0, LanguageID: 0"""
+    for i in range(255):
+        if ttfont['name'].getName(i, 1, 0, 0):
+            return True
+    return False
+
+
+def drop_superflous_mac_names(ttfont):
+    """Drop superflous Mac nameIDs.
+
+    The following nameIDS are kept:
+    1: Font Family name,
+    2: Font Family Subfamily name,
+    3: Unique font identifier,
+    4: Full font name,
+    5: Version string,
+    6: Postscript name,
+    16: Typographic family name,
+    17: Typographic Subfamily name
+    18: Compatible full (Macintosh only),
+    20: PostScript CID,
+    21: WWS Family Name,
+    22: WWS Subfamily Name,
+    25: Variations PostScript Name Prefix.
+
+    We keep these IDs in order for certain application to still function
+    such as Word 2011. IDs 1-6 are very common, > 16 are edge cases.
+
+    https://www.microsoft.com/typography/otspec/name.htm"""
+    keep_ids = [1, 2, 3, 4, 5, 6, 16, 17, 18, 20, 21, 22, 25]
+    for n in range(255):
+        if n not in keep_ids:
+            name = ttfont['name'].getName(n, 1, 0, 0)
+            if name:
+                ttfont['name'].names.remove(name)
 
 
 def main():
@@ -64,6 +107,15 @@ def main():
             if saveit:
                 font.save(path + ".fix")
 
+    if args.drop_superflous_mac_names:
+        for path in args.font:
+            font = ttLib.TTFont(path)
+            if has_mac_names(font):
+                drop_superflous_mac_names(font)
+                font.save(path + ".fix")
+            else:
+                print('font %s has no mac nametable' % path)
+
+
 if __name__ == '__main__':
   main()
-

--- a/bin/fontbakery-fix-nameids.py
+++ b/bin/fontbakery-fix-nameids.py
@@ -14,9 +14,9 @@ parser.add_argument('--csv', default=False, action='store_true',
                          " (CSV) file format")
 parser.add_argument('--id', '-i', default='all')
 parser.add_argument('--platform', '-p', type=int, default=3)
-parser.add_argument('--drop-superflous-mac-names', '-m', default=False,
+parser.add_argument('--drop-superfluous-mac-names', '-m', default=False,
                     action='store_true',
-                    help='Drop superflous Mac names')
+                    help='Drop superfluous Mac names')
 
 
 def has_mac_names(ttfont):
@@ -29,8 +29,8 @@ def has_mac_names(ttfont):
     return False
 
 
-def drop_superflous_mac_names(ttfont):
-    """Drop superflous Mac nameIDs.
+def drop_superfluous_mac_names(ttfont):
+    """Drop superfluous Mac nameIDs.
 
     The following nameIDS are kept:
     1: Font Family name,
@@ -107,11 +107,11 @@ def main():
             if saveit:
                 font.save(path + ".fix")
 
-    if args.drop_superflous_mac_names:
+    if args.drop_superfluous_mac_names:
         for path in args.font:
             font = ttLib.TTFont(path)
             if has_mac_names(font):
-                drop_superflous_mac_names(font)
+                drop_superfluous_mac_names(font)
                 font.save(path + ".fix")
             else:
                 print('font %s has no mac nametable' % path)


### PR DESCRIPTION
As requested in #1443, superfluous mac nameIDs can now be dropped using the following command:

`fontbakery fix-nameids [fonts] -m` or 
`fontbakery fix-nameids [fonts] --drop-superfluous-mac-names`

It will only remove nameIDs which have no affect on applications; manufacturer, designer, URL Vendor etc will be dropped.

Running this on [Miriam Libre](https://github.com/MichalSahar/Miriam-Libre) does the following:

**Before**
```
Font                       platformID    encodingID    languageID    nameID  nameString
MiriamLibre-Regular.ttf             1             0             0         0  Copyright 2016 The Miriam Libre Project Authors (https://github.com/MichalSahar/Miriam-Libre)
MiriamLibre-Regular.ttf             1             0             0         1  Miriam Libre
MiriamLibre-Regular.ttf             1             0             0         2  Regular
MiriamLibre-Regular.ttf             1             0             0         3  1.001;MCHL;MiriamLibre-Regular
MiriamLibre-Regular.ttf             1             0             0         4  Miriam Libre Regular
MiriamLibre-Regular.ttf             1             0             0         5  Version 1.001
MiriamLibre-Regular.ttf             1             0             0         6  MiriamLibre-Regular
MiriamLibre-Regular.ttf             1             0             0         7  Miriam Libre is a tradmark of Michal Sahar
MiriamLibre-Regular.ttf             1             0             0         8  Hagilda
MiriamLibre-Regular.ttf             1             0             0         9  Michal Sahar
MiriamLibre-Regular.ttf             1             0             0        11  http://hagilda.com
MiriamLibre-Regular.ttf             1             0             0        12  http://hagilda.com
MiriamLibre-Regular.ttf             1             0             0        13  This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL
MiriamLibre-Regular.ttf             1             0             0        14  http://scripts.sil.org/OFL
MiriamLibre-Regular.ttf             3             1          1033         0  Copyright 2016 The Miriam Libre Project Authors (https://github.com/MichalSahar/Miriam-Libre)
MiriamLibre-Regular.ttf             3             1          1033         1  Miriam Libre
MiriamLibre-Regular.ttf             3             1          1033         2  Regular
MiriamLibre-Regular.ttf             3             1          1033         3  1.001;MCHL;MiriamLibre-Regular
MiriamLibre-Regular.ttf             3             1          1033         4  Miriam Libre Regular
MiriamLibre-Regular.ttf             3             1          1033         5  Version 1.001
MiriamLibre-Regular.ttf             3             1          1033         6  MiriamLibre-Regular
MiriamLibre-Regular.ttf             3             1          1033         7  Miriam Libre is a tradmark of Michal Sahar
MiriamLibre-Regular.ttf             3             1          1033         8  Hagilda
MiriamLibre-Regular.ttf             3             1          1033         9  Michal Sahar
MiriamLibre-Regular.ttf             3             1          1033        11  http://hagilda.com
MiriamLibre-Regular.ttf             3             1          1033        12  http://hagilda.com
MiriamLibre-Regular.ttf             3             1          1033        13  This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL
MiriamLibre-Regular.ttf             3             1          1033        14  http://scripts.sil.org/OFL
```

**After**
```
Font                        platformID    encodingID    languageID    nameID  nameString
MiriamLibre-Regular1.ttf             1             0             0         1  Miriam Libre
MiriamLibre-Regular1.ttf             1             0             0         2  Regular
MiriamLibre-Regular1.ttf             1             0             0         3  1.001;MCHL;MiriamLibre-Regular
MiriamLibre-Regular1.ttf             1             0             0         4  Miriam Libre Regular
MiriamLibre-Regular1.ttf             1             0             0         5  Version 1.001
MiriamLibre-Regular1.ttf             1             0             0         6  MiriamLibre-Regular
MiriamLibre-Regular1.ttf             3             1          1033         0  Copyright 2016 The Miriam Libre Project Authors (https://github.com/MichalSahar/Miriam-Libre)
MiriamLibre-Regular1.ttf             3             1          1033         1  Miriam Libre
MiriamLibre-Regular1.ttf             3             1          1033         2  Regular
MiriamLibre-Regular1.ttf             3             1          1033         3  1.001;MCHL;MiriamLibre-Regular
MiriamLibre-Regular1.ttf             3             1          1033         4  Miriam Libre Regular
MiriamLibre-Regular1.ttf             3             1          1033         5  Version 1.001
MiriamLibre-Regular1.ttf             3             1          1033         6  MiriamLibre-Regular
MiriamLibre-Regular1.ttf             3             1          1033         7  Miriam Libre is a tradmark of Michal Sahar
MiriamLibre-Regular1.ttf             3             1          1033         8  Hagilda
MiriamLibre-Regular1.ttf             3             1          1033         9  Michal Sahar
MiriamLibre-Regular1.ttf             3             1          1033        11  http://hagilda.com
MiriamLibre-Regular1.ttf             3             1          1033        12  http://hagilda.com
MiriamLibre-Regular1.ttf             3             1          1033        13  This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL
MiriamLibre-Regular1.ttf             3             1          1033        14  http://scripts.sil.org/OFL
```

@felipesanches could you review this? when we get the time, we need to revise this script properly. The following doesn't [work](https://github.com/googlefonts/fontbakery/blob/master/bin/fontbakery-fix-nameids.py#L60-L63). Running `del` on a list will not remove elements. Either list.pop() or list.remove() will.

cc @davelab6 