### PR TITLE
new 'meta' check: Font Bakery must be up-to-date to avoid relying on out-dated checking routines.

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -164,6 +164,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/vttclean' # There must not be VTT Talk sources in the font.
       , 'com.google.fonts/check/varfont/has_HVAR' # Check that variable fonts have an HVAR table.
 #      , 'com.google.fonts/check/varfont/has_MVAR' # Check that variable fonts have an MVAR table.
+      , 'com.google.fonts/check/fontbakery_version' # Do we have the latest version of FontBakery installed?
 ]
 
 specification = spec_factory(default_section=Section("Google Fonts"))

--- a/tests/specifications/general_test.py
+++ b/tests/specifications/general_test.py
@@ -492,3 +492,25 @@ def test_check_ttx_roundtrip():
   #bad_font_path = os.path.join("data", "test", ...)
   #status, _ = list(check(bad_font_path))[-1]
   #assert status == FAIL
+
+def test_is_up_to_date():
+  from fontbakery.specifications.general import is_up_to_date
+  # is_up_to_date(installed, latest)
+  assert(is_up_to_date(installed="0.5.0",
+                          latest="0.5.0") == True)
+  assert(is_up_to_date(installed="0.5.1",
+                          latest="0.5.0") == True)
+  assert(is_up_to_date(installed="0.4.1",
+                          latest="0.5.0") == False)
+  assert(is_up_to_date(installed="0.3.4",
+                          latest="0.3.5") == False)
+  assert(is_up_to_date(installed="1.0.0",
+                          latest="1.0.1") == False)
+  assert(is_up_to_date(installed="2.0.0",
+                          latest="1.5.3") == True)
+  assert(is_up_to_date(installed="0.5.2.dev73+g8c9ebc0.d20181023",
+                          latest="0.5.1") == True)
+  assert(is_up_to_date(installed="0.5.2.dev73+g8c9ebc0.d20181023",
+                          latest="0.5.2") == False)
+  assert(is_up_to_date(installed="0.5.2.dev73+g8c9ebc0.d20181023",
+                          latest="0.5.3") == False)


### PR DESCRIPTION
This pull request addresses the problems described at issue #2093 