### PR TITLE
Add __main__ entry point

### DIFF
--- a/Lib/fontbakery/__main__.py
+++ b/Lib/fontbakery/__main__.py
@@ -1,0 +1,4 @@
+import fontbakery.cli
+
+if __name__ == "__main__":
+  fontbakery.cli.main()

--- a/Lib/fontbakery/cli.py
+++ b/Lib/fontbakery/cli.py
@@ -6,7 +6,7 @@ import sys
 import fontbakery.commands
 
 
-def main(args=None):
+def main():
     subcommands = [
         pkg[1].replace("_", "-")
         for pkg in pkgutil.walk_packages(fontbakery.commands.__path__)


### PR DESCRIPTION
Makes it possible to run fontbakery from `python -m fontbakery`. Useful if Python script path not in PATH.

Remove unusable args parameter from main().