### PR TITLE
com_google_fonts_test_118: improve detection of modified glyphs

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -4040,7 +4040,7 @@ def com_google_fonts_test_118(ttFont, gfonts_ttFont):
     this_glyph_area = (these_glyphs[glyph] / this_upm) * gfonts_upm
     gfont_glyph_area = (gfonts_glyphs[glyph] / gfonts_upm) * this_upm
 
-    if abs(this_glyph_area - gfont_glyph_area) > 8000:
+    if abs(this_glyph_area - gfont_glyph_area) > 7000:
       bad_glyphs.append(glyph)
 
   if bad_glyphs:

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -4032,8 +4032,15 @@ def com_google_fonts_test_118(ttFont, gfonts_ttFont):
 
   shared_glyphs = set(these_glyphs) & set(gfonts_glyphs)
 
+  this_upm = ttFont['head'].unitsPerEm
+  gfonts_upm = gfonts_ttFont['head'].unitsPerEm
+
   for glyph in shared_glyphs:
-    if abs(int(these_glyphs[glyph]) - int(gfonts_glyphs[glyph])) > 8000:
+    # Normalize area difference against comparison's upm
+    this_glyph_area = (these_glyphs[glyph] / this_upm) * gfonts_upm
+    gfont_glyph_area = (gfonts_glyphs[glyph] / gfonts_upm) * this_upm
+
+    if abs(this_glyph_area - gfont_glyph_area) > 8000:
       bad_glyphs.append(glyph)
 
   if bad_glyphs:


### PR DESCRIPTION
I have revised this check because of https://github.com/huertatipografica/Alegreya-Sans/issues/11

There are two problems this pr addresses

---
In the previous implementation, if the fonts have different upms, all glyphs would be flagged as modified.

When a font's upm increases and the glyphs are scaled accordingly, the surface area of each glyph will also increase. I've updated the check so the upms are used when calculating the surface area.

---
The previous glyph difference value was too high. This mean't Alegreya's tbar issue slipped through.