### PR TITLE
make sure the "style" condition returns None when style name is not canonical.

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -581,9 +581,12 @@ def com_google_fonts_test_019(ttFont):
 @condition
 def style(font):
   """Determine font style from canonical filename."""
+  from fontbakery.constants import STYLE_NAMES
   filename = os.path.split(font)[-1]
   if '-' in filename:
-    return os.path.splitext(filename)[0].split('-')[1]
+    stylename = os.path.splitext(filename)[0].split('-')[1]
+    if stylename in [name.replace(' ', '') for name in STYLE_NAMES]:
+      return stylename
 
 
 @register_test


### PR DESCRIPTION
This fixes errors we were getting at com.google.fonts/test/020

This pull request addresses the problems described at issue #1607 
