### PR TITLE
com_google_fonts_check_018: Downgrade archVendID from FAIL to WARN

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -598,10 +598,10 @@ def com_google_fonts_check_018(ttFont, registered_vendor_ids):
   vid = ttFont['OS/2'].achVendID
   bad_vids = ['UKWN', 'ukwn', 'PfEd']
   if vid is None:
-    yield FAIL, Message("not set", "OS/2 VendorID is not set." +
+    yield WARN, Message("not set", "OS/2 VendorID is not set." +
                                    SUGGEST_MICROSOFT_VENDORLIST_WEBSITE)
   elif vid in bad_vids:
-    yield FAIL, Message("bad", ("OS/2 VendorID is '{}',"
+    yield WARN, Message("bad", ("OS/2 VendorID is '{}',"
                                 " a font editor default.").format(vid) +
                                 SUGGEST_MICROSOFT_VENDORLIST_WEBSITE)
   elif vid not in registered_vendor_ids.keys():

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -348,17 +348,17 @@ def test_check_018():
   # Let's start with our reference Cabin Regular
   ttFont = TTFont("data/test/merriweather/Merriweather-Regular.ttf")
 
-  print('Test FAIL with bad vid.')
+  print('Test WARN with bad vid.')
   bad_vids = ['UKWN', 'ukwn', 'PfEd']
   for bad_vid in bad_vids:
     ttFont['OS/2'].achVendID = bad_vid
     status, message = list(check(ttFont, registered_ids))[-1]
-    assert status == FAIL and message.code == "bad"
+    assert status == WARN and message.code == "bad"
 
   print('Test FAIL with font missing vendor id info.')
   ttFont['OS/2'].achVendID = None
   status, message = list(check(ttFont, registered_ids))[-1]
-  assert status == FAIL and message.code == "not set"
+  assert status == WARN and message.code == "not set"
 
   print('Test WARN with unknwon vendor id.')
   ttFont['OS/2'].achVendID = "????"


### PR DESCRIPTION
This check currently fails if archVendID isn't set or a placeholder is provided.

Imo, this check shouldn't fail on a placeholder, it should warn instead.

Keep this open until it gets approval from @davelab6. If we still need it, we'll need to improve the rationale and investigate which apps use it.