### PR TITLE
Reverting PR #2167 (__str__ for Section and Check) as it caused the ghmarkdown output to crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.6.3 (2018-Nov-26)
 ### Bug fixes
+  - **[GHMarkdown output]:** PR #2167 (__str__ for Section and Check) was reverted because it was causing the ghmarkdown output to crash. We may get back to it later, but being more careful about the side effects of it. (issue #2194)
   - **[com.google.fonts/check/028]:** Also search for a license file on the git-repo rootdir if the font project is in a repo. (issue #2087)
   - **[com.google.fonts/check/062]:** fix a typo leading to a bad string formatting syntax crash. (issue #2183)
 

--- a/Lib/fontbakery/callable.py
+++ b/Lib/fontbakery/callable.py
@@ -204,8 +204,9 @@ class FontBakeryCheck(FontbakeryCallable):
     # self._conditions_setup = conditions_setup
     self._advancedMessageSetup = advancedMessageSetup
 
-  def __str__(self):
-    return self.id
+  # This was problematic. See: https://github.com/googlefonts/fontbakery/issues/2194
+  # def __str__(self):
+  #  return self.id
 
 def condition(*args, **kwds):
   """Check wrapper, a factory for FontBakeryCondition

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -702,8 +702,9 @@ class Section:
   def __repr__(self):
     return f'<Section: {self.name}>'
 
-  def __str__(self):
-    return self.name
+  # This was problematic. See: https://github.com/googlefonts/fontbakery/issues/2194
+  # def __str__(self):
+  #   return self.name
 
   def __eq__(self, other):
     """ True if other.checks has the same checks in the same order"""


### PR DESCRIPTION
We may get back to it later, but being more careful about the side effects of it.

This pull request addresses the problems described at issue #2194 
