### PR TITLE
[reporters/serialize] Fix KeyError

### DIFF
--- a/Lib/fontbakery/reporters/serialize.py
+++ b/Lib/fontbakery/reporters/serialize.py
@@ -132,19 +132,19 @@ class SerializeReporter(FontbakeryReporter):
 
       check = self._items[key]
       if self._results_by:
-        if not len(sectionDoc['checks']):
+        if not len(sectionDoc['check']):
           clusterlen = self._max_cluster_by_index + 1
           if self._results_by != '*check':
             # + 1 for rests bucket
             clusterlen += 1
-          sectionDoc['checks'] = [[] for _ in range(clusterlen)]
+          sectionDoc['check'] = [[] for _ in range(clusterlen)]
         index = check['clustered']['index']
         if index is None:
           # last element collects unclustered
           index = -1
-        sectionDoc['checks'][index].append(check)
+        sectionDoc['check'][index].append(check)
       else:
-        sectionDoc['checks'].append(check)
+        sectionDoc['check'].append(check)
       if sectionKey not in seen:
         seen.add(sectionKey)
         doc['sections'].append(sectionDoc)


### PR DESCRIPTION
"checks" is an invalid key for the sectionDoc object. It has the following keys.

```
{'check': [], 'key': (u'<Section: Default>', None, None), 'result': Counter({u'SKIP': 51, u'PASS': 45, u'FAIL': 15, u'WARN': 8, u'INFO': 5, u'ERROR': 3})}
```
I've renamed 'checks' to 'check'.

Fixes #1709

@graphicore it may be best to quickly look over this and #1709. 
