### PR TITLE
WIP: Fontbakery CI

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,1 @@
+TODO (M Foley)

--- a/ci/run_fb.sh
+++ b/ci/run_fb.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+file_names=`curl -v -H "Authorization: token $GH_TOKEN" "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST/files" | jq '.[] | .filename' | tr '\n' ' ' | tr '"' ' '`
+fontbakery check-googlefonts $file_names -l FAIL -n

--- a/ci/travis.template.yaml
+++ b/ci/travis.template.yaml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+  - "3.6"
+
+before_install:
+  - sudo apt-get install -y jq
+
+install:
+  - pip install fontbakery
+
+script:
+  - sh run_fb.sh


### PR DESCRIPTION
WARNING: still super wip, don't use yet.

I recently pushed some fonts to google/fonts which were faulty. I had too much faith and should've rerun the fonts through FB. Imo, this still isn't enough. To stop this from happening in the future, we must hook FB up as a CI tool. It needs to stop PRs from being merged if any FAILS occur.

I've hooked this wip up to my fork of google/fonts and it's going in the right direction, https://travis-ci.org/m4rc1e/fonts

I still need to do the following:
- Install OTS, Ms Font Val, ftxvalidator
- Remove any false positive tests AvgCharWidth 

In the not too distant future, we need do the following:
- Drop QAing in dispatcher. It should only be done here.
- Add diffbrowsers and visual regression checks

The .travis file and shell script must be able to run on all upstream font projects and any fork of google/fonts. 

I have not included the files in the Lib dir since these are templates which should be added to other projects.

Totally open to any suggestions.

