### PR TITLE
com.google.fonts/check/037: Downgrade missing Mac name table records to warn

### DIFF
--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -144,7 +144,9 @@ def com_google_fonts_check_037(font):
   downgrade_to_warn = [
     "The xAvgCharWidth field does not equal the calculated value",
     "There are undefined bits set in fsSelection field",
-    "Misoriented contour"
+    "Misoriented contour",
+    "The table doesn't contain strings for Mac platform",
+    "The PostScript string is not present for both required platforms"
   ]
 
   # Some other checks we want to completely disable:


### PR DESCRIPTION
Fontmake doesn't generate mac name table records. Apparently, they're not
needed, https://github.com/googlei18n/fontmake/issues/414

Found these fails in https://github.com/googlei18n/fontmake/issues/414.