### PR TITLE
[check-specification] move 'fonts' validation to the spec

### DIFF
--- a/Lib/fontbakery/commands/check_specification.py
+++ b/Lib/fontbakery/commands/check_specification.py
@@ -192,9 +192,6 @@ def main(specification=None, values=None):
         values_[key] = getattr(args, key)
 
   try:
-    if not args.fonts:
-      raise ValueValidationError, "No files to check specified."
-
     runner = runner_factory(specification
                      , explicit_checks=args.checkid
                      , custom_order=args.order

--- a/Lib/fontbakery/specifications/ufo_sources.py
+++ b/Lib/fontbakery/specifications/ufo_sources.py
@@ -59,6 +59,9 @@ fonts_expected_value = ExpectedValue(
       'fonts'
     , default=[]
     , description='A list of the ufo file paths to check.'
+    , validator=lambda fonts: (True, None) if len(fonts) \
+                                    else (False, 'Value is empty.')
+
 )
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
The spec defines this dependency and there's a mechanism to validate it, that also does the same as the current code. It's bad to leak knowledge about arguments into `check-specification` that originate somewhere else.

This pull request addresses the problems described at comment https://github.com/googlefonts/fontbakery/pull/1745#pullrequestreview-110109092
