### PR TITLE
Add special case for "of" suffix on familynames for checks that rely on the familyname_with_spaces condition.

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -4711,6 +4711,21 @@ def familyname_with_spaces(ttFont):
     result += c
   result = result.strip()
 
+  def of_special_case(s):
+    """Special case for family names such as
+       MountainsofChristmas which would need to
+       have the "of" split apart from "Mountains".
+
+       See also: https://github.com/googlefonts/fontbakery/issues/1489
+       "Failure to handle font family with 3 words in it"
+    """
+    if s[-2:] == "of":
+      return s[:-2] + " of"
+    else:
+      return s
+
+  result = " ".join(map(of_special_case, result.split(" ")))
+
   if result[-3:] == "S C":
     return result[:-3] + "SC"
   else:


### PR DESCRIPTION
There are still potential problems with ambiguous familynames
such as "Proof Read" but if any of those surface we may add them
to the list of explicit exceptions, as these are probably
quite rare occurrences.

This pull request addresses the problems described at issue #1489 
