### PR TITLE
downgrade xAvgWidth check from FAIL to WARN since sometimes it diverges from GlyphsApp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[com.google.fonts/check/001]:** Accept variable font filenames with Roman/Italic suffixes (issue #2214)
+  - **[com.google.fonts/check/034]:** Downgrade xAvgWidth check from FAIL to WARN since sometimes it diverges from GlyphsApp. Also, it seems that the value is not actually used on relevant programs. I still want to clarify what's going on with GlyphsApp calculations of this value. Once that's figured out, we may redefine the severity of the check once again. (issue #2095)
   - **[com.google.fonts/check/097]:** Accept variable font filenames with Roman/Italic suffixes (issue #2214)
   - **[com.google.fonts/check/102]:** Check for consistency of copyright notice strings on both METADATA.pb and on name table entries. (issue #2210)
   - **[com.google.fonts/check/105]:** Accept variable font filenames with Roman/Italic suffixes (issue #2214)
-
 
 ## 0.6.2 (2018-Nov-19)
 ### New checks

--- a/Lib/fontbakery/specifications/os2.py
+++ b/Lib/fontbakery/specifications/os2.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.checkrunner import FAIL, PASS, WARN
+from fontbakery.checkrunner import FAIL, PASS, WARN, INFO
 from fontbakery.message import Message
 # used to inform get_module_specification whether and how to create a specification
 from fontbakery.fonts_spec import spec_factory # NOQA pylint: disable=unused-import
@@ -133,7 +133,7 @@ def com_google_fonts_check_034(ttFont):
   if current_value == expected_value or difference == 1:
     yield PASS, "OS/2 xAvgCharWidth value is correct."
   elif difference < ACCEPTABLE_ERROR:
-    yield WARN, ("OS/2 xAvgCharWidth is {} but should be"
+    yield INFO, ("OS/2 xAvgCharWidth is {} but should be"
                   " {} which corresponds to the weighted"
                   " average of the widths of the latin"
                   " lowercase glyphs in the font."
@@ -144,7 +144,7 @@ def com_google_fonts_check_034(ttFont):
                   " this at https://github.com/googlefonts/fontbakery"
                   "/issues/1622").format(current_value, expected_value)
   else:
-    yield FAIL, ("OS/2 xAvgCharWidth is {} but it should be "
+    yield WARN, ("OS/2 xAvgCharWidth is {} but it should be "
                   "{} which corresponds to the weighted "
                   "average of the widths of the latin "
                   "lowercase glyphs in "

--- a/tests/specifications/os2_test.py
+++ b/tests/specifications/os2_test.py
@@ -92,11 +92,11 @@ def test_check_034():
 
   test_font['OS/2'].xAvgCharWidth = 556
   status, message = list(check(test_font))[-1]
-  assert status == WARN
+  assert status == INFO
 
   test_font['OS/2'].xAvgCharWidth = 500
   status, message = list(check(test_font))[-1]
-  assert status == FAIL
+  assert status == WARN
 
   test_font = TTFont()
   test_font['OS/2'] = fontTools.ttLib.newTable('OS/2')
@@ -124,11 +124,11 @@ def test_check_034():
 
   test_font['OS/2'].xAvgCharWidth = 450
   status, message = list(check(test_font))[-1]
-  assert status == WARN
+  assert status == INFO
 
   test_font['OS/2'].xAvgCharWidth = 500
   status, message = list(check(test_font))[-1]
-  assert status == FAIL
+  assert status == WARN
 
   test_font = TTFont(temp_file)
   subsetter = fontTools.subset.Subsetter()


### PR DESCRIPTION
Also, it seems that the value is not actually used on relevant programs.
I still want to clarify what's going on with GlyphsApp calculations of this value.
Once that's figured out, we may redefine the severity of the check once again.

This pull request addresses the problems described at issue #2095
