### PR TITLE
fix py3 crash on check/056 (The map func changed on Python 3)

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1033,8 +1033,8 @@ def com_google_fonts_check_056(ttFont, ttfautohint_stats):
         return results.group(1)
 
   def installed_version_is_newer(installed, used):
-    installed = map(int, installed.split("."))
-    used = map(int, used.split("."))
+    installed = list(map(int, installed.split(".")))
+    used = list(map(int, used.split(".")))
     return installed > used
 
   version_strings = get_name_entry_strings(ttFont, NAMEID_VERSION_STRING)


### PR DESCRIPTION
The map func changed on Python 3, so we must wrap it with list, otherwise we simply get an iterator instead of a list as used to be the case in python 2
This fixes the crash reported on issue #1970 (and may even fix #1969)
