### PR TITLE
use FontValidator installed from pip package

### DIFF
--- a/INSTALL_GNU.md
+++ b/INSTALL_GNU.md
@@ -18,16 +18,6 @@ From a PPA on Ubuntu:
     sudo apt-get update -qq;
     sudo apt-get install python-fontforge
 
-##### Microsoft Font Validator
-
-Font Validator has useful tests for a font's glyf table. We use Hintak's fork.
-
-* download the latest [release](https://github.com/HinTak/Font-Validator/) for your OS.
-* unzip it
-* Change the unzipped binary's permissions, `chmod 755 FontValidator`
-* Move the binary to your bin folder, `mv /path/to/unzipped/FontValidator /usr/local/bin/FontValidator`
-
-
 ##### Remote ftxvalidator
 
 The script available at `prebuilt/workarounds/ftxvalidator/ssh-implementation/ftxvalidator` let's you execute the Mac OS tool `ftxvalidator` on a remote host. It is designed as a drop in replacement to be put in your `/usr/local/bin` directory.

--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -56,12 +56,3 @@ If you wish to run the installation process in Terminal, you can do it this way:
     cd fontTools.pkg/ ;
     cat Payload | gunzip -dc | cpio -i ;
     sudo mv ftx* /usr/local/bin/ ;
-
-##### Microsoft Font Validator
-
-Font Validator has useful tests for a font's glyf table. We use Hintak's fork.
-
-* download the latest [release](https://github.com/HinTak/Font-Validator/) for your OS.
-* unzip it
-* Change the unzipped binary's permissions, `chmod 755 FontValidator`
-* Move the binary to your bin folder, `mv /path/to/unzipped/FontValidator /usr/local/bin/FontValidator`

--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -24,12 +24,6 @@ If this doesn't work for you, wait for the next release of FontBakery after 0.5.
 
 1. Grab and install a Windows release from https://github.com/fontforge/fontforge/releases
 
-#### Microsoft Font Validator
-
-1. Grab a Windows release from https://github.com/HinTak/Font-Validator/releases (e.g. `FontVal-something-win32+64.zip`)
-2. Extract the archive somewhere and remember where
-3. Repeat the steps above to add fontbakery to the PATH variable and add the directory where you extracted the `FontValidator.exe`.
-
 #### ftxvalidator
 
 Not available for Windows.


### PR DESCRIPTION
This should simplify our install procedures.

This pull request addresses the problems described at issue #2112 
