### PR TITLE
openTypeOS2UnicodeRanges are actually useful to have.

### DIFF
--- a/Lib/fontbakery/specifications/ufo_sources.py
+++ b/Lib/fontbakery/specifications/ufo_sources.py
@@ -144,16 +144,17 @@ def com_daltonmaag_check_unnecessary_fields(ufo_font):
 
     ufo2ft will generate these.
 
-    openTypeOS2CodePageRanges is exempted because it is useful to toggle a
-    range when not _all_ the glyphs in that region are present.
+    openTypeOS2UnicodeRanges and openTypeOS2CodePageRanges are exempted
+    because it is useful to toggle a range when not _all_ the glyphs in that
+    region are present.
 
     year is deprecated since UFO v2.
     """
     unnecessary_fields = []
 
     for field in [
-            "openTypeOS2UnicodeRanges", "openTypeNameUniqueID",
-            "openTypeNameVersion", "postscriptUniqueID", "year"
+            "openTypeNameUniqueID", "openTypeNameVersion", "postscriptUniqueID",
+            "year"
     ]:
         if ufo_font.info.__dict__.get("_" + field) is not None:
             unnecessary_fields.append(field)

--- a/Lib/fontbakery/specifications/ufo_sources_test.py
+++ b/Lib/fontbakery/specifications/ufo_sources_test.py
@@ -40,7 +40,7 @@ def test_check_ufolint(empty_ufo_font):
 def test_check_required_fields(empty_ufo_font):
     from fontbakery.specifications.ufo_sources import (
         com_daltonmaag_check_required_fields as check)
-    ufo, ufo_path = empty_ufo_font
+    ufo, _ = empty_ufo_font
 
     print('Test FAIL with empty UFO.')
     c = list(check(ufo))
@@ -94,7 +94,6 @@ def test_check_unnecessary_fields(empty_ufo_font):
     status, _ = c[-1]
     assert status == PASS
 
-    ufo.info.openTypeOS2UnicodeRanges = [1]
     ufo.info.openTypeNameUniqueID = "aaa"
     ufo.info.openTypeNameVersion = "1.000"
     ufo.info.postscriptUniqueID = -1


### PR DESCRIPTION
ufo2ft will not generate this field automatically, as a designer can mark
a range as supported when not _all_ glpyhs in that range are present.
