### PR TITLE
Remove check 069

### DIFF
--- a/Lib/fontbakery/specifications/glyf.py
+++ b/Lib/fontbakery/specifications/glyf.py
@@ -8,39 +8,6 @@ from fontbakery.checkrunner import FAIL, PASS, WARN
 from fontbakery.fonts_spec import spec_factory # NOQA pylint: disable=unused-import
 
 
-@check(
-    id='com.google.fonts/check/069',
-    conditions=['is_ttf'])
-def com_google_fonts_check_069(ttFont):
-  """Is there any unused data at the end of the glyf table?"""
-  # -1 because https://www.microsoft.com/typography/otspec/loca.htm
-  expected = len(ttFont['loca']) - 1
-  actual = len(ttFont['glyf'])
-  diff = actual - expected
-
-  # allow up to 3 bytes of padding
-  if diff > 3:
-    yield FAIL, Message("unreachable-data",
-                        ("Glyf table has unreachable data at"
-                         " the end of the table."
-                         " Expected glyf table length {}"
-                         " (from loca table), got length"
-                         " {} (difference: {})").format(expected,
-                                                        actual,
-                                                        diff))
-  elif diff < 0:
-    yield FAIL, Message("data-beyond-table-end",
-                        ("Loca table references data beyond"
-                         " the end of the glyf table."
-                         " Expected glyf table length {}"
-                         " (from loca table), got length"
-                         " {} (difference: {})").format(expected,
-                                                        actual,
-                                                        diff))
-  else:
-    yield PASS, "There is no unused data at the end of the glyf table."
-
-
 # This check was originally ported from
 # Mekkablue Preflight Checks available at:
 # https://github.com/mekkablue/Glyphs-Scripts/blob/master/Test/Preflight%20Font.py

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -100,7 +100,6 @@ expected_check_ids = [
       , 'com.google.fonts/check/066' # Is there a "kern" table declared in the font?
       , 'com.google.fonts/check/067' # Make sure family name does not begin with a digit.
       , 'com.google.fonts/check/068' # Does full font name begin with the font family name?
-      , 'com.google.fonts/check/069' # Is there any unused data at the end of the glyf table?
       , 'com.google.fonts/check/070' # Font has all expected currency sign characters?
       , 'com.google.fonts/check/071' # Font follows the family naming recommendations?
       , 'com.google.fonts/check/072' # Font enables smart dropout control in "prep" table instructions?

--- a/tests/specifications/glyf_test.py
+++ b/tests/specifications/glyf_test.py
@@ -15,16 +15,6 @@ check_statuses = (ERROR, FAIL, SKIP, PASS, WARN, INFO, DEBUG)
 
 # from fontTools.ttLib import TTFont
 
-def NOT_IMPLEMENTED_test_check_069():
-  """ Is there any unused data at the end of the glyf table? """
-  # from fontbakery.specifications.general import com_google_fonts_check_069 as check
-  # TODO: Implement-me!
-  #
-  # code-paths:
-  # - FAIL, code="unreachable-data"
-  # - FAIL, code="data-beyond-table-end"
-  # - PASS, "There is no unused data at the end of the glyf table."
-
 
 def NOT_IMPLEMENTED_test_check_075():
   """ Check for points out of bounds. """


### PR DESCRIPTION
Fonttools runs some sanitization on load that catches wrongly set up loca tables and matches them to the glyf table.

#1821 