### PR TITLE
Check skip filter, spec_imports: try to import names as submodules

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -1428,8 +1428,18 @@ class Spec(object):
         if names is None:
           results.append(module)
         else:
-          # getattr raises AttributeError if not available (which is a good thing)!
-          results += [getattr(module, name) for name in names]
+          #  1. check if the imported module has an attribute by that name
+          #  2. if not, attempt to import a submodule with that name
+          #  3. if the attribute is not found, ImportError is raised.
+          #  …
+          for name in names:
+            try:
+              results.append(getattr(module, name))
+            except AttributeError:
+              # attempt to import a submodule with that name
+              sub_module_name = '.'.join([module_name, name])
+              sub_module = importlib.import_module(sub_module_name, package=package)
+              results.append(sub_module)
     return results
 
   def auto_register(self, symbol_table, filter_func=None, spec_imports=None):

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -986,7 +986,7 @@ def com_google_fonts_check_061(ttFont):
 )
 def com_google_fonts_check_062(ttFont):
   """Is 'gasp' table set to optimize rendering?
-  
+
   Traditionally version 0 'gasp' tables were set
   so that font sizes below 8 ppem had no grid
   fitting but did have antialiasing. From 9-16
@@ -3105,7 +3105,7 @@ def fontforge_skip_checks(font):
     return 0x20 + 0x200
   return None
 
-def check_filter(checkid, font=None, **iterargs):
+def check_skip_filter(checkid, font=None, **iterargs):
   if font and is_librebarcode(font) and checkid in (
         # See: https://github.com/graphicore/librebarcode/issues/3
         'com.google.fonts/check/033' # Checking correctness of monospaced metadata.
@@ -3117,7 +3117,7 @@ def check_filter(checkid, font=None, **iterargs):
                   'https://github.com/graphicore/librebarcode/issues/3')
   return True, None
 
-specification.set_check_filter(check_filter)
+specification.check_skip_filter = check_skip_filter
 
 specification.auto_register(globals())
 


### PR DESCRIPTION
This pull request addresses the problems described at issue #1886 

And https://github.com/googlefonts/fontbakery/pull/1888#issuecomment-392574472 rename and docstring document `def set_check_filter` to `@property check_skip_filter`
