### PR TITLE
deprecate check/066 (mandatory kern table check)

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2528,21 +2528,9 @@ def com_google_fonts_check_065(ttFont, ligatures, has_kerning_info):
                    "all non-ligated sequences.")
 
 
-@register_check
-@check(
-    id = 'com.google.fonts/check/066'
-)
-def com_google_fonts_check_066(ttFont):
-  """Is there a "kern" table declared in the font?
-
-     Fonts should have their kerning implemented in the GPOS table.
-  """
-
-  if "kern" in ttFont:
-    yield FAIL, "Font should not have a \"kern\" table"
-  else:
-    yield PASS, "Font does not declare a \"kern\" table."
-
+# DEPRECATED: com.google.fonts/check/066
+# "Is there a "kern" table declared in the font?"
+# See: https://github.com/googlefonts/fontbakery/issues/1675
 
 @register_check
 @check(

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -1297,28 +1297,9 @@ def test_check_065():
   status, message = list(check(ttFont, lig, has_kinfo))[-1]
   assert status == WARN and message.code == "lacks-kern-info"
 
-
-def test_check_066():
-  """ Is there a "kern" table declared in the font ? """
-  from fontbakery.specifications.googlefonts import com_google_fonts_check_066 as check
-
-  # Our reference Mada Regular is known to be good
-  # (does not have a 'kern' table):
-  ttFont = TTFont("data/test/mada/Mada-Regular.ttf")
-
-  # So it must PASS the check:
-  print ("Test PASS with a font without a 'kern' table...")
-  status, message = list(check(ttFont))[-1]
-  assert status == PASS
-
-  # add a fake 'kern' table:
-  ttFont["kern"] = "foo"
-
-  # and make sure the check FAILs:
-  print ("Test FAIL with a font containing a 'kern' table...")
-  status, message = list(check(ttFont))[-1]
-  assert status == FAIL
-
+# DEPRECATED: com.google.fonts/check/066
+# "Is there a "kern" table declared in the font?"
+# See: https://github.com/googlefonts/fontbakery/issues/1675
 
 def test_check_067():
   """ Make sure family name does not begin with a digit. """


### PR DESCRIPTION
This pull request addresses the problems described at issue #1675 
