### PR TITLE
[bin/fontbakery-fix-dsig] Use really empty DSIG as a dummy. Closes #1437

### DIFF
--- a/bin/fontbakery-fix-dsig.py
+++ b/bin/fontbakery-fix-dsig.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 # See AUTHORS.txt for the list of Authors and LICENSE.txt for the License.
+from __future__ import print_function, unicode_literals
 import argparse
 import os
 from fontTools import ttLib
@@ -24,10 +25,25 @@ parser = argparse.ArgumentParser(description=description)
 parser.add_argument('ttf_font',
                     nargs='+',
                     help="One or more font files")
-parser.add_argument('--autofix',
+parser.add_argument('-a', '--autofix',
                     action='store_true',
-                    help='Apply autofix')
+                    help='Write empty DSIG table if not present in font.')
 
+parser.add_argument('-f', '--force',
+                    action='store_true',
+                    help='Write empty DSIG table in any case.')
+
+parser.add_argument('-d', '--delete',
+                    action='store_true',
+                    help='Delete DSIG table if present in font.')
+
+def set_empty_dsig(ttFont):
+  newDSIG = ttLib.newTable("DSIG")
+  newDSIG.ulVersion = 1
+  newDSIG.usFlag = 0
+  newDSIG.usNumSigs = 0
+  newDSIG.signatureRecords = []
+  ttFont.tables["DSIG"] = newDSIG
 
 def main():
   args = parser.parse_args()
@@ -35,48 +51,41 @@ def main():
     if not os.path.exists(path):
       continue
     font = ttLib.TTFont(path)
-    if "DSIG" not in font:
-      try:
-        if args.autofix:
-          from fontTools.ttLib.tables.D_S_I_G_ import SignatureRecord
-          newDSIG = ttLib.newTable("DSIG")
-          newDSIG.ulVersion = 1
-          newDSIG.usFlag = 1
-          newDSIG.usNumSigs = 1
-          sig = SignatureRecord()
-          sig.ulLength = 20
-          sig.cbSignature = 12
-          sig.usReserved2 = 0
-          sig.usReserved1 = 0
-          sig.pkcs7 = '\xd3M4\xd3M5\xd3M4\xd3M4'
-          sig.ulFormat = 1
-          sig.ulOffset = 20
-          newDSIG.signatureRecords = [sig]
-          font.tables["DSIG"] = newDSIG
-          font.save(path)
-          print(("HOTFIX: '{}': The font lacks a digital"
-                 " signature (DSIG), so we just added a dummy"
-                 " placeholder that should be enough for the"
-                 " applications that require its presence in"
-                 " order to work properly.").format(path))
-        else:
-          print(("ERROR: '{}': This font lacks a digital signature"
+    has_DSIG = "DSIG" in font
+    write_DSIG = args.force or args.autofix and not has_DSIG
+
+    if has_DSIG and args.delete:
+      del font["DSIG"]
+      font.save(path)
+      has_DSIG = False
+      print("DELETED: '{}': removed digital "
+              "signature (DSIG)".format(path))
+
+    if write_DSIG:
+      set_empty_dsig(font)
+      font.save(path)
+
+      if not args.force:
+        print("HOTFIX: '{}': Font lacked a digital"
+              " signature (DSIG), so we just added a dummy"
+              " placeholder that should be enough for the"
+              " applications that require its presence in"
+              " order to work properly.".format(path))
+      else:
+        print("FORCED: '{}': Font has a new a dummy digital "
+              "signature (DSIG)".format(path))
+
+    elif not has_DSIG and not args.delete:
+      print(("ERROR: '{}': Font lacks a digital signature"
                  " (DSIG table). Some applications may required"
                  " one (even if only a dummy placeholder)"
                  " in order to work properly. Re-run this script"
                  " passing --autofix in order to hotfix the font"
                  " with a dummy signature.").format(path))
+    elif has_DSIG:
+      print(("INFO: '{}': Font has a digital signature"
+                 " (DSIG table).").format(path))
 
-      except ImportError:
-        error_message = ("ERROR '{}': The font lacks a"
-                         " digital signature (DSIG), so OpenType features"
-                         " will not be available in some applications that"
-                         " use its presense as a (stupid) heuristic."
-                         " So we need to add one. But for that we'll need "
-                         "Fonttools v2.3+ so you need to upgrade it. Try:"
-                         " $ pip install --upgrade fontTools; or see"
-                         " https://pypi.python.org/pypi/FontTools")
-        print (error_message.format(path))
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
This pull request addresses the problems described at issue #1437

I also added a `--force` and `--delete` switch to the command.

Just created a `DSIG` with this that looks like:

```xml
  <DSIG>
    <!-- note that the Digital Signature will be invalid after recompilation! -->
    <tableHeader flag="0x0" numSigs="0" version="1"/>
  </DSIG>
```