### PR TITLE
modified .travis.yml testing install of font-v dependency to pypi release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - cp /usr/lib/python2.7/dist-packages/fontforge.* /home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages
 - pip install -e .
 - pip install git+https://github.com/behdad/fonttools.git
-- pip install -U git+https://github.com/source-foundry/font-v.git@libfv
+- pip install font-v
 - pip install pytest
 - pip install flake8
 - pip install pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
 - cp /usr/lib/python2.7/dist-packages/fontforge.* /home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages
 - pip install -e .
 - pip install git+https://github.com/behdad/fonttools.git
-- pip install font-v
 - pip install pytest
 - pip install flake8
 - pip install pylint


### PR DESCRIPTION
Addresses #1659

The changes that @felipesanches requested in https://github.com/source-foundry/font-v/issues/14 were merged to our master branch and pushed to PyPI as v0.4.0.  As per his request in https://github.com/googlefonts/fontbakery/pull/1659#issuecomment-348381269 it is now ok to install from PyPI for your travis tests.

This PR modifies a single line in the .travis.yml file to install the new font-v dependency from PyPI.

When this is merged, I will delete the temporary `libfv` branch.

A big thanks to Felipe and Lasse for all of their input and feedback on the changes in this release.  It was incredibly useful and greatly appreciated.  I hope that the changes that we made are of some use here down the road.
