### PR TITLE
search for a license file on the git-repo rootdir if the font project is in a repo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.6.3 (2018-Nov-26)
 ### Bug fixes
+  - **[com.google.fonts/check/028]:** Also search for a license file on the git-repo rootdir if the font project is in a repo. (issue #2087)
   - **[com.google.fonts/check/062]:** fix a typo leading to a bad string formatting syntax crash. (issue #2183)
 
 ### Changes to existing checks


### PR DESCRIPTION
This also changes the checkrunner-based example test in order to avoid the detection of Fontbakery's license (on this repo) to mess up the execution of that check.

This pull request addresses the problems described at issue #2087