### PR TITLE
temporarily disable check/082 as we currently lack a profiles.csv ...

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -3175,7 +3175,9 @@ def com_google_fonts_check_081(listed_on_gfonts_api):
     yield PASS, "Font is properly listed via Google Fonts API."
 
 
-@register_check
+# Temporarily disabled as requested at
+# https://github.com/googlefonts/fontbakery/issues/1728
+#@register_check
 @check(
     id = 'com.google.fonts/check/082'
   , conditions=['metadata']


### PR DESCRIPTION
...  file on the google/fonts git repo, after https://github.com/google/fonts/commit/188dc570f6610ed1c7ea1aa7d6269a238d4c93ff

This pull request addresses the problems described at issue #1728 
