### PR TITLE
Use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,13 @@ install:
 - cp /usr/lib/python2.7/dist-packages/fontforge.* /home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages
 - pip install -e .
 - pip install git+https://github.com/behdad/fonttools.git
-- pip install pytest
+- pip install tox
 - pip install flake8
 - pip install pylint
-- pip install ufolint
 script:
 - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 - export WONT_FIX=invalid-name,bad-indentation,inconsistent-return-statements
 - export MAYBE_SOMEDAY=fixme,missing-docstring,too-many-locals,too-many-branches,too-many-statements,bad-continuation,unidiomatic-typecheck,logging-format-interpolation,too-many-nested-blocks,superfluous-parens,bare-except,undefined-loop-variable,too-many-instance-attributes,old-style-class,unnecessary-pass,unused-argument,consider-iterating-dictionary,attribute-defined-outside-init,too-many-boolean-expressions,too-many-arguments,wrong-import-order,bad-whitespace,pointless-string-statement,pointless-statement,redefined-builtin,global-statement,too-many-lines,global-variable-undefined,redefined-variable-type,multiple-statements,expression-not-assigned,too-many-format-args,deprecated-lambda,broad-except,no-self-use,no-name-in-module,abstract-method,no-member,line-too-long,trailing-newlines,duplicate-code,redefined-outer-name,trailing-whitespace,unused-variable,logging-not-lazy,undefined-variable,protected-access,anomalous-backslash-in-string,wrong-import-position,ungrouped-imports,singleton-comparison,misplaced-comparison-constant,consider-using-enumerate,used-before-assignment,too-few-public-methods,dangerous-default-value,unexpected-keyword-arg,len-as-condition,no-else-return,relative-import,not-callable
 - export PYLINT="pylint --disable=$WONT_FIX,$MAYBE_SOMEDAY"
 - "$PYLINT Lib/fontbakery/specifications/*.py"
-- pytest Lib/fontbakery --verbose
+- tox

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1271,7 +1271,8 @@ def com_google_fonts_check_037(font):
   xml_report = open("{}.report.xml".format(font), "r").read()
 
   os.remove("{}.report.xml".format(font))
-  os.remove("{}.report.html".format(font))
+  if os.path.exists("{}.report.html".format(font)):
+    os.remove("{}.report.html".format(font))
   fval_file = os.path.join(os.path.dirname(font), 'fval.xsl')
   os.remove(fval_file)
 

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ git commit -m "Updating version in preparation for a new release"
 
 # install fontbakery on it and run our code tests
 pip install .
-pip install pytest
-pytest Lib/fontbakery --verbose
+pip install tox
+tox
 
 # crate the package
 python setup.py bdist_wheel
@@ -321,9 +321,9 @@ In addition to a complete architectural overhaul, release 0.3.1 introduced a set
 This "testsuite for the testsuite" initially covered a third of the full set of check and as of version 0.3.2 covers 53%.
 We aim to reach 100% test coverage.
 
-In order to run the code tests you need to have the pytest dependence installed and then run:
+In order to run the code tests you need to have the tox dependence installed and then run:
 
-    pytest Lib/fontbakery --verbose
+    tox
 
 All future pull-requests adding new checks must also provide a corresponding code test.
 Travis is configured to automatically run the code tests and pull-requests cannot be merged if any test is failing.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+testpaths=Lib/fontbakery

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 testpaths=Lib/fontbakery

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         'bs4',
         'fontTools',
         'font-v',
-        'defcon'
+        'defcon',
+        'ufolint',
     ]
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps=pytest
+commands=pytest {posargs} Lib

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,4 @@ envlist = py27
 [testenv]
 deps=pytest
 commands=pytest {posargs} Lib
+passenv=LD_LIBRARY_PATH LD_PRELOAD

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,5 @@ envlist = py27
 
 [testenv]
 deps=pytest
-commands=pytest {posargs} Lib
+commands=pytest {posargs}
 passenv=LD_LIBRARY_PATH LD_PRELOAD


### PR DESCRIPTION
Use tox instead of invoking pytest directly. That makes it easier to have different Python versions run the test suite and takes care of setting up a proper test environment with all the packages.