### PR TITLE
com_google_fonts_test_040: Check values are greater than bbox,

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1458,7 +1458,7 @@ def com_google_fonts_test_040(ttFont, vmetrics):
     failed = True
     yield FAIL, Message("ascent",
                  ("OS/2.usWinAscent value"
-                  " should be greater than {}, but got"
+                  " should be equal or greater than {}, but got"
                   " {} instead").format(vmetrics['ymax'],
                                         ttFont['OS/2'].usWinAscent))
   # OS/2 usWinDescent:
@@ -1466,7 +1466,7 @@ def com_google_fonts_test_040(ttFont, vmetrics):
     failed = True
     yield FAIL, Message("descent",
                  ("OS/2.usWinDescent value"
-                  " should be greater than {}, but got"
+                  " should be equal or greater than {}, but got"
                   " {} instead").format(abs(vmetrics['ymin']),
                                         ttFont['OS/2'].usWinDescent))
   if not failed:

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1436,33 +1436,37 @@ def vmetrics(ttFonts):
 def com_google_fonts_test_040(ttFont, vmetrics):
   """Checking OS/2 usWinAscent & usWinDescent
 
-  A font's winAscent and winDescent values should be the same as the
-  head table's yMax, abs(yMin) values. By not setting them to these values,
-  clipping can occur on Windows platforms,
+  A font's winAscent and winDescent values should be greater than the
+  head table's yMax, abs(yMin) values. If they are less than these
+  values, clipping can occur on Windows platforms,
   https://github.com/RedHatBrand/Overpass/issues/33
 
   If the font includes tall/deep writing systems such as Arabic or
-  Devanagari, the linespacing can appear too loose. To counteract this,
-  enabling the OS/2 fsSelection bit 7 (Use_Typo_Metrics), Windows will use
-  the OS/2 typo values instead. This means the font developer can control
-  the linespacing with the typo values, whilst avoiding clipping by setting
-  the win values to the bounding box."""
+  Devanagari, the winAscent and winDescent can be greater than the yMax and
+  abs(yMin) to accommodate vowel marks.
+
+  When the win Metrics are significantly greater than the upm, the
+  linespacing can appear too loose. To counteract this, enabling the
+  OS/2 fsSelection bit 7 (Use_Typo_Metrics), will force Windows to use the
+  OS/2 typo values instead. This means the font developer can control the
+  linespacing with the typo values, whilst avoiding clipping by setting
+  the win values to values greater than the yMax and abs(yMin)."""
   failed = False
 
   # OS/2 usWinAscent:
-  if ttFont['OS/2'].usWinAscent != vmetrics['ymax']:
+  if ttFont['OS/2'].usWinAscent < vmetrics['ymax']:
     failed = True
     yield FAIL, Message("ascent",
                  ("OS/2.usWinAscent value"
-                  " should be {}, but got"
+                  " should be greater than {}, but got"
                   " {} instead").format(vmetrics['ymax'],
                                         ttFont['OS/2'].usWinAscent))
   # OS/2 usWinDescent:
-  if ttFont['OS/2'].usWinDescent != abs(vmetrics['ymin']):
+  if ttFont['OS/2'].usWinDescent < abs(vmetrics['ymin']):
     failed = True
     yield FAIL, Message("descent",
                  ("OS/2.usWinDescent value"
-                  " should be {}, but got"
+                  " should be greater than {}, but got"
                   " {} instead").format(abs(vmetrics['ymin']),
                                         ttFont['OS/2'].usWinDescent))
   if not failed:

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -826,14 +826,14 @@ def test_id_040(mada_ttFonts):
 
   # Then we break it:
   print('Test FAIL with a bad OS/2.usWinAscent...')
-  ttFont['OS/2'].usWinAscent = vm['ymax'] + 1
+  ttFont['OS/2'].usWinAscent = vm['ymax'] - 1
   ttFont['OS/2'].usWinDescent = abs(vm['ymin'])
   status, message = list(test(ttFont, vm))[-1]
   assert status == FAIL and message.code == "ascent"
 
   print('Test FAIL with a bad OS/2.usWinDescent...')
   ttFont['OS/2'].usWinAscent = vm['ymax']
-  ttFont['OS/2'].usWinDescent = abs(vm['ymin']) + 1
+  ttFont['OS/2'].usWinDescent = abs(vm['ymin']) - 1
   status, message = list(test(ttFont, vm))[-1]
   assert status == FAIL and message.code == "descent"
 


### PR DESCRIPTION
Solves #1655. Khaled's comment is correct. Some non Latin scripts require vowel marks which are higher than the bbox. These need to be accommodated
