### PR TITLE
Do not trim trailing whitespace automatically

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,4 @@ indent_size = 2
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = false


### PR DESCRIPTION
Prevents diffs because the editor is doing the right thing.