### PR TITLE
Fixes for the Dashboard to run properly

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -371,7 +371,13 @@ class CheckRunner(object):
       error = MissingConditionError(name, err, tb)
       return error, None
 
-    args = self._get_args(condition, iterargs, path)
+    try:
+      args = self._get_args(condition, iterargs, path)
+    except Exception as err:
+      tb = get_traceback()
+      error = FailedConditionError(condition, err, tb)
+      return error, None
+
     path.pop()
     try:
       return None, condition(**args)

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1163,7 +1163,7 @@ def com_google_fonts_check_035(font):
       yield FAIL, "ftxvalidator output follows:\n\n{}\n".format(ftx_output)
 
   except subprocess.CalledProcessError as e:
-    yield INFO, ("ftxvalidator returned an error code. Output follows :"
+    yield WARN, ("ftxvalidator returned an error code. Output follows :"
                  "\n\n{}\n").format(e.output)
   except OSError:
     yield ERROR, "ftxvalidator is not available!"

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1219,14 +1219,10 @@ def com_google_fonts_check_037(font):
       filtered_msgs += line + "\n"
     yield INFO, ("Microsoft Font Validator returned an error code."
                  " Output follows :\n\n{}\n").format(filtered_msgs)
-  except OSError:
+  except (OSError, IOError) as error:
     yield ERROR, ("Mono runtime and/or "
                   "Microsoft Font Validator are not available!")
-    return
-  except IOError:
-    yield ERROR, ("Mono runtime and/or "
-                  "Microsoft Font Validator are not available!")
-    return
+    raise error
 
   xml_report = open("{}.report.xml".format(font), "r").read()
   try:

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -135,16 +135,12 @@ def get_font_glyph_data(font):
 
 
 def get_FamilyProto_Message(path):
-  try:
-    from fontbakery.fonts_public_pb2 import FamilyProto
-    from google.protobuf import text_format
-    message = FamilyProto()
-    text_data = open(path, "rb").read()
-    text_format.Merge(text_data, message)
-    return message
-  except:
-    import sys
-    sys.exit("Needs protobuf.\n\nsudo pip install protobuf")
+  from fontbakery.fonts_public_pb2 import FamilyProto
+  from google.protobuf import text_format
+  message = FamilyProto()
+  text_data = open(path, "rb").read()
+  text_format.Merge(text_data, message)
+  return message
 
 
 def check_bit_entry(ttFont, table, attr, expected, bitmask, bitname):


### PR DESCRIPTION
The commit messages are pretty much self describing. I think the one that may be discussed is 
7ee8162 "make failed `ftxvalidator` a WARN."

I'm using a simple bash script in the checker container as replacement for the `ftxvalidator` command:

```
#! /bin/bash
>&2 echo 'ftxvalidator is not available!'; exit 1;
```

I don't really think that things that we really can't fix at the moment should be an ERROR, so that bash script is a workaround. WARN seems more appropriate than INFO though.

related: https://github.com/googlefonts/fontbakery/issues/445#issuecomment-352243332 CC @madig