### PR TITLE
do not run check/046 on CFF fonts...

### DIFF
--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -575,7 +575,8 @@ def com_google_fonts_check_039(fontforge_check_results, fontforge_skip_checks):
 
 
 @check(
-  id = 'com.google.fonts/check/046'
+  id = 'com.google.fonts/check/046',
+  conditions = ['not is_cff']
 )
 def com_google_fonts_check_046(ttFont):
   """Font contains .notdef as first glyph?

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -163,6 +163,10 @@ def download_file(url):
   return BytesIO(urlopen(url).read())
 
 
+# FIX-ME:
+#  This method directly references `glyf`.
+#  In the future we should consider refactoring
+#  it to also deal with CFF fonts.
 def glyph_has_ink(font, name):
   # type: (TTFont, Text) -> bool
   """Checks if specified glyph has any ink.


### PR DESCRIPTION
... because the helper method `glyph_has_ink` directly references `glyf`.
In the future we may refactor it to also deal with CFF fonts.

This pull request addresses the problems described at issue #1994
