### PR TITLE
SKETCH: Refactoring to allow testing of items other than fonts

### DIFF
--- a/Lib/fontbakery/argumentparser.py
+++ b/Lib/fontbakery/argumentparser.py
@@ -1,0 +1,123 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import sys
+import logging
+import argparse
+import glob
+from collections import OrderedDict
+
+from fontbakery.testrunner import (
+              distribute_generator
+            , TestRunner
+            , Spec
+            , DEBUG
+            , INFO
+            , WARN
+            , ERROR
+            , SKIP
+            , PASS
+            , FAIL
+            )
+
+log_levels =  OrderedDict((s.name,s) for s in sorted((
+              DEBUG
+            , INFO
+            , WARN
+            , ERROR
+            , SKIP
+            , PASS
+            , FAIL
+            )))
+
+DEFAULT_LOG_LEVEL = WARN
+
+from fontbakery.reporters.terminal import TerminalReporter
+from fontbakery.reporters.serialize import SerializeReporter
+
+
+
+def FBArgumentParser(specification):
+  argument_parser = argparse.ArgumentParser(description="Check a specification.",
+                                  formatter_class=argparse.RawTextHelpFormatter)
+
+  argument_parser.add_argument('-c', '--checkid', action='append',
+                      help='Explicit check-ids to be executed.\n'
+                           'Use this option multiple times to select multiple checks.'
+                     )
+
+  def log_levels_get(key):
+    if key in log_levels:
+      return log_levels[key]
+    raise argparse.ArgumentTypeError('Key "{}" must be one of: {}.'.format(
+                                          key, ', '.join(log_levels.keys())))
+  argument_parser.add_argument('-v', '--verbose', dest='loglevels', const=PASS, action='append_const',
+                      help='Shortcut for `-l PASS`.\n')
+
+  argument_parser.add_argument('-l', '--loglevel', dest='loglevels', type=log_levels_get,
+                      action='append',
+                      metavar= 'LOGLEVEL',
+                      help='Report tests with a result of this status or higher.\n'
+                           'One of: {}.\n'
+                           '(default: {})'.format(', '.join(log_levels.keys())
+                                                   , DEFAULT_LOG_LEVEL.name))
+
+  argument_parser.add_argument('-m', '--loglevel-messages', default=None, type=log_levels_get,
+                      help=('Report log messages of this status or higher.\n'
+                            'Messages are all status lines within a test.\n'
+                            'One of: {}.\n'
+                            '(default: LOGLEVEL)'
+                            ).format(', '.join(log_levels.keys())))
+
+  argument_parser.add_argument('-n', '--no-progress', default=False, action='store_true',
+                      help='In a tty as stdout, don\'t render the progress indicators.')
+
+  argument_parser.add_argument('-C', '--no-colors', default=False, action='store_true',
+                      help='No colors for tty output.')
+
+  argument_parser.add_argument('-L', '--list-tests', default=False, action='store_true',
+                      help='List the tests available in the selected specification.')
+
+  argument_parser.add_argument('--json', default=False, type=argparse.FileType('w'),
+                      metavar= 'JSON_FILE',
+                      help='Write a json formatted report to JSON_FILE.')
+
+  iterargs = sorted(specification.iterargs.keys())
+
+
+
+  gather_by_choices = iterargs + ['*test']
+  argument_parser.add_argument('-g','--gather-by', default=None,
+                      metavar= 'ITERATED_ARG',
+                      choices=gather_by_choices,
+                      help='Optional: collect results by ITERATED_ARG\n'
+                      'In terminal output: create a summary counter for each ITERATED_ARG.\n'
+                      'In json output: structure the document by ITERATED_ARG.\n'
+                      'One of: {}'.format(', '.join(gather_by_choices))
+                      )
+
+  def parse_order(arg):
+    order = filter(len, [n.strip() for n in arg.split(',')])
+    return order or None
+  argument_parser.add_argument('-o','--order', default=None, type=parse_order,
+                      help='Comma separated list of order arguments.\n'
+                      'The execution order is determined by the order of the test\n'
+                      'definitions and by the order of the iterable arguments.\n'
+                      'A section defines its own order. `--order` can be used to\n'
+                      'override the order of *all* sections.\n'
+                      'Despite the ITERATED_ARGS there are two special\n'
+                      'values available:\n'
+                      '"*iterargs" -- all remainig ITERATED_ARGS\n'
+                      '"*test"     -- order by test\n'
+                      'ITERATED_ARGS: {}\n'
+                      'A sections default is equivalent to: "*iterargs, *test".\n'
+                      'A common use case is `-o "*test"` when testing the whole \n'
+                      'collection against a selection of tests picked with `--checkid`.'
+                      ''.format(', '.join(iterargs))
+                      )
+  return argument_parser
+
+class ArgumentParserError(Exception): pass
+
+class ThrowingArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise ArgumentParserError(message)

--- a/Lib/fontbakery/commands/check_googlefonts.py
+++ b/Lib/fontbakery/commands/check_googlefonts.py
@@ -4,17 +4,39 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from functools import partial
 from fontbakery.specifications.googlefonts import specification
-from fontbakery.commands.check_spec import (
-                                             runner_factory as super_runner_factory
-                                           , main as super_main
-                                           )
-
+from fontbakery.commands.check_spec import main as super_main
+import argparse
+from fontbakery.argumentparser import FBArgumentParser
+import glob
 # The values dict will probably get one or more specific blacklists
 # for the google font project. It would be good if it was not necessary
 # to copy paste this kind of configuration, thus a central init for
 # the google/fonts repository is be good.
 GOOGLEFONTS_SPECIFICS = {}
 
-runner_factory = partial(super_runner_factory, specification, values=GOOGLEFONTS_SPECIFICS)
-main = partial(super_main, specification, values=GOOGLEFONTS_SPECIFICS)
 
+def get_fonts(pattern):
+  fonts_to_check = []
+  # use glob.glob to accept *.ttf
+  for fullpath in glob.glob(pattern):
+    if fullpath.endswith(".ttf"):
+      fonts_to_check.append(fullpath)
+    else:
+      logging.warning("Skipping '{}' as it does not seem "
+                        "to be valid TrueType font file.".format(fullpath))
+  return fonts_to_check
+
+class MergeAction(argparse.Action):
+  def __call__(self, parser, namespace, values, option_string=None):
+    target = [item for l in values for item in l]
+    setattr(namespace, self.dest, target)
+
+parser = FBArgumentParser(specification)
+parser.add_argument('fonts', nargs='+', type=get_fonts,
+                    action=MergeAction, help='font file path(s) to check.'
+                                         ' Wildcards like *.ttf are allowed.')
+args = parser.parse_args()
+main = partial(super_main, args=args,
+                           specification=specification,
+                           items_label='fonts',
+                           values=GOOGLEFONTS_SPECIFICS)

--- a/Lib/fontbakery/commands/check_googlefonts_upstream.py
+++ b/Lib/fontbakery/commands/check_googlefonts_upstream.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+from functools import partial
+from fontbakery.specifications.googlefonts_upstream import specification
+from fontbakery.commands.check_spec import main as super_main
+from fontbakery.argumentparser import FBArgumentParser
+import glob
+# The values dict will probably get one or more specific blacklists
+# for the google font project. It would be good if it was not necessary
+# to copy paste this kind of configuration, thus a central init for
+# the google/fonts repository is be good.
+GOOGLEFONTS_UPSTREAM_SPECIFICS = {}
+
+parser = FBArgumentParser(specification)
+parser.add_argument('font_dirs', nargs='+')
+
+args = parser.parse_args()
+main = partial(super_main, args=args, 
+                           specification=specification,
+                           items_label='font_dirs',
+                           values=GOOGLEFONTS_UPSTREAM_SPECIFICS)

--- a/Lib/fontbakery/commands/check_spec.py
+++ b/Lib/fontbakery/commands/check_spec.py
@@ -39,142 +39,11 @@ DEFAULT_LOG_LEVEL = WARN
 from fontbakery.reporters.terminal import TerminalReporter
 from fontbakery.reporters.serialize import SerializeReporter
 
-argument_parser = argparse.ArgumentParser(description="Check TTF files"
-                                             " for common issues.",
-                                 formatter_class=argparse.RawTextHelpFormatter)
 
-def ArgumentParser(specification, spec_arg=True):
-  argument_parser = argparse.ArgumentParser(description="Check TTF files"
-                                               " against a specification.",
-                                  formatter_class=argparse.RawTextHelpFormatter)
-
-  if spec_arg:
-    argument_parser.add_argument('specification',
-        help='Module name, must define a fontbakery "specification".')
-
-  def get_fonts(pattern):
-    fonts_to_check = []
-    # use glob.glob to accept *.ttf
-    for fullpath in glob.glob(pattern):
-      if fullpath.endswith(".ttf"):
-        fonts_to_check.append(fullpath)
-      else:
-        logging.warning("Skipping '{}' as it does not seem "
-                          "to be valid TrueType font file.".format(fullpath))
-    return fonts_to_check
-
-
-  class MergeAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-      target = [item for l in values for item in l]
-      setattr(namespace, self.dest, target)
-
-  argument_parser.add_argument('fonts', nargs='+', type=get_fonts,
-                      action=MergeAction, help='font file path(s) to check.'
-                                         ' Wildcards like *.ttf are allowed.')
-
-  argument_parser.add_argument('-c', '--checkid', action='append',
-                      help='Explicit check-ids to be executed.\n'
-                           'Use this option multiple times to select multiple checks.'
-                     )
-
-  def log_levels_get(key):
-    if key in log_levels:
-      return log_levels[key]
-    raise argparse.ArgumentTypeError('Key "{}" must be one of: {}.'.format(
-                                          key, ', '.join(log_levels.keys())))
-  argument_parser.add_argument('-v', '--verbose', dest='loglevels', const=PASS, action='append_const',
-                      help='Shortcut for `-l PASS`.\n')
-
-  argument_parser.add_argument('-l', '--loglevel', dest='loglevels', type=log_levels_get,
-                      action='append',
-                      metavar= 'LOGLEVEL',
-                      help='Report tests with a result of this status or higher.\n'
-                           'One of: {}.\n'
-                           '(default: {})'.format(', '.join(log_levels.keys())
-                                                   , DEFAULT_LOG_LEVEL.name))
-
-  argument_parser.add_argument('-m', '--loglevel-messages', default=None, type=log_levels_get,
-                      help=('Report log messages of this status or higher.\n'
-                            'Messages are all status lines within a test.\n'
-                            'One of: {}.\n'
-                            '(default: LOGLEVEL)'
-                            ).format(', '.join(log_levels.keys())))
-
-  argument_parser.add_argument('-n', '--no-progress', default=False, action='store_true',
-                      help='In a tty as stdout, don\'t render the progress indicators.')
-
-  argument_parser.add_argument('-C', '--no-colors', default=False, action='store_true',
-                      help='No colors for tty output.')
-
-  argument_parser.add_argument('-L', '--list-tests', default=False, action='store_true',
-                      help='List the tests available in the selected specification.')
-
-  argument_parser.add_argument('--json', default=False, type=argparse.FileType('w'),
-                      metavar= 'JSON_FILE',
-                      help='Write a json formatted report to JSON_FILE.')
-
-  iterargs = sorted(specification.iterargs.keys())
-
-
-
-  gather_by_choices = iterargs + ['*test']
-  argument_parser.add_argument('-g','--gather-by', default=None,
-                      metavar= 'ITERATED_ARG',
-                      choices=gather_by_choices,
-                      help='Optional: collect results by ITERATED_ARG\n'
-                      'In terminal output: create a summary counter for each ITERATED_ARG.\n'
-                      'In json output: structure the document by ITERATED_ARG.\n'
-                      'One of: {}'.format(', '.join(gather_by_choices))
-                      )
-
-  def parse_order(arg):
-    order = filter(len, [n.strip() for n in arg.split(',')])
-    return order or None
-  argument_parser.add_argument('-o','--order', default=None, type=parse_order,
-                      help='Comma separated list of order arguments.\n'
-                      'The execution order is determined by the order of the test\n'
-                      'definitions and by the order of the iterable arguments.\n'
-                      'A section defines its own order. `--order` can be used to\n'
-                      'override the order of *all* sections.\n'
-                      'Despite the ITERATED_ARGS there are two special\n'
-                      'values available:\n'
-                      '"*iterargs" -- all remainig ITERATED_ARGS\n'
-                      '"*test"     -- order by test\n'
-                      'ITERATED_ARGS: {}\n'
-                      'A sections default is equivalent to: "*iterargs, *test".\n'
-                      'A common use case is `-o "*test"` when testing the whole \n'
-                      'collection against a selection of tests picked with `--checkid`.'
-                      ''.format(', '.join(iterargs))
-                      )
-  return argument_parser
-
-class ArgumentParserError(Exception): pass
-
-class ThrowingArgumentParser(argparse.ArgumentParser):
-    def error(self, message):
-        raise ArgumentParserError(message)
-
-def get_spec():
-  """ Prefetch the specification module, to fill some holes in the help text."""
-  argument_parser = ThrowingArgumentParser(add_help=False)
-  argument_parser.add_argument('specification')
-  try:
-    args, unknown = argument_parser.parse_known_args()
-  except ArgumentParserError as e:
-    # silently fails, the main parser will show usage string.
-    return Spec()
-
-  from importlib import import_module
-  # Fails with an appropriate ImportError.
-  imported = import_module(args.specification, package=None)
-  # Fails with an attribute error if specification is undefined.
-  return imported.specification
-
-def runner_factory(specification, fonts, explicit_tests=None, custom_order=None
+def runner_factory(specification, label, items, explicit_tests=None, custom_order=None
                                                         , values=None):
   """ Convenience TestRunner factory. """
-  values_ = dict(fonts=fonts)
+  values_ = {label: items}
   if values is not None:
     values_.update(values)
   return TestRunner( specification, values_
@@ -182,22 +51,15 @@ def runner_factory(specification, fonts, explicit_tests=None, custom_order=None
                    , custom_order=custom_order
                    )
 
-def main(specification=None, values=None):
-  # this won't be used in check-googlefonts
-  add_spec_arg = False
-  if specification is None:
-    specification = get_spec()
-    add_spec_arg = True
-  argument_parser = ArgumentParser(specification, spec_arg=add_spec_arg)
-  args = argument_parser.parse_args()
-
+def main(args, specification=None, items_label=None, values=None):
   if args.list_tests:
     for section_name, section in specification._sections.items():
       tests = section.list_tests()
       sys.exit("Available tests on {} are:\n{}".format(section_name,
                                                        "\n".join(tests)))
 
-  runner = runner_factory(specification, args.fonts
+  items = getattr(args, items_label)
+  runner = runner_factory(specification, items_label, items
                      , explicit_tests=args.checkid
                      , custom_order=args.order
                      , values=values
@@ -221,5 +83,3 @@ def main(specification=None, values=None):
   if args.json:
     import json
     json.dump(sr.getdoc(), args.json, sort_keys=True, indent=4)
-
-

--- a/Lib/fontbakery/specifications/googlefonts_upstream.py
+++ b/Lib/fontbakery/specifications/googlefonts_upstream.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import,
+                        print_function,
+                        unicode_literals,
+                        division)
+
+from fontbakery.testrunner import (
+              INFO
+            , WARN
+            , ERROR
+            , SKIP
+            , PASS
+            , FAIL
+            , Section
+            , Spec
+            )
+import os
+from fontbakery.callable import condition, test
+from fontbakery.message import Message
+from fontbakery.constants import(
+        # TODO: priority levels are not yet part of the new runner/reporters.
+        # How did we ever use this information?
+        # Check priority levels:
+        CRITICAL
+      , IMPORTANT
+#     , NORMAL
+#     , LOW
+#     , TRIVIAL
+)
+
+default_section = Section('Default')
+specification = Spec(
+    default_section=default_section
+  , iterargs={'font_dir': 'font_dirs'}
+  #, sections=[]
+)
+
+register_test = specification.register_test
+register_condition = specification.register_condition
+
+
+def has_dir(upstream_path, dir_name):
+  path = os.path.join(upstream_path, dir_name)
+
+  if os.path.isdir(path):
+    yield PASS, ('Repo has "{}" dir'.format(dir_name))
+  else:
+    yield FAIL, ('Repo needs "{}" dir or must be similiar dir must be '
+                 'renamed'.format(dir_name))
+
+
+@register_test
+@test(
+    id='com.upstream.repo/test/001'
+  , priority=CRITICAL
+)
+def com_upstream_repo_test_001(font_dir):
+  """Check repo has font dir
+  """
+  return has_dir(font_dir, 'fonts')
+
+
+@register_test
+@test(
+    id='com.upstream.repo/test/002'
+  , priority=CRITICAL
+)
+def com_upstream_repo_test_002(font_dir):
+  """Check repo has sources dir
+  """
+  return has_dir(font_dir, 'sources')
+

--- a/bin/fontbakery-check-googlefonts-upstream.py
+++ b/bin/fontbakery-check-googlefonts-upstream.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+if __name__ == '__main__':
+  from fontbakery.commands.check_googlefonts_upstream import main
+  main()


### PR DESCRIPTION
**WARNING: Please don't merge this. This is merely a sketch. There are plenty of code smells and I've removed some objects which probably should've been kept.**

At the moment, FontBakery only allows ttfs to be tested. There's absolutely nothing wrong with this and I'm glad we didn't go making FB an all singing all dancing test suite from the start.

I'd like fontbakery to be able to test upstream font repos such as [Montserrat](https://github.com/JulietaUla/Montserrat). The benefits of doing this means we can use travis so designers will know straight away when they have deviated from the GF spec. Myself and Lasse brought this up in a proposal written a week or so ago.

In order to make FB check collection of items and not just fonts, I've done the following:

**Move the arg_parse object out of commands.check_spec.main()**
Inside commands.check_spec.main(), a [helper ArgumentParser object](https://github.com/googlefonts/fontbakery/blob/master/Lib/fontbakery/commands/check_spec.py#L46-L150) is instantiated. This helper has a compulsory argument ['font'](https://github.com/googlefonts/fontbakery/blob/master/Lib/fontbakery/commands/check_spec.py#L72-L74). I've moved all compulsory arguments out of this helper and moved it to its own module. In the commands module. This helper can now be imported into other command modules. I've add commands.check_googlefonts_upstream.py as a demo of how this could function.


**Let runner_factory create TestRunners which are not just made from args.fonts**
At the moment it can only create TestRunners from the ArgumentParser's fonts arg.


@graphicore Be as harsh as you like. I think it's best to get your opinion on this solution before I take it any further. In the meantime, I can carry on adding tests to Lib/fontbakery/specifications/googlefonts_upstream.py