### PR TITLE
new check/174: static ttf can be generated from a variable font.

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts_test.py
+++ b/Lib/fontbakery/specifications/googlefonts_test.py
@@ -2557,3 +2557,16 @@ def disabled_test_check_173():
   status, message = list(check(ttFont))[-1]
   assert status == FAIL
 
+
+def test_check_174():
+  """ Check a static ttf can be generated from a variable font. """
+  from fontbakery.specifications.googlefonts import com_google_fonts_check_174 as check
+
+  ttFont = TTFont('data/test/cabinvfbeta/CabinVFBeta.ttf')
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+  # Removing a table to deliberately break variable font
+  del ttFont['fvar']
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL


### PR DESCRIPTION
This check will ensure that variable fonts can gen a static ttf instance using fontTools.varLib.mutator. In the future, GoogleFonts may serve static ttfs using this approach.

This check is related to #1727. I understand we have check 173 which solves this issue directly. This check is more of a functional test, a bit like running ots etc.