### PR TITLE
[com.google.fonts/test/154] check_regression_missing_glyphs added

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -4284,3 +4284,25 @@ def check_glyphs_have_recommended_contour_count(ttFont):
                   " of contours [{}]").format(', '.join(bad_glyphs_name)))
   else:
     yield PASS, "All glyphs have the recommended amount of contours"
+
+
+@register_test
+@test(
+    id='com.google.fonts/test/154'
+  , conditions=['gfonts_ttFont']
+)
+def check_regression_missing_glyphs(ttFont, gfonts_ttFont):
+  """Check font has same encoded glyphs as version hosted on
+  fonts.google.com"""
+  cmap = ttFont['cmap'].getcmap(3, 1).cmap
+  gf_cmap = gfonts_ttFont['cmap'].getcmap(3, 1).cmap
+  missing_codepoints = set(gf_cmap.keys()) - set(cmap.keys())
+
+  if missing_codepoints:
+    hex_codepoints = ['0x' + hex(c).upper()[2:].zfill(4) for c
+                      in missing_codepoints]
+    yield FAIL, ("Font is missing the following glyphs "
+                 "from the previous release [%s]" % (
+                   ', '.join(hex_codepoints)))
+  else:
+    yield PASS, ('Font has all the glyphs from the previous release')

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -570,3 +570,32 @@ def test_id_153(montserrat_ttFonts):
     ttFont['glyf']['a'] = ttFont['glyf']['c']
     status, message = list(check_glyphs_have_recommended_contour_count(ttFont))[-1]
     assert status == WARN
+
+
+def test_id_154(cabin_ttFonts):
+    """Check glyphs are not missing when compared to version on fonts.google.com"""
+    from fontbakery.specifications.googlefonts import (
+                                      check_regression_missing_glyphs,
+                                      gfonts_ttFont,
+                                      remote_styles, metadata)
+
+    font = cabin_ttFonts[-1]
+    print(cabin_ttFonts)
+    style = font['name'].getName(2, 1, 0, 0)
+
+    meta = metadata("data/test/cabin/")
+    gfonts_remote_styles = remote_styles(meta)
+    gfont = gfonts_ttFont(str(style), gfonts_remote_styles)
+
+    # Cabin font hosted on fonts.google.com contains all the glyphs for the font in
+    # data/test/cabin
+    status, message = list(check_regression_missing_glyphs(font, gfont))[-1]
+    assert status == PASS
+
+    # Take A glyph out of font
+    font['cmap'].getcmap(3, 1).cmap.pop(ord('A'))
+    font['glyf'].glyphs.pop('A')
+
+    status, message = list(check_regression_missing_glyphs(font, gfont))[-1]
+    assert status == FAIL
+    assert 'Font is missing the following glyphs from the previous release [0x0041]' == message

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -577,7 +577,8 @@ def test_id_154(cabin_ttFonts):
     from fontbakery.specifications.googlefonts import (
                                       check_regression_missing_glyphs,
                                       gfonts_ttFont,
-                                      remote_styles, metadata)
+                                      remote_styles,
+                                      metadata)
 
     font = cabin_ttFonts[-1]
     print(cabin_ttFonts)
@@ -598,4 +599,4 @@ def test_id_154(cabin_ttFonts):
 
     status, message = list(check_regression_missing_glyphs(font, gfont))[-1]
     assert status == FAIL
-    assert 'Font is missing the following glyphs from the previous release [0x0041]' == message
+


### PR DESCRIPTION
This pr will check if encoded glyphs are missing from the current version hosted on fonts.google.com.

I've decided to only include the uni codepoint of a glyph; not the name. Using glyph names may cause confusion. Also, many folks will use their own naming scheme (AGL names, uniXXXX names etc). I think it is more usable if we just provide the uni codepoint.

Output for fonts which fail this test:
`Font is missing the following glyphs from the previous release [0x0041, ...]`