### PR TITLE
com.google.fonts/check/042: Downgrade hhea match typo metrics to WARN

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -3327,10 +3327,10 @@ def com_google_fonts_check_042(ttFont):
   """
   # OS/2 sTypoAscender and sTypoDescender match hhea ascent and descent
   if ttFont["OS/2"].sTypoAscender != ttFont["hhea"].ascent:
-    yield FAIL, Message("ascender",
+    yield WARN, Message("ascender",
                         "OS/2 sTypoAscender and hhea ascent must be equal.")
   elif ttFont["OS/2"].sTypoDescender != ttFont["hhea"].descent:
-    yield FAIL, Message("descender",
+    yield WARN, Message("descender",
                         "OS/2 sTypoDescender and hhea descent must be equal.")
   else:
     yield PASS, ("OS/2.sTypoAscender/Descender" " match hhea.ascent/descent.")

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -2520,7 +2520,7 @@ def test_check_042(mada_ttFonts):
   correct = ttFont['hhea'].ascent
   ttFont['OS/2'].sTypoAscender = correct + 1
   status, message = list(check(ttFont))[-1]
-  assert status == FAIL and message.code == "ascender"
+  assert status == WARN and message.code == "ascender"
 
   # Restore good value:
   ttFont['OS/2'].sTypoAscender = correct
@@ -2530,7 +2530,7 @@ def test_check_042(mada_ttFonts):
   correct = ttFont['hhea'].descent
   ttFont['OS/2'].sTypoDescender = correct + 1
   status, message = list(check(ttFont))[-1]
-  assert status == FAIL and message.code == "descender"
+  assert status == WARN and message.code == "descender"
 
 
 def test_check_072():


### PR DESCRIPTION
Ideally you'd want both sets of metrics to match. Unfortunately we've already released many fonts which don't have matching metrics.

If we attempt to fix this issue in the existing families, we'll break the vert metrics on either Win or Mac, which will upset existing users.