### PR TITLE
Fix check 174 on Windows by not using the filesystem

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -5460,9 +5460,9 @@ def com_google_fonts_check_174(ttFont):
   try:
     loc = {k.axisTag: float((k.maxValue + k.minValue) / 2)
            for k in ttFont['fvar'].axes}
-    with tempfile.NamedTemporaryFile() as instance:
+    with tempfile.TemporaryFile() as instance:
       font = mutator.instantiateVariableFont(ttFont, loc)
-      font.save(instance.name)
+      font.save(instance)
       yield PASS, ("fontTools.varLib.mutator generated a static font "
                    "instance")
   except Exception as e:


### PR DESCRIPTION
Having TTFont save() to the named temporary file throws an IOError on Windows.

The docs for tempfile.NamedTemporaryFile say: "Whether the name can be used to
open the file a second time, while the named temporary file is still open,
varies across platforms (it can be so used on Unix; it cannot on Windows NT or
later)."

Solved by using a TemporaryFile, since TTFont.save() also accepts a writable
file object. And we avoid touching the file system. Yay for in-memory operations.
