### PR TITLE
FAIL when fontTools is unable to lookup ligature data on a malformed font file

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2314,10 +2314,12 @@ def com_google_fonts_test_064(ttFont, ligatures):
       issues with caret rendering.
   """
   if ligatures == -1:
-    yield FAIL, ("Failed to lookup ligatures."
-                 " This font file seems to be malformed."
-                 " For more info, read:"
-                 " https://github.com/googlefonts/fontbakery/issues/1596")
+    yield FAIL, Message("malformed",
+                        "Failed to lookup ligatures."
+                        " This font file seems to be malformed."
+                        " For more info, read:"
+                        " https://github.com"
+                        "/googlefonts/fontbakery/issues/1596")
   elif "GDEF" not in ttFont:
     yield WARN, Message("GDEF-missing",
                         ("GDEF table is missing, but it is mandatory"
@@ -2377,10 +2379,12 @@ def com_google_fonts_test_065(ttFont, ligatures, has_kerning_info):
     return result
 
   if ligatures == -1:
-    yield FAIL, ("Failed to lookup ligatures."
-                 " This font file seems to be malformed."
-                 " For more info, read:"
-                 " https://github.com/googlefonts/fontbakery/issues/1596")
+    yield FAIL, Message("malformed",
+                        "Failed to lookup ligatures."
+                        " This font file seems to be malformed."
+                        " For more info, read:"
+                        " https://github.com"
+                        "/googlefonts/fontbakery/issues/1596")
   else:
     for lookup in ttFont["GPOS"].table.LookupList.Lookup:
       if lookup.LookupType == 2:  # type 2 = Pair Adjustment
@@ -2390,9 +2394,10 @@ def com_google_fonts_test_065(ttFont, ligatures, has_kerning_info):
       #     look_for_nonligated_kern_info(lookup.SubTable[0])
 
     if remaining != {}:
-      yield FAIL, ("GPOS table lacks kerning info for the following"
-                   " non-ligated sequences: "
-                   "{}").format(ligatures_str(remaining))
+      yield FAIL, Message("lacks-kern-info",
+                          ("GPOS table lacks kerning info for the following"
+                           " non-ligated sequences: "
+                           "{}").format(ligatures_str(remaining)))
     else:
       yield PASS, ("GPOS table provides kerning info for "
                    "all non-ligated sequences.")

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -1280,7 +1280,7 @@ def test_id_065():
   # So it must FAIL the test:
   print ("Test FAIL with a bad font...")
   status, message = list(test(ttFont, lig, has_kinfo))[-1]
-  assert status == FAIL
+  assert status == FAIL and message.code == "lacks-kern-info"
 
 
 def test_id_066():


### PR DESCRIPTION
This pull request addresses the problems described at issue #1596 
