### PR TITLE
Add argument switch to exclude tests

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -1252,7 +1252,7 @@ class Spec(object):
           check for check in section.checks if check.id not in exclude_checks
       ]
     else:
-      checks = [check for check in section.checks]
+      checks = section.checks
 
     scopes = self._analyze_checks(full_order, checks)
     key = lambda item: item[1] # check, signature, scope = item

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -256,6 +256,11 @@ class CheckRunner(object):
     # to make sure that they won't change anymore.
     # Also remove duplicates from list like iterables
 
+    if explicit_checks and exclude_checks:
+      raise APIViolationError(
+          "Specifying tests to include (explicit_checks) and "
+          "exclude (exclude_checks) is mutually exclusive.", None)
+
     self._custom_order = custom_order
     self._explicit_checks = explicit_checks
     self._exclude_checks = exclude_checks

--- a/Lib/fontbakery/commands/check_specification.py
+++ b/Lib/fontbakery/commands/check_specification.py
@@ -56,10 +56,27 @@ def ArgumentParser(specification, spec_arg=True):
 
   values_keys = specification.setup_argparse(argument_parser)
 
-  argument_parser.add_argument('-c', '--checkid', action='append',
-                      help='Explicit check-ids to be executed.\n'
-                           'Use this option multiple times to select multiple checks.'
-                     )
+  select_group = argument_parser.add_mutually_exclusive_group()
+
+  select_group.add_argument(
+      "-c",
+      "--checkid",
+      action="append",
+      help=(
+          "Explicit check-ids to be executed. "
+          "Use this option multiple times to select multiple checks."
+      ),
+  )
+
+  select_group.add_argument(
+      "-x",
+      "--exclude-checkid",
+      action="append",
+      help=(
+          "Exclude check-ids from execution. "
+          "Use this option multiple times to exclude multiple checks."
+      ),
+  )
 
   def log_levels_get(key):
     if key in log_levels:
@@ -203,11 +220,13 @@ def get_spec():
 
 def runner_factory( specification
                   , explicit_checks=None
+                  , exclude_checks=None
                   , custom_order=None
                   , values=None):
   """ Convenience CheckRunner factory. """
   return CheckRunner( specification, values
                     , explicit_checks=explicit_checks
+                    , exclude_checks=exclude_checks
                     , custom_order=custom_order
                     )
 
@@ -243,6 +262,7 @@ def main(specification=None, values=None):
   try:
     runner = runner_factory(specification
                      , explicit_checks=args.checkid
+                     , exclude_checks=args.exclude_checkid
                      , custom_order=args.order
                      , values=values_
                      )


### PR DESCRIPTION
Works the opposite of `--checkid`.

Pointers on how to do this more elegantly welcome, the code in checkrunner.py is hard to read and understand.