### PR TITLE
rename download_family_from_GoogleFontDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* 0.3.2 (2017-Aug-??):
+  - fix crash on fontbakery-check-font-version.py
+  - add automated tests for the fixer scripts
+
 * 0.3.1 (2017-Aug-11):
   - Emergencial release to address broken 0.3.0 packaging.
   - setup.py: Added modules that were missing in previous release

--- a/bin/fontbakery-check-font-version.py
+++ b/bin/fontbakery-check-font-version.py
@@ -25,7 +25,7 @@ from fontTools.ttLib import TTFont
 from ntpath import basename
 
 from fontbakery.utils import (
-  download_family_from_GoogleFontDirectory,
+  download_family_from_Google_Fonts,
   download_zip,
   fonts_from_zip,
   parse_version_head,
@@ -41,7 +41,7 @@ def main():
                       help='Compare against a set of local ttfs')
   args = parser.parse_args()
 
-  google_family_zip = download_family_from_GoogleFontDirectory(args.family)
+  google_family_zip = download_family_from_Google_Fonts(args.family)
   google_family_fonts = [f[1] for f in fonts_from_zip(google_family_zip)]
   google_family_version = parse_version_head(google_family_fonts)
 


### PR DESCRIPTION
... to download_family_from_Google_Fonts
(Fixes #1525)

This is also related to the #1513 pull request.
