### PR TITLE
WIP: check-browsers

### DIFF
--- a/Lib/fontbakery/browserdata.py
+++ b/Lib/fontbakery/browserdata.py
@@ -1,0 +1,68 @@
+config_browsers = \
+{
+    "browsers":[
+   {
+      "os":"Windows",
+      "os_version":"7",
+      "browser":"chrome",
+      "device":None,
+      "browser_version":"50.0"
+   },
+   {
+      "os":"Windows",
+      "os_version":"7",
+      "browser":"firefox",
+      "device":None,
+      "browser_version":"45.0"
+   },
+   {
+      "os":"Windows",
+      "os_version":"8.1",
+      "browser":"ie",
+      "device":None,
+      "browser_version":"11.0"
+   },
+   {
+      "os":"Windows",
+      "os_version":"10",
+      "browser":"ie",
+      "device":None,
+      "browser_version":"11.0"
+   },
+   {
+      "os":"Windows",
+      "os_version":"10",
+      "browser":"edge",
+      "device":None,
+      "browser_version":"13.0"
+   },
+   {
+      "os":"ios",
+      "os_version":"8.3",
+      "browser":"Mobile Safari",
+      "device":"iPad Air",
+      "browser_version":None
+   },
+   {
+      "os":"ios",
+      "os_version":"8.3",
+      "browser":"Mobile Safari",
+      "device":"iPhone 6",
+      "browser_version":None
+   },
+   {
+      "os":"android",
+      "os_version":"5.0",
+      "browser":"Android Browser",
+      "device":"Google Nexus 6",
+      "browser_version":None
+   },
+   {
+      "os":"android",
+      "os_version":"4.1",
+      "browser":"Android Browser",
+      "device":"Google Nexus 7",
+      "browser_version":None
+   }
+]
+}

--- a/bin/fontbakery-check-browsers.py
+++ b/bin/fontbakery-check-browsers.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+fontbakery-browser-tests
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use BrowserStack and GF Regression to take a waterfall screenshot of
+a collection of fonts on a range of Browsers.
+
+TODO (Marc Foley) Once Diffenator matures, return differences... not 
+just a waterfall.
+"""
+import argparse
+import sys
+from PIL import Image
+import browserstack_screenshots
+import requests
+import os
+from glob import glob
+from ntpath import basename
+import time
+import json
+
+from fontbakery.browserdata import config_browsers
+
+CONFIG = 'browser_config.json'
+
+
+def _build_filename_from_browserstack_json(j):
+    """Build useful filename for an image from the screenshot json metadata"""
+    filename = ''
+    device = j['device'] if j['device'] else 'Desktop'
+    if j['state'] == 'done' and j['image_url']:
+        detail = [device, j['os'], j['os_version'],
+                  j['browser'], j['browser_version'], '.jpg']
+        filename = '_'.join(item.replace(" ", "_") for item in detail if item)
+    else:
+        print 'screenshot timed out, ignoring this result'
+    return filename
+
+
+def _download_file(uri, filename):
+    try:
+        with open(filename, 'wb') as handle:
+            request = requests.get(uri, stream=True)
+            for block in request.iter_content(1024):
+                if not block:
+                    break
+                handle.write(block)
+    except IOError, e:
+        print e
+
+
+def _mkdir(path):
+    if not os.path.isdir(path):
+        os.mkdir(path)
+
+
+def gen_browserstack_imgs(auth, website, out_dir):
+    _mkdir(out_dir)
+
+    config = config_browsers
+    config['url'] = website
+
+    bstack = browserstack_screenshots.Screenshots(auth=auth, config=config)
+    generate_resp_json = bstack.generate_screenshots()
+    job_id = generate_resp_json['job_id']
+    print "http://www.browserstack.com/screenshots/{0}".format(job_id)
+    screenshots_json = bstack.get_screenshots(job_id)
+    print 'Generating images, be patient'
+    while screenshots_json == False: # keep refreshing until browerstack is done
+        time.sleep(3)
+        screenshots_json = bstack.get_screenshots(job_id)
+    for screenshot in screenshots_json['screenshots']:
+        filename = _build_filename_from_browserstack_json(screenshot)
+        base_image = os.path.join(out_dir, filename)
+        if filename:
+            _download_file(screenshot['image_url'], base_image)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('username', help='Browserstack username')
+    parser.add_argument('auth_key', help='Browserstack auth key')
+    parser.add_argument('fonts', nargs="+", help="Font paths")
+    parser.add_argument('-d', '--output-dir',
+                        help="Directory to output images to")
+    args = parser.parse_args()
+    auth = (args.username, args.auth_key)
+    out_dir = args.output_dir if args.output_dir else os.getcwd()
+
+    # Send fonts to GF Regression
+    url_gfregression = 'http://45.55.138.144'
+    url_upload = url_gfregression + '/api/upload'
+    payload = [('fonts', open(f, 'rb')) for f in args.fonts]
+    request = requests.post(url_upload, files=payload)
+    url_screenshot = url_gfregression + request.content
+
+    gen_browserstack_imgs(auth, url_screenshot, out_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ bs4==0.0.1
 defusedxml==0.4.1
 lxml==3.5.0
 Unidecode==0.4.19
+pybrowserstack-screenshots==0.1


### PR DESCRIPTION
While in Montreal, I discussed the idea of using [Browserstack's screenshot api](https://www.browserstack.com/screenshots) to test fonts in different browsers. At the time I thought this would be a difficult task. In reality, I just needed to add a [post endpoint](https://github.com/m4rc1e/gfregression/blob/master/app/main.py#L107-L134) to GF Regression to upload fonts and hey presto! we have pretty much all the bits needed.

At the moment it can only do waterfall glyph previews. There's no reason why it can't do more.

It works in the following manner.

- Upload fonts to GF Regression using POST endpoint
- Return a URL for the screenshot
- Use browserstack to take a screenshot from the returned url
- Download to user's system

CLI command is pretty simple

```
fontbakery check-browsers username auth_key [fonts]
```


We get back the following images:

*Win 10 IE 11*
![desktop_windows_10_ie_11 0_](https://user-images.githubusercontent.com/7525512/31948827-bf54a336-b8cf-11e7-99fd-9a35fa221ba8.jpg)

*Ipad Air IOS Safari 8.3*
![ipad_air_ios_8 3_mobile_safari_](https://user-images.githubusercontent.com/7525512/31948851-ce91c5c2-b8cf-11e7-8577-02fbe082affa.jpg)

There are many browsers we can choose from. We should probably decide these together.

---

This is still very much a WIP so keep it open.

I'm on a lot of releases at the moment so I won't be able to touch this for a week or two.