### PR TITLE
Make fontbakery actually run on Python 3

### DIFF
--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -199,9 +199,10 @@ class TerminalProgress(FontbakeryReporter):
     self._progressbar = []
     self._unicorn = unicorn
     self._skip_status_report = skip_status_report or tuple()
-
-    self._structure_threshold = min(START.weight, structure_threshold) \
-                        or START.weight # if structure_threshold is None
+    if structure_threshold:
+      self._structure_threshold = min(START.weight, structure_threshold)
+    else:
+      self._structure_threshold = START.weight
     if self._structure_threshold % 2:
       # always include the according START status
       self._structure_threshold -= 1

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -24,6 +24,13 @@ def test_command_check_googlefonts():
   """Test if `fontbakery check-googlefonts` can run successfully`."""
   subprocess.check_output(["fontbakery", "check-googlefonts", "-h"])
 
+  test_font = os.path.join("data", "test", "nunito", "Nunito-Regular.ttf")
+
+  subprocess.check_output([
+      "fontbakery", "check-googlefonts", "-n", "-c",
+      "com.google.fonts/check/001", test_font
+  ])
+
   with pytest.raises(subprocess.CalledProcessError):
     subprocess.check_output(["fontbakery", "check-googlefonts"])
 


### PR DESCRIPTION
Currently throws this traceback on Py3:
```
Traceback (most recent call last):
  File "c:\userslocal\nikolaus.waxweiler\development\fontbakery\.tox\py36\scripts\fontbakery-script.py", line 11, in <module>
    load_entry_point('fontbakery==0.3.5.dev177+gfdc5618c.d20180420', 'console_scripts', 'fontbakery')()
  File "c:\userslocal\nikolaus.waxweiler\development\fontbakery\.tox\py36\lib\site-packages\fontbakery\cli.py", line 24, in main
    "fontbakery.commands." + subcommand_module, run_name='__main__')
  File "C:\Program Files\Python36\Lib\runpy.py", line 208, in run_module
    return _run_code(code, {}, init_globals, run_name, mod_spec)
  File "C:\Program Files\Python36\Lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "c:\userslocal\nikolaus.waxweiler\development\fontbakery\.tox\py36\lib\site-packages\fontbakery\commands\check_googlefonts.py", line 31, in <module>
    sys.exit(main())
  File "c:\userslocal\nikolaus.waxweiler\development\fontbakery\.tox\py36\lib\site-packages\fontbakery\commands\check_specification.py", line 251, in main
    else (STARTSECTION, ENDSECTION)
  File "c:\userslocal\nikolaus.waxweiler\development\fontbakery\.tox\py36\lib\site-packages\fontbakery\reporters\terminal.py", line 367, in __init__
    super(TerminalReporter, self).__init__(**kwd)
  File "c:\userslocal\nikolaus.waxweiler\development\fontbakery\.tox\py36\lib\site-packages\fontbakery\reporters\terminal.py", line 203, in __init__
    self._structure_threshold = min(START.weight, structure_threshold) \
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```