### PR TITLE
Clarify wording on test/155 ...

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -4354,7 +4354,8 @@ def check_regression_missing_glyphs(ttFont, gfonts_ttFont):
   , conditions=['font_metadata']
 )
 def check_METADATA_copyright_notices_match_name_table_entries(ttFont, font_metadata):
-  """"Copyright notice name entry matches those on METADATA.pb ?"""
+  """Copyright field for this font on METADATA.pb matches
+     all copyright notice entries on the name table ?"""
   from fontbakery.constants import NAMEID_COPYRIGHT_NOTICE
   from unidecode import unidecode
   failed = False
@@ -4363,10 +4364,11 @@ def check_METADATA_copyright_notices_match_name_table_entries(ttFont, font_metad
     if nameRecord.nameID == NAMEID_COPYRIGHT_NOTICE and\
        string != font_metadata.copyright:
         failed = True
-        yield FAIL, ("Copyright notice name entry ('{}')"
-                     " differs from copyright field on"
-                     " METADATA.pb ('{}').").format(unidecode(string),
-                                                    font_metadata.copyright)
+        yield FAIL, ("Copyright field for this font on METADATA.pb ('{}')"
+                     " differs from a copyright notice entry"
+                     " on the name table:"
+                     " '{}'").format(font_metadata.copyright,
+                                     unidecode(string))
   if not failed:
-    yield PASS, ("Copyright notice name entry matches"
-                 " those on METADATA.pb fields.")
+    yield PASS, ("Copyright field for this font on METADATA.pb matches"
+                 " copyright notice entries on the name table.")

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -1335,7 +1335,8 @@ def test_id_154(cabin_ttFonts):
 
 
 def test_id_155():
-  """ Copyright notice name entry matches those on METADATA.pb ? """
+  """ Copyright field for this font on METADATA.pb matches
+      all copyright notice entries on the name table ? """
   from fontbakery.constants import NAMEID_COPYRIGHT_NOTICE
   from fontbakery.specifications.googlefonts import \
                    (check_METADATA_copyright_notices_match_name_table_entries,
@@ -1348,13 +1349,13 @@ def test_id_155():
   font_meta = font_metadata(family_meta, ttFont)
 
   # So it must PASS the test:
-  print ("Test PASS with a good font...")
+  print ("Test PASS with a good METADATA.pb for this font...")
   status, message = list(check_METADATA_copyright_notices_match_name_table_entries(ttFont, font_meta))[-1]
   assert status == PASS
 
   # Then we FAIL with mismatching names:
   good_value = get_name_string(ttFont, NAMEID_COPYRIGHT_NOTICE)[0]
   font_meta.copyright = good_value + "something bad"
-  print ("Test FAIL with a bad font...")
+  print ("Test FAIL with a bad METADATA.pb (with a copyright string not matching this font)...")
   status, message = list(check_METADATA_copyright_notices_match_name_table_entries(ttFont, font_meta))[-1]
   assert status == FAIL


### PR DESCRIPTION
... to make it clear that the copyright notice entries on name table are the reference values which are expected to be found on METADATA.pb font.copyright field (not the other way around).

This does not alter the test implementation. It only changes the wording of the log messages and docstrings and comments/messages on the corresponding self-test.

This pull request addresses the problems described at issue #183 
