### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+*   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the Project
+Steward has a reasonable belief that an individual's behavior may have a
+negative impact on the project or its community.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement
+often yield positive results. However, it is never okay to be disrespectful or
+to engage in behavior that violates the project’s code of conduct.
+
+If you see someone violating the code of conduct, you are encouraged to address
+the behavior directly with those involved. Many issues can be resolved quickly
+and easily, and this gives people more control over the outcome of their
+dispute. If you are unable to resolve the matter for any reason, or if the
+behavior is threatening or harassing, report it. We are dedicated to providing
+an environment where participants feel welcome and safe.
+
+Reports should be directed to Dave Crossland <dcrossland@google.com>, the
+Project Steward(s) for Font Bakery. It is the Project Steward’s duty to
+receive and address reported violations of the code of conduct. They will then
+work with a committee consisting of representatives from the Open Source
+Programs Office and the Google Open Source Strategy team. If for any reason you
+are uncomfortable reaching out the Project Steward, please email
+<opensource@google.com>.
+
+We will investigate every complaint, but you may not receive a direct response.
+We will use our discretion in determining when and how to follow up on reported
+incidents, which may range from not taking action to permanent expulsion from
+the project and project-sponsored spaces. We will notify the accused of the
+report and provide them an opportunity to discuss it before any action is taken.
+The identity of the reporter will be omitted from the details of the report
+supplied to the accused. In potentially harmful situations, such as ongoing
+harassment or threats to anyone's safety, we may take action without notice.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
+available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,37 @@
-The project is run on Github, in the [typical](http://producingoss.com) free software way. 
-We'd love to accept your patches and contributions to this project. 
-There is just one thing you need to do first.
-
-## Google CLA
-
-Contributions to Google projects, even unofficial ones like this, must be accompanied by a Contributor License Agreement. 
-This is not a copyright assignment, it simply gives Google permission to use and redistribute your contributions as part of the project.
-
-If you are an individual writing original source code and you're sure you own the rights, then you'll need to sign an
-[individual CLA](https://developers.google.com/open-source/cla/individual).
-
-If you work for a company that wants to allow you to contribute your work, then you'll need to sign a [corporate CLA](https://developers.google.com/open-source/cla/corporate).
-
-You generally only need to submit a CLA once, so if you've already submitted one for a different project, you probably don't need to do it again.
-
-After your contribution is included, you will be listed in CONTRIBUTORS.txt and/or AUTHORS.txt: CONTRIBUTORS is the official list of people who can contribute (and typically have contributed) code to this repository, while the AUTHORS file lists the copyright holders.
-
 ## How to Contribute
 
-Our production vision and high level requirements are explained in the [BRIEF.md](BRIEF.md)
+The project is run on Github, in the [typical](http://producingoss.com) free software way. 
+We'd love to accept your patches and contributions to this project. 
+There are just a few small guidelines you need to follow.
+
+Our production vision and high level requirements are explained in the [BRIEF.md](BRIEF.md).
 
 We use Github's Issue Tracker to report and track bugs, map out future improvements, set priorities and assign people to them.
-
 We only assign an issue to someone when they are going to work on that issue soon.
-
 We tag all issues with a priority tag, P0 for "urgent" through P5 for "someday-maybe"
 
 If you find a bug or have an idea, please create a new issue and we'll be happy to work with you on it!
+
+## Google CLA
+
+Contributions to this project must be accompanied by a Contributor License Agreement. 
+You (or your employer) retain the copyright to your contribution; 
+this simply gives us permission to use and redistribute your contributions as part of the project.
+Head over to <https://cla.developers.google.com/> to see your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.
+
+After your contribution is included, you will be listed in [CONTRIBUTORS.txt](CONTRIBUTORS.txt) and/or [AUTHORS.txt](AUTHORS.txt):
+`CONTRIBUTORS.txt` is the official list of people who can contribute (and typically have contributed) code to this repository, while the `AUTHORS.txt` file lists the copyright holders.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. 
+We use GitHub pull requests for this purpose. 
+Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using pull requests.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community Guidelines](https://opensource.google.com/conduct/)
+
+We also have a [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
This pull request adds Google's standard Code of Conduct, and updates the CONTRIBUTING file to use the latest template from the Google Open Source Project Office
