### PR TITLE
[checkrunner] fix using a custom_order by explicitly converting to li…

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -1223,7 +1223,7 @@ class Spec(object):
       order may contain "*check" otherwise, it is like *check is appended
       to the end (Not done explicitly though).
     """
-    stack = custom_order[:] if custom_order is not None else section.order[:]
+    stack = list(custom_order) if custom_order is not None else list(section.order)
     if '*iterargs' not in stack:
       stack.append('*iterargs')
     stack.reverse()


### PR DESCRIPTION
…st; See #1918

Fixes this:

```
$ fontbakery check-googlefonts  -v -o "*check" -c com.google.fonts/check/001 -c com.google.fonts/check/156 ../testfonts/RobotoSlab-*
77 checks on <Section: Google Fonts>
14 checks on <Section: fontbakery.specifications.general>
3 checks on <Section: fontbakery.specifications.cmap>
3 checks on <Section: fontbakery.specifications.head>
6 checks on <Section: fontbakery.specifications.os2>
2 checks on <Section: fontbakery.specifications.post>
8 checks on <Section: fontbakery.specifications.name>
3 checks on <Section: fontbakery.specifications.hhea>
1 checks on <Section: fontbakery.specifications.dsig>
1 checks on <Section: fontbakery.specifications.hmtx>
2 checks on <Section: fontbakery.specifications.gpos>
1 checks on <Section: fontbakery.specifications.gdef>
1 checks on <Section: fontbakery.specifications.kern>
2 checks on <Section: fontbakery.specifications.glyf>
1 checks on <Section: fontbakery.specifications.prep>
6 checks on <Section: fontbakery.specifications.fvar>
1 checks on <Section: fontbakery.specifications.loca>
Traceback (most recent call last):
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/venv/bin/fontbakery", line 11, in <module>
    load_entry_point('fontbakery', 'console_scripts', 'fontbakery')()
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/cli.py", line 24, in main
    "fontbakery.commands." + subcommand_module, run_name='__main__')
  File "/usr/lib/python2.7/runpy.py", line 192, in run_module
    fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/commands/check_googlefonts.py", line 31, in <module>
    sys.exit(main())
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/commands/check_specification.py", line 311, in main
    distribute_generator(runner.run(), reporters)
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/checkrunner.py", line 722, in distribute_generator
    for item in gen:
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/checkrunner.py", line 686, in run
    order = self.order
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/checkrunner.py", line 665, in order
    exclude_checks=self._exclude_checks):
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/checkrunner.py", line 1278, in execution_order
    , exclude_checks=exclude_checks):
  File "/home/commander/Projekte/fontdev/googlefonts/fontbakery/Lib/fontbakery/checkrunner.py", line 1226, in _section_execution_order
    stack = custom_order[:] if custom_order is not None else section.order[:]
TypeError: 'itertools.ifilter' object has no attribute '__getitem__'
```
