### PR TITLE
Modify macOS ots-sanitize installation documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,11 +32,9 @@ This checker is embedded in Chrome and Firefox, so it is important that font fil
 If available, Font Bakery will wrap around OTS and run it as part of its standard checking.
 Install it with:
 
-    brew tap bramstein/webfonttools;
-    brew update;
-    brew install ots --HEAD;
-
-If brew fails, try installing the binaries from <https://github.com/khaledhosny/ots/releases> and report an error on the Font Bakery issue tracker.
+    curl -L -O https://github.com/khaledhosny/ots/releases/download/v7.1.7/ots-7.1.7-osx.zip
+    unzip ots-7.1.7-osx.zip
+    mv ots-7.1.7-osx.zip/ots-sanitize /usr/local/bin/ots-sanitize
 
 ##### FontForge
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,10 @@ Install it with:
 
     curl -L -O https://github.com/khaledhosny/ots/releases/download/v7.1.7/ots-7.1.7-osx.zip
     unzip ots-7.1.7-osx.zip
-    mv ots-7.1.7-osx.zip/ots-sanitize /usr/local/bin/ots-sanitize
+    mv ots-7.1.7-osx/ots-sanitize /usr/local/bin/ots-sanitize
+    rm -rf ots-7.1.7-osx
+    rm ots-7.1.1-osx.zip
+
 
 ##### FontForge
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ Install it with:
     unzip ots-7.1.7-osx.zip
     mv ots-7.1.7-osx/ots-sanitize /usr/local/bin/ots-sanitize
     rm -rf ots-7.1.7-osx
-    rm ots-7.1.1-osx.zip
+    rm ots-7.1.7-osx.zip
 
 
 ##### FontForge


### PR DESCRIPTION
This PR modifies the homebrew-based ots-sanitize installation documentation for the macOS platform. It changes the recommended approach to a curl pull of the compiled binaries from Khaled's ots repository releases with a manual move of `ots-sanitize` to the `/usr/local/bin` directory so that it is accessible on the system PATH for Font Bakery testing.  This achieves a faster install c/w the homebrew process (eliminates the compile on the user system) and it allows users to install the current release version of `ots-sanitize` which is not currently supported through homebrew.

Associated issue reports:
- https://github.com/googlefonts/fontbakery/issues/2041
- https://github.com/googlefonts/fontbakery/issues/2057