### PR TITLE
Remove fval.xsl file after running FontValidator.exe

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1291,13 +1291,11 @@ def com_google_fonts_check_037(font):
     raise error
 
   xml_report = open("{}.report.xml".format(font), "r").read()
-  try:
-    os.remove("{}.report.xml".format(font))
-    os.remove("{}.report.html".format(font))
-  except:
-    # Treat failure to delete reports
-    # as non-critical. Silently move on.
-    pass
+
+  os.remove("{}.report.xml".format(font))
+  os.remove("{}.report.html".format(font))
+  fval_file = os.path.join(os.path.dirname(font), 'fval.xsl')
+  os.remove(fval_file)
 
   def report_message(msg, details):
     if details:


### PR DESCRIPTION
When FB runs MS FontValidator.exe on a set of fonts, it creates 3 report files for each font:

```
Family-Style.ttf.report.xml
Family-Style.ttf.report.html
fval.xsl
```

Currently, fval.xsl isn't being deleted. This pr will delete it when the other two files also get deleted.

I also decided to remove the try/accept block as well. If FontValidator changes the report naming it will just sail past which isn't what we want.