### PR TITLE
fix check/028 & add a test for family_directory condition

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -279,7 +279,10 @@ def com_google_fonts_check_001(font):
 def family_directory(fonts):
   """Get the path of font project directory."""
   if fonts:
-    return os.path.dirname(fonts[0])
+    dirname = os.path.dirname(fonts[0])
+    if dirname == '':
+      dirname = '.'
+    return dirname
 
 
 @condition
@@ -688,7 +691,7 @@ def com_google_fonts_check_028(licenses):
                         ("More than a single license file found."
                          " Please review."))
   elif not licenses:
-    yield FAIL, Message("none",
+    yield FAIL, Message("no-license",
                         ("No license file was found."
                          " Please add an OFL.txt or a LICENSE.txt file."
                          " If you are running fontbakery on a Google Fonts"

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -429,6 +429,14 @@ def test_check_020():
   # TODO: test FAIL with an ExtraLight:200 OTF
 
 
+def test_family_directory_condition():
+  from fontbakery.specifications.googlefonts import family_directory
+  assert family_directory(["some_directory/Foo.ttf"]) == "some_directory"
+  assert family_directory(["some_directory/subdir/Foo.ttf"]) == "some_directory/subdir"
+  assert family_directory(["Foo.ttf"]) == "." # This is meant to ensure license files
+                                              # are correctly detected on the current
+                                              # working directory.
+
 def test_check_028():
   """ Check font project has a license. """
   from fontbakery.specifications.googlefonts import (com_google_fonts_check_028 as check,
@@ -441,7 +449,7 @@ def test_check_028():
   print('Test FAIL with no license...')
   detected_licenses = licenses("data/test/028/none/")
   status, message = list(check(detected_licenses))[-1]
-  assert status == FAIL and message.code == "none"
+  assert status == FAIL and message.code == "no-license"
 
   print('Test PASS with a single OFL license...')
   detected_licenses = licenses("data/test/028/pass_ofl/")


### PR DESCRIPTION
Now a license file on the current working directory is properly detected.

This pull request addresses the problems described at issue #2087 
