### PR TITLE
com_google_fonts_check_035: adding exception for python3

### DIFF
--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -90,7 +90,10 @@ def com_google_fonts_check_035(font):
     ]
     ftx_output = subprocess.check_output(ftx_cmd, stderr=subprocess.STDOUT)
 
-    ftx_data = plistlib.readPlistFromString(ftx_output)
+    try:
+      ftx_data = plistlib.readPlistFromString(ftx_output)
+    except AttributeError:
+      ftx_data = plistlib.readPlistFromBytes(ftx_output)  # for python3
     # we accept kATSFontTestSeverityInformation
     # and kATSFontTestSeverityMinorError
     if 'kATSFontTestSeverityFatalError' \


### PR DESCRIPTION
This pull request addresses the problems described at issue #1936

I tested this fix on MacOS 10.11 and it works. 
