### PR TITLE
Remove requirements that are only used by fontbakery-dashbord.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,5 @@ tabulate==0.7.5
 Unidecode==0.4.19
 wheel==0.24.0
 GitPython==0.3.2rc1
-rethinkdb
 python-dateutil
-pika
 pyicu


### PR DESCRIPTION
There's no usage RethinkDB or AMQP in this repository anymore.