### PR TITLE
Add .ttfautohint glyph to valid glyphs

### DIFF
--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -597,7 +597,7 @@ def com_google_fonts_check_058(ttFont):
     import re
     bad_names = []
     for _, glyphName in enumerate(ttFont.getGlyphOrder()):
-      if glyphName in [".null", ".notdef"]:
+      if glyphName in [".null", ".notdef", ".ttfautohint"]:
         # These 2 names are explicit exceptions
         # in the glyph naming rules
         continue


### PR DESCRIPTION
Ttfautohint sometimes adds a glyph called `.ttfautohint`. I must admit, I haven't researched what settings cause ttfautohint to add this glyph.

Found in https://github.com/google/fonts/pull/1636
