### PR TITLE
Print Font Bakery version on the header of Markdown reports

### DIFF
--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -1,6 +1,7 @@
 import os
 from fontbakery.reporters.serialize import SerializeReporter
 from fontbakery.checkrunner import Status
+from fontbakery import __version__ as version
 
 LOGLEVELS=["ERROR","FAIL","WARN","SKIP","INFO","PASS"]
 
@@ -78,6 +79,7 @@ class GHMarkdownReporter(SerializeReporter):
             checks[key].append(check)
 
     md = "## Fontbakery report\n\n"
+    md += f"Fontbakery version: {version}\n\n"
 
     if family_checks:
       family_checks.sort(key=lambda c: c["result"])


### PR DESCRIPTION
So that we know if a report was generated with an old version.

This pull request addresses the problems described at issue #2133 
