### PR TITLE
Add code-tests to ttx roundtrip check and fix issue #2048

### DIFF
--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -677,7 +677,8 @@ def com_google_fonts_check_078(ttFont):
 
 
 @check(
-  id = 'com.google.fonts/check/ttx-roundtrip'
+  id = 'com.google.fonts/check/ttx-roundtrip',
+  conditions = ["not vtt_talk_sources"]
 )
 def com_google_fonts_check_ttx_roundtrip(font):
   """Checking with fontTools.ttx"""

--- a/tests/specifications/general_test.py
+++ b/tests/specifications/general_test.py
@@ -482,3 +482,17 @@ def DISABLED_test_check_078():
   test_otf = ufo2ft.compileOTF(test_font, useProductionNames=True)
   status, _ = list(check(test_otf))[-1]
   assert status == PASS
+
+
+def test_check_ttx_roundtrip():
+  """ Checking with fontTools.ttx """
+  from fontbakery.specifications.general import com_google_fonts_check_ttx_roundtrip as check
+
+  good_font_path = os.path.join("data", "test", "mada", "Mada-Regular.ttf")
+  status, _ = list(check(good_font_path))[-1]
+  assert status == PASS
+
+  # TODO: Can anyone show us a font file that fails ttx roundtripping?!
+  #bad_font_path = os.path.join("data", "test", ...)
+  #status, _ = list(check(bad_font_path))[-1]
+  #assert status == FAIL


### PR DESCRIPTION
by not checking ttx roundtripping on fonts that did not yet
have VTT Talk sources cleaned out of its TSI* tables
(this should always be done prior to release).

This pull request addresses the problems described at issue #2048 
