### PR TITLE
Python 3 fixes (dashboard related)

### DIFF
--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -32,7 +32,7 @@ def fontforge_check_results(font):
   try:
     return {
       "validation_state": int(ret_val),
-      "ff_err_messages": ff_err_messages
+      "ff_err_messages": ff_err_messages.decode("utf-8")
     }
   except:
     return None

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2287,7 +2287,7 @@ def github_gfonts_ttFont(ttFont, license):
   LICENSE_DIRECTORY = {
     "OFL.txt": "ofl",
     "UFL.txt": "ufl",
-    "APACHE.txt": "apache"
+    "LICENSE.txt": "apache"
   }
   filename = os.path.basename(ttFont.reader.file.name)
   fontname = filename.split('-')[0].lower()

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -547,7 +547,7 @@ def registered_vendor_ids():
   registered_vendor_ids = {}
   CACHED = resource_filename('fontbakery',
                              'data/fontbakery-microsoft-vendorlist.cache')
-  content = open(CACHED).read()
+  content = open(CACHED, encoding='utf-8').read()
   soup = BeautifulSoup(content, 'html.parser')
 
   IDs = [chr(c + ord('a')) for c in range(ord('z') - ord('a') + 1)]


### PR DESCRIPTION
These came up when I was updating the dashboard to python 3.



d5ab680 had this ERROR

```
com.google.fonts/check/038 FontForge validation outputs error messages?

    ERROR Failed with TypeError: a bytes-like object is required, not 'str'
    traceback

      File "/usr/local/lib/python3.6/dist-packages/fontbakery/checkrunner.py", line 350, in _exec_check
        for sub_result in result:  # Might raise.
      File "/usr/local/lib/python3.6/dist-packages/fontbakery/specifications/general.py", line 232, in com_google_fonts_check_038
        for line in fontforge_check_results["ff_err_messages"].split('\n'):

```


2d8208e had this ERROR:

 ```
com.google.fonts/check/018 Checking OS/2 achVendID.

    ERROR   The condition <FontBakeryCondition:registered_vendor_ids> had an error: UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 17812: ordinal not in range(128)
    traceback

      File "/usr/local/lib/python3.6/dist-packages/fontbakery/checkrunner.py", line 382, in _evaluate_condition
        return None, condition(**args)
      File "/usr/local/lib/python3.6/dist-packages/fontbakery/callable.py", line 71, in __call__
        return self._func(*args, **kwds)
      File "/usr/local/lib/python3.6/dist-packages/fontbakery/specifications/googlefonts.py", line 550, in registered_vendor_ids
        content = open(CACHED).read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
```

475596d since https://github.com/googlefonts/fontbakery/commit/67eaeb9479e7cf7e298c44a41d7b4d7b0c2d247e it seems like we were looking here for an `APACHE.txt` file, but it should be `LICNESE.txt` for apache families:

```
com.google.fonts/check/117 Version number has increased since previous release on Google Fonts?

    ERROR The condition <FontBakeryCondition:github_gfonts_ttFont> had an error: KeyError: 'LICENSE.txt'
    traceback

      File "/usr/local/lib/python3.6/dist-packages/fontbakery/checkrunner.py", line 382, in _evaluate_condition
        return None, condition(**args)
      File "/usr/local/lib/python3.6/dist-packages/fontbakery/callable.py", line 71, in __call__
        return self._func(*args, **kwds)
      File "/usr/local/lib/python3.6/dist-packages/fontbakery/specifications/googlefonts.py", line 2295, in github_gfonts_ttFont
        "/{}/{}/{}").format(LICENSE_DIRECTORY[license],
```