### PR TITLE
auto_register: add spec_import kwarg

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -1442,6 +1442,7 @@ class Spec(object):
       not be registered.
     """
     if spec_imports:
+      symbol_table = symbol_table.copy()  # Avoid messing with original table
       symbol_table['spec_imports'] = spec_imports
 
     all_items = list(symbol_table.values()) + self._load_spec_imports(symbol_table)

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -1410,7 +1410,7 @@ class Spec(object):
           results += [getattr(module, name) for name in names]
     return results
 
-  def auto_register(self, symbol_table, filter_func=None):
+  def auto_register(self, symbol_table, filter_func=None, spec_imports=None):
     """
       Register items from `symbol_table` in the specification.
 
@@ -1420,6 +1420,8 @@ class Spec(object):
       the default section.
       If an item is a python module, try to get a spec using `get_module_specification(item)`
       and then using `merge_specification`;
+      If the spec_imports kwarg is given, it is used instead of the one taken from
+      the module namespace.
 
       To register the current module use explicitly:
         `specification.auto_register(globals())`
@@ -1439,6 +1441,9 @@ class Spec(object):
       if filter_func returns a falsy value for an item, the item will
       not be registered.
     """
+    if spec_imports:
+      symbol_table['spec_imports'] = spec_imports
+
     all_items = list(symbol_table.values()) + self._load_spec_imports(symbol_table)
     namespace_types = (FontBakeryCondition, FontBakeryExpectedValue)
     namespace_items = []

--- a/tests/specifications/external_spec_test.py
+++ b/tests/specifications/external_spec_test.py
@@ -20,6 +20,13 @@ def test_external_specification():
   specification = spec_factory(default_section=Section("Dalton Maag OpenType"))
   specification.set_check_filter(check_filter)
   specification.auto_register(
-      globals(), spec_imports=['fontbakery.specifications.opentype'])
+      globals(), spec_imports=["fontbakery.specifications.opentype"])
+
+  # Probe some tests
+  expected_tests = ["com.google.fonts/check/002", "com.google.fonts/check/180"]
+  specification.test_expected_checks(expected_tests)
+
+  # Probe tests we don't want
+  assert "com.google.fonts/check/035" not in specification._check_registry.keys()
 
   assert len(specification.sections) > 1

--- a/tests/specifications/external_spec_test.py
+++ b/tests/specifications/external_spec_test.py
@@ -3,6 +3,7 @@ from fontbakery.fonts_spec import spec_factory
 
 
 def check_filter(item_type, item_id, item):
+  # Filter out external tool checks for testing purposes.
   if item_type == "check" and item_id in (
       "com.google.fonts/check/035",  # ftxvalidator
       "com.google.fonts/check/036",  # ots-sanitize

--- a/tests/specifications/external_spec_test.py
+++ b/tests/specifications/external_spec_test.py
@@ -1,0 +1,25 @@
+from fontbakery.checkrunner import Section
+from fontbakery.fonts_spec import spec_factory
+
+
+def check_filter(checkid, font=None, **iterargs):
+  if checkid in (
+      "com.google.fonts/check/035",  # ftxvalidator
+      "com.google.fonts/check/036",  # ots-sanitize
+      "com.google.fonts/check/037",  # Font Validator
+      "com.google.fonts/check/038",  # Fontforge
+      "com.google.fonts/check/039",  # Fontforge
+  ):
+    return False, "Skipping external tools."
+
+  return True, None
+
+
+def test_external_specification():
+  """Test the creation of external specifications."""
+  specification = spec_factory(default_section=Section("Dalton Maag OpenType"))
+  specification.set_check_filter(check_filter)
+  specification.auto_register(
+      globals(), spec_imports=['fontbakery.specifications.opentype'])
+
+  assert len(specification.sections) > 1

--- a/tests/specifications/external_spec_test.py
+++ b/tests/specifications/external_spec_test.py
@@ -2,28 +2,29 @@ from fontbakery.checkrunner import Section
 from fontbakery.fonts_spec import spec_factory
 
 
-def check_filter(checkid, font=None, **iterargs):
-  if checkid in (
+def check_filter(item_type, item_id, item):
+  if item_type == "check" and item_id in (
       "com.google.fonts/check/035",  # ftxvalidator
       "com.google.fonts/check/036",  # ots-sanitize
       "com.google.fonts/check/037",  # Font Validator
       "com.google.fonts/check/038",  # Fontforge
       "com.google.fonts/check/039",  # Fontforge
   ):
-    return False, "Skipping external tools."
+    return False
 
-  return True, None
+  return True
 
 
 def test_external_specification():
   """Test the creation of external specifications."""
   specification = spec_factory(default_section=Section("Dalton Maag OpenType"))
-  specification.set_check_filter(check_filter)
   specification.auto_register(
-      globals(), spec_imports=["fontbakery.specifications.opentype"])
+      globals(),
+      spec_imports=["fontbakery.specifications.opentype"],
+      filter_func=check_filter)
 
   # Probe some tests
-  expected_tests = ["com.google.fonts/check/002", "com.google.fonts/check/180"]
+  expected_tests = ["com.google.fonts/check/002", "com.google.fonts/check/171"]
   specification.test_expected_checks(expected_tests)
 
   # Probe tests we don't want


### PR DESCRIPTION
Expanding on https://github.com/googlefonts/fontbakery/pull/1887, I added an explicit spec_import kwarg to auto_register. I suspect sniffing globals will make testing more error-prone.