### PR TITLE
Add Apple Dev URL with font tools dmg download

### DIFF
--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -51,6 +51,7 @@ Apple provides various font utilities, and `ftxvalidator` is especially useful a
 
 You must use your Apple ID to sign in to http://developer.apple.com and then:
 
+* go to https://developer.apple.com/download/more/?=font
 * download `Font_Tools_for_Xcode_9.dmg`
 * double-click on `Font_Tools_for_Xcode_9.dmg`
 * double-click on `macOS Font Tools.pkg`


### PR DESCRIPTION
It wasn't obvious where to find the download for Font Tools for Xcode 9 – I had to search around for a page on the Apple Developer site with the dmg listed. Here, I've added a specific link to a page it can be found on. If someone else knows of a more specific page, that would be even better.
