### PR TITLE
Do not check the ttfautohint params if font is not hinted

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -976,6 +976,9 @@ def com_google_fonts_check_has_ttfautohint_params(ttFont):
       if params:
         yield PASS, f"Font has ttfautohint params ({params})"
         failed = False
+    else:
+        yield SKIP, "Font is not hinted using ttfautohint."
+        failed = False
 
   if failed:
     yield FAIL, "Font is lacking ttfautohint params on its version strings on the name table."


### PR DESCRIPTION
Skip the com.google.fonts/check/has_ttfautohint_params test if the
font is not hinted using ttfautohint

This pull request addresses the problems described at issue #2115 
