### PR TITLE
check-googlefonts: Updated Warn message for com_google_fonts_test_075

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2765,6 +2765,7 @@ def com_google_fonts_test_074(ttFont):
 def com_google_fonts_test_075(ttFont):
   """Check for points out of bounds."""
   failed = False
+  out_of_bounds = []
   for glyphName in ttFont['glyf'].keys():
     glyph = ttFont['glyf'][glyphName]
     coords = glyph.getCoordinates(ttFont['glyf'])[0]
@@ -2773,17 +2774,19 @@ def com_google_fonts_test_075(ttFont):
          y < glyph.yMin or y > glyph.yMax or \
          abs(x) > 32766 or abs(y) > 32766:
         failed = True
-        yield WARN, ("Glyph '{}' coordinates ({},{})"
-                     " out of bounds."
-                     " This happens a lot when points are not extremes,"
-                     " which is usually bad. However, fixing this alert"
-                     " by adding points on extremes may do more harm"
-                     " than good, especially with italics,"
-                     " calligraphic-script, handwriting, rounded and"
-                     " other fonts. So it is common to"
-                     " ignore this message.").format(glyphName, x, y)
-  if not failed:
-    yield PASS, "All glyph paths have coordinates within bounds!"
+        out_of_bounds.append((glyphName, x, y))
+
+  if failed:
+      yield WARN, ("The following glyphs have coordinates which are"
+                   " out of bounds:\n{}\nThis happens a lot when points"
+                   " are not extremes, which is usually bad. However,"
+                   " fixing this alert by adding points on extremes may"
+                   " do more harm than good, especially with italics,"
+                   " calligraphic-script, handwriting, rounded and"
+                   " other fonts. So it is common to"
+                   " ignore this message".format(out_of_bounds))
+  else:
+      yield PASS, "All glyph paths have coordinates within bounds!"
 
 
 @register_test


### PR DESCRIPTION
The previous implementation would produced incredibly long messages for handwitten or display fonts. It would unnecessarily repeat the lengthy description of why this error happens for each glyph. This information is only needed at the end of the test.

Warnings have gone from this:
![screen shot 2017-10-19 at 10 57 01](https://user-images.githubusercontent.com/7525512/31765440-442c8a50-b4bc-11e7-9d88-da70b2da09d6.png)


to this:
![screen shot 2017-10-19 at 10 56 29](https://user-images.githubusercontent.com/7525512/31765413-31168e2a-b4bc-11e7-922e-fdea7439dc74.png)

