### PR TITLE
Add shorthand for `fontbakery check-specification fontbakery.specifications.opentype`

### DIFF
--- a/Lib/fontbakery/commands/check_opentype.py
+++ b/Lib/fontbakery/commands/check_opentype.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+import sys
+from functools import partial
+
+import fontbakery.specifications.opentype
+from fontbakery.commands.check_specification import (
+    main as super_main, get_module_specification)
+
+main = partial(super_main,
+               get_module_specification(fontbakery.specifications.opentype))
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -43,6 +43,14 @@ def test_command_check_specification():
     subprocess.check_output(["fontbakery", "check-specification"])
 
 
+def test_command_check_opentype():
+  """Test if `fontbakery check-opentype` can run successfully`."""
+  subprocess.check_output(["fontbakery", "check-opentype", "-h"])
+
+  with pytest.raises(subprocess.CalledProcessError):
+    subprocess.check_output(["fontbakery", "check-opentype"])
+
+
 def test_command_check_ufo_sources():
   """Test if `fontbakery check-ufo-sources` can run successfully`."""
   subprocess.check_output(["fontbakery", "check-ufo-sources", "-h"])


### PR DESCRIPTION
`fontbakery check-opentype ...`