### PR TITLE
Bump up requests version to mitigate CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fonttools>=3.19
 protobuf>=3.4.0
-requests==2.11.1
+requests>=2.20.0
 beautifulsoup4==4.5.1
 bs4==0.0.1
 defusedxml==0.4.1


### PR DESCRIPTION
Even though I think our usage of requests in Font Bakery likely does not expose our users to this specific vulnerability, I think it is harmless to require a newer version of the requests module, which is the suggested mitigation for the issue.

CVE-2018-18074
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

This pull request addresses the problems described at issue #2135 

![screenshot at 2018-10-30 11 18 12](https://user-images.githubusercontent.com/213676/47725006-abf09d00-dc4f-11e8-8ebc-4c39198514f1.png)
