### PR TITLE
New check: Var Fonts have HVAR table (to avoid costly text-layout operations on some platforms)

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -162,6 +162,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/ttx-roundtrip' # Checking with fontTools.ttx
       , 'com.google.fonts/check/has_ttfautohint_params' # Font has ttfautohint params
       , 'com.google.fonts/check/vttclean' # There must not be VTT Talk sources in the font.
+      , 'com.google.fonts/check/varfont/has_HVAR' # Check that variable fonts have an HVAR table.
 ]
 
 specification = spec_factory(default_section=Section("Google Fonts"))
@@ -3173,6 +3174,37 @@ def com_google_fonts_check_174(ttFont):
   except Exception as e:
     yield FAIL, ("fontTools.varLib.mutator failed to generated a static font "
                  "instance\n{}".format(repr(e)))
+
+
+@check(
+  id = 'com.google.fonts/check/varfont/has_HVAR',
+  rationale = """
+  Not having a HVAR table can lead to costly
+  text-layout operations on some platforms,
+  which we want to avoid.
+
+  So, all variable fonts on the Google Fonts
+  collection should have an HVAR with valid values.
+
+  More info on the HVAR table can be found at:
+  https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#variation-data-tables-and-miscellaneous-requirements
+  """, # FIX-ME: We should clarify which are these
+       #         platforms in which there can be issues
+       #         with costly text-layout operations
+       #         when an HVAR table is missing!
+  conditions = ['is_variable_font'],
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2119'
+  })
+def com_google_fonts_check_varfont_has_HVAR(ttFont):
+  """ Check that variable fonts have an HVAR table. """
+  if "HVAR" in ttFont.keys():
+    yield PASS, ("This variable font contains an HVAR table.")
+  else:
+    yield FAIL, ("All variable fonts on the Google Fonts collection"
+                 " must have a properly set HVAR table in order"
+                 " to avoid costly text-layout operations on"
+                 " certain platforms.")
 
 
 @check(

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -2285,6 +2285,23 @@ def test_check_174():
   assert status == FAIL
 
 
+def test_check_varfont_has_HVAR():
+  """ Check that variable fonts have an HVAR table. """
+  from fontbakery.specifications.googlefonts import com_google_fonts_check_varfont_has_HVAR as check
+
+  # Our reference Cabin Variable Font contains an HVAR table.
+  ttFont = TTFont('data/test/cabinvfbeta/CabinVFBeta.ttf')
+
+  # So the check must PASS.
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+  # Introduce the problem by removing the HVAR table:
+  del ttFont['HVAR']
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL
+
+
 def test_check_040(mada_ttFonts):
   """ Checking OS/2 usWinAscent & usWinDescent. """
   from fontbakery.specifications.googlefonts import com_google_fonts_check_040 as check


### PR DESCRIPTION
This pull request addresses the problems described at issue #2119


