### PR TITLE
Add Writing Specifications link to TOC on Sphinx documentation home page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ The project is licensed under the `Apache v2.0 license <https://github.com/googl
    :caption: Developer Documentation
 
    developer/contrib-getting-started
+   developer/writing-specifications
    developer/source-contrib-guide
    developer/doc-contrib-guide
 


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontbakery/issues/2145#issuecomment-436360984
