### PR TITLE
New test: max length of 500 chars for COPYRIGHT_NOTICE

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -4627,3 +4627,34 @@ def com_google_fonts_test_163(ttFont):
                                 unidecode(stylename_str))
   if not failed:
     yield PASS, "All name entries are good."
+
+
+@register_test
+@test(
+    id='com.google.fonts/test/164'
+  , rationale = """
+    This is an arbitrary max lentgh for the copyright notice field
+    of the name table. We simply don't want such notices to be too long.
+    Typically such notices are actually much shorter than this with
+    a lenghth of roughtly 70 or 80 characters.
+    """
+  , request = 'https://github.com/googlefonts/fontbakery/issues/1603'
+)
+def com_google_fonts_test_164(ttFont):
+  """ Length of copyright notice must not exceed 500 characters. """
+  from unidecode import unidecode
+  from fontbakery.utils import get_name_entries
+  from fontbakery.constants import NAMEID_COPYRIGHT_NOTICE
+
+  failed = False
+  for notice in get_name_entries(ttFont, NAMEID_COPYRIGHT_NOTICE):
+    notice_str = notice.string.decode(notice.getEncoding())
+    if len(notice_str) > 500:
+        failed = True
+        yield FAIL, ("The length of the following copyright notice ({})"
+                     " exceeds 500 chars: '{}'"
+                     "").format(len(notice_str),
+                                unidecode(notice_str))
+  if not failed:
+    yield PASS, ("All copyright notice name entries on the"
+                 " 'name' table are shorter than 500 characters.")

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -253,19 +253,19 @@ def test_id_005():
   """ DESCRIPTION.en_us.html must have more than 200 bytes. """
   from fontbakery.specifications.googlefonts import com_google_fonts_test_005 as test
 
-  good_length = 'a' * 199
+  bad_length = 'a' * 199
   print('Test FAIL with 199-byte buffer...')
-  status, message = list(test(good_length))[-1]
-  assert status == FAIL
-
-  good_length = 'a' * 200
-  print('Test FAIL with 200-byte buffer...')
-  status, message = list(test(good_length))[-1]
-  assert status == FAIL
-
-  bad_length = 'a' * 201
-  print('Test PASS with 201-byte buffer...')
   status, message = list(test(bad_length))[-1]
+  assert status == FAIL
+
+  bad_length = 'a' * 200
+  print('Test FAIL with 200-byte buffer...')
+  status, message = list(test(bad_length))[-1]
+  assert status == FAIL
+
+  good_length = 'a' * 201
+  print('Test PASS with 201-byte buffer...')
+  status, message = list(test(good_length))[-1]
   assert status == PASS
 
 
@@ -2201,5 +2201,37 @@ def test_id_163():
       break
 
   print ("Test FAIL with a bad font...")
+  status, message = list(test(ttFont))[-1]
+  assert status == FAIL
+
+
+def test_id_164():
+  """ Length of copyright notice must not exceed 500 characters. """
+  from fontbakery.specifications.googlefonts import com_google_fonts_test_164 as test
+  from fontbakery.constants import NAMEID_COPYRIGHT_NOTICE
+
+  ttFont = TTFont("data/test/cabin/Cabin-Regular.ttf")
+
+  print('Test PASS with 499-byte copyright notice string...')
+  good_entry = 'a' * 499
+  for i, entry in enumerate(ttFont['name'].names):
+    if entry.nameID == NAMEID_COPYRIGHT_NOTICE:
+      ttFont['name'].names[i].string = good_entry.encode(entry.getEncoding())
+  status, message = list(test(ttFont))[-1]
+  assert status == PASS
+
+  print('Test PASS with 500-byte copyright notice string...')
+  good_entry = 'a' * 500
+  for i, entry in enumerate(ttFont['name'].names):
+    if entry.nameID == NAMEID_COPYRIGHT_NOTICE:
+      ttFont['name'].names[i].string = good_entry.encode(entry.getEncoding())
+  status, message = list(test(ttFont))[-1]
+  assert status == PASS
+
+  print('Test FAIL with 501-byte copyright notice string...')
+  bad_entry = 'a' * 501
+  for i, entry in enumerate(ttFont['name'].names):
+    if entry.nameID == NAMEID_COPYRIGHT_NOTICE:
+      ttFont['name'].names[i].string = bad_entry.encode(entry.getEncoding())
   status, message = list(test(ttFont))[-1]
   assert status == FAIL


### PR DESCRIPTION
on the name table. com.google.fonts/test/164

This pull request addresses the problems described at issue #1603 
