### PR TITLE
[FSanches] com.google.fonts/check/037: Downgrade missing Mac name table records to warn

### DIFF
--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -144,7 +144,9 @@ def com_google_fonts_check_037(font):
   downgrade_to_warn = [
     "The xAvgCharWidth field does not equal the calculated value",
     "There are undefined bits set in fsSelection field",
-    "Misoriented contour"
+    "Misoriented contour",
+    "The table doesn't contain strings for Mac platform",
+    "The PostScript string is not present for both required platforms"
   ]
 
   # Some other checks we want to completely disable:


### PR DESCRIPTION
This pull request addresses the problems described at previous PR #2102
