### PR TITLE
Refactor for deprecated fontv.libfv.FontVersion method

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -5030,7 +5030,7 @@ def com_google_fonts_check_165(ttFont, familyname):
       The git sha1 tagging and dev/release features of Source Foundry font-v
        tool are awesome and we would love to consider upstreaming the approach
        into fontmake someday. For now we only emit a WARN if a given font does
-       not yet follow the experimental versionin style, but at some point we
+       not yet follow the experimental versioning style, but at some point we
        may start enforcing it.
     """
   , request = 'https://github.com/googlefonts/fontbakery/issues/1563'
@@ -5045,10 +5045,10 @@ def com_google_fonts_check_166(ttFont):
   else:
     yield INFO, ("Version string is: \"{}\"\n"
                  "The version string must ideally include a git commit hash"
-                 " and eigther a 'dev' or a 'release' suffix such as in the"
+                 " and either a 'dev' or a 'release' suffix such as in the"
                  " example below:\n"
                  "\"Version 1.3; git-0d08353-release\""
-                 "").format(fv.get_version_string())
+                 "").format(fv.get_name_id5_version_string())
 
 
 for section_name, section in specification._sections.items():

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -2286,10 +2286,10 @@ def test_check_166():
   status, message = list(check(ttFont))[-1]
   assert status == INFO
 
-  print('Test PASS with one that follows the seggested scheme ...')
+  print('Test PASS with one that follows the suggested scheme ...')
   fv = FontVersion(ttFont)
   fv.set_git_commit_sha1(development=True)
-  version_string = fv.get_version_string()
+  version_string = fv.get_name_id5_version_string()
   for record in ttFont['name'].names:
     if record.nameID == NAMEID_VERSION_STRING:
       record.string = version_string

--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -2288,7 +2288,7 @@ def test_check_166():
 
   print('Test PASS with one that follows the suggested scheme ...')
   fv = FontVersion(ttFont)
-  fv.set_git_commit_sha1(development=True)
+  fv.set_state_git_commit_sha1(development=True)
   version_string = fv.get_name_id5_version_string()
   for record in ttFont['name'].names:
     if record.nameID == NAMEID_VERSION_STRING:


### PR DESCRIPTION
This pull request addresses the problems described at issue #1689

Includes:

- conversion from `fontv.libfv.FontVersion.get_version_string` method name to `fontv.libfv.FontVersion.get_name_id5_version_string` method name (former is deprecated as of v0.6.0 release of font-v)
- spelling corrections

There is no change in the expected return string with the refactored method call.

closes #1689 
  