### PR TITLE
[check-specification] allow a filename as specification

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -721,7 +721,7 @@ class Section(object):
     self.description = description
     self._add_check_callback = None
     self._checks = [] if checks is None else list(checks)
-    self._checkid2index = {i:check.id for i, check in enumerate(self._checks)}
+    self._checkid2index = {check.id:i for i, check in enumerate(self._checks)}
     # a list of iterarg-names
     self._order = order or []
 

--- a/Lib/fontbakery/message.py
+++ b/Lib/fontbakery/message.py
@@ -3,10 +3,9 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 class Message(object):
+  """Status messages to be yielded by FontBakeryCheck"""
   def __init__(self, code, message):
     """
-      Status messages to be yielded by FontBakeryCheck
-
       code: (string|number) a check internal, unique code to describe a
             specific failure condition. A short string is preferred, it
             makes a better experience to read the code.


### PR DESCRIPTION
Thisl allows it to just hack a spec file and do:

```
$ fontbakery check-specification path/to/my/file.py ../my/fonts/**
```

so people don't have to install their custom specification into their python system.
