### PR TITLE
Provide yapf and flake8 defaults

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [tool:pytest]
 testpaths=Lib/fontbakery
+
+[yapf]
+based_on_style = google
+indent_width = 2
+
+[flake8]
+ignore = E111, E114


### PR DESCRIPTION
This makes work on the code a bit easier.

The flake8 settings ignore the indent width being != 4.