### PR TITLE
fix crash on check/117: added safety test before continuing

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -4248,6 +4248,9 @@ def github_gfonts_ttFont(ttFont, license):
   """Get a TTFont object of a font downloaded
      from Google Fonts git repository.
   """
+  if not license:
+    return
+
   from fontbakery.utils import download_file
   from fontTools.ttLib import TTFont
   LICENSE_DIRECTORY = {


### PR DESCRIPTION
It immediately returns from the fb-condition function if no license was specified (meaning no license name was previously identified).

The license name is needed here in order to decide which is the correct URL for the family hosted on the google/fonts github repo.

This pull request addresses the problems described at issue #1722 
