### PR TITLE
use opentype-sanitizer python wheels insted of external ots-sanitize

### DIFF
--- a/INSTALL_GNU.md
+++ b/INSTALL_GNU.md
@@ -10,19 +10,6 @@ To upgrade:
 
 #### Additional Dependencies
 
-##### OTS
-
-From source:
-
-    git clone https://github.com/khaledhosny/ots.git;
-    cd ots;
-    ./autogen.sh;
-    ./configure;
-    make CXXFLAGS=-DOTS_DEBUG;
-    sudo make install;
-    cd ..;
-    rm -rf ots;
-
 ##### FontForge
 
 From a PPA on Ubuntu:

--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -24,19 +24,6 @@ If you already installed a previous version of Font Bakery, upgrade to a newer v
 
 #### Additional dependencies
 
-##### OTS: OpenType Sanitizer
-
-This checker is embedded in Chrome and Firefox, so it is important that font files pass OTS.
-If available, Font Bakery will wrap around OTS and run it as part of its standard checking.
-Install it with:
-
-    curl -L -O https://github.com/khaledhosny/ots/releases/download/v7.1.7/ots-7.1.7-osx.zip
-    unzip ots-7.1.7-osx.zip
-    mv ots-7.1.7-osx/ots-sanitize /usr/local/bin/ots-sanitize
-    rm -rf ots-7.1.7-osx
-    rm ots-7.1.7-osx.zip
-
-
 ##### FontForge
 
 FontForge has some font checking features, which Font Bakery will also wrap around and run, if available.

--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -20,12 +20,6 @@ If this doesn't work for you, wait for the next release of FontBakery after 0.5.
 
 ### Additional Dependencies
 
-#### OTS - Opentype Sanitizer
-
-1. Grab a Windows release from https://github.com/khaledhosny/ots/releases
-2. Put the contained `.exe` files somewhere and remember where
-3. Repeat the steps above to add fontbakery to the PATH variable and add the directory where you put the `.exe`s this time.
-
 #### FontForge
 
 1. Grab and install a Windows release from https://github.com/fontforge/fontforge/releases

--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -116,25 +116,21 @@ def com_google_fonts_check_035(font):
 )
 def com_google_fonts_check_036(font):
   """Checking with ots-sanitize."""
+  import ots
+
   try:
-    import subprocess
-    ots_output = subprocess.check_output(
-        ["ots-sanitize", font], stderr=subprocess.STDOUT).decode()
-    if ots_output != "" and "File sanitized successfully" not in ots_output:
-      yield FAIL, f"ots-sanitize output follows:\n\n{ots_output}"
+    process = ots.sanitize(font, check=True, capture_output=True)
+  except ots.CalledProcessError as e:
+    yield FAIL, (
+      "ots-sanitize returned an error code ({}). Output follows:\n\n{}{}"
+    ).format(e.returncode, e.stderr.decode(), e.stdout.decode())
+  else:
+    if process.stderr:
+      yield WARN, (
+        "ots-sanitize passed this file, however warnings were printed:\n\n{}"
+      ).format(process.stderr.decode())
     else:
       yield PASS, "ots-sanitize passed this file"
-  except subprocess.CalledProcessError as e:
-    yield FAIL, ("ots-sanitize returned an error code. Output follows :"
-                 "\n\n{}").format(e.output)
-  except OSError as e:
-    yield ERROR, ("ots-sanitize is not available!"
-                  " You really MUST check the fonts with this tool."
-                  " To install it, see"
-                  " https://github.com/googlefonts"
-                  "/gf-docs/blob/master/ProjectChecklist.md#ots"
-                  " Actual error message was: "
-                  "'{}'").format(e)
 
 
 @check(

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
         'font-v',
         'defcon',
         'ufolint',
-        'ttfautohint-py'
+        'ttfautohint-py',
+        'opentype-sanitizer',
     ],
     entry_points={
         'console_scripts': ['fontbakery=fontbakery.cli:main'],

--- a/tests/specifications/general_test.py
+++ b/tests/specifications/general_test.py
@@ -59,15 +59,11 @@ def test_check_036():
   status, _ = list(check(sanitary_font))[-1]
   assert status == PASS
 
-  bogus_font = os.path.join("data", "test", "cabinvfbeta", "CabinVFBeta.ttf")
-  status, _ = list(check(bogus_font))[-1]
+  bogus_font = os.path.join("data", "test", "README.txt")
+  status, output = list(check(bogus_font))[-1]
   assert status == FAIL
-
-  old_path = os.environ["PATH"]
-  os.environ["PATH"] = ""
-  status, _ = list(check(bogus_font))[-1]
-  assert status == ERROR
-  os.environ["PATH"] = old_path
+  assert "invalid version tag" in output
+  assert "Failed to sanitize file!" in output
 
 
 def test_check_037():


### PR DESCRIPTION
I made a python wrapper for the OpenType Sanitizer, and published pre-compiled wheels on PyPI.
This PR changes fontbakery to use that, instead of requiring the user to manually install ots-sanitize tool.

For more info, see
https://github.com/googlefonts/ots-python
https://pypi.org/project/opentype-sanitizer