### PR TITLE
from functools import partial

### DIFF
--- a/Lib/fontbakery/testrunner.py
+++ b/Lib/fontbakery/testrunner.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import types
 from collections import OrderedDict, Counter
+from functools import partial
 from itertools import chain
 import sys
 import traceback


### PR DESCRIPTION
partial() is called on lines 1039 and 1064.

This pull request addresses the problems described at issue #1547
