### PR TITLE
WIP: Make in/exclude check parameters fuzzy

### DIFF
--- a/Lib/fontbakery/commands/check_specification.py
+++ b/Lib/fontbakery/commands/check_specification.py
@@ -52,24 +52,22 @@ def ArgumentParser(specification, spec_arg=True):
 
   values_keys = specification.setup_argparse(argument_parser)
 
-  select_group = argument_parser.add_mutually_exclusive_group()
-
-  select_group.add_argument(
+  argument_parser.add_argument(
       "-c",
       "--checkid",
       action="append",
       help=(
-          "Explicit check-ids to be executed. "
+          "Explicit check-ids (or parts of their name) to be executed. "
           "Use this option multiple times to select multiple checks."
       ),
   )
 
-  select_group.add_argument(
+  argument_parser.add_argument(
       "-x",
       "--exclude-checkid",
       action="append",
       help=(
-          "Exclude check-ids from execution. "
+          "Exclude check-ids (or parts of their name) from execution. "
           "Use this option multiple times to exclude multiple checks."
       ),
   )

--- a/tests/specifications/external_spec_test.py
+++ b/tests/specifications/external_spec_test.py
@@ -170,10 +170,16 @@ def test_in_and_exclude_checks():
   explicit_checks = ["06", "07"]  # "06" or "07" in check ID
   exclude_checks = ["065", "079"]  # "065" or "079" in check ID
   iterargs = {"font": 1}
-  check_names = sorted(c[1].id for c in specification.execution_order(
-      iterargs, explicit_checks=explicit_checks, exclude_checks=exclude_checks))
-  check_names_expected = sorted(
-      c for c in specification._check_registry
-      if any(i in c for i in explicit_checks) and not any(
-          x in c for x in exclude_checks))
+  check_names = {
+      c[1].id for c in specification.execution_order(
+          iterargs,
+          explicit_checks=explicit_checks,
+          exclude_checks=exclude_checks)
+  }
+  check_names_expected = set()
+  for section in specification.sections:
+    for check in section.checks:
+      if any(i in check.id for i in explicit_checks) and not any(
+          x in check.id for x in exclude_checks):
+        check_names_expected.add(check.id)
   assert check_names == check_names_expected

--- a/tests/specifications/external_spec_test.py
+++ b/tests/specifications/external_spec_test.py
@@ -160,3 +160,20 @@ def test_googlefonts_checks_load():
   specification = spec_factory(default_section=Section("Google Fonts Testing"))
   specification.auto_register({}, spec_imports=spec_imports)
   specification.test_dependencies()
+
+
+def test_in_and_exclude_checks():
+  spec_imports = ("fontbakery.specifications.opentype", )
+  specification = spec_factory(default_section=Section("OpenType Testing"))
+  specification.auto_register({}, spec_imports=spec_imports)
+  specification.test_dependencies()
+  explicit_checks = ["06", "07"]  # "06" or "07" in check ID
+  exclude_checks = ["065", "079"]  # "065" or "079" in check ID
+  iterargs = {"font": 1}
+  check_names = sorted(c[1].id for c in specification.execution_order(
+      iterargs, explicit_checks=explicit_checks, exclude_checks=exclude_checks))
+  check_names_expected = sorted(
+      c for c in specification._check_registry
+      if any(i in c for i in explicit_checks) and not any(
+          x in c for x in exclude_checks))
+  assert check_names == check_names_expected


### PR DESCRIPTION
1. Make `-c` and `-x` match substrings.
2. Make `-c` and `-x` able to coexist.

E.g. `-c 06 -x 065` will run just check 064.

Todo: write test, maybe based on `test_example_checkrunner_based`. Writing infrastructure tests remains hard.