### PR TITLE
Fix expected values glyphdata

### DIFF
--- a/Lib/fontbakery/glyphdata.py
+++ b/Lib/fontbakery/glyphdata.py
@@ -88,7 +88,7 @@ desired_glyph_data = \
         "name": "uni200C", 
         "unicode": 8204, 
         "contours": [
-            1
+            0
         ]
     }, 
     {
@@ -4250,7 +4250,7 @@ desired_glyph_data = \
         "name": "uni200D", 
         "unicode": 8205, 
         "contours": [
-            1
+            0
         ]
     }, 
     {


### PR DESCRIPTION
Changed expected value for zerowidthjoiner(uni200D) and zerowidthnonjoiner(uni200C) from 1 to 0

This pull request addresses the problems described at issue #2178 
