### PR TITLE
Avoid reporting style=None by only running com.google.fonts/check/011 when files are named canonically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.abobe.fonts/check/postscript_name_cff_vs_name]:** CFF table FontName must match name table ID 6 (PostScript name). (PR #2229)
 
 ### Bug fixes
-  - **[com.google.fonts/check/011]:** Safeguard against `None` when style is non-cannonical. (issue #2196)
+  - **[com.google.fonts/check/011]:** Safeguard against reportingn style=`None` by only running the check when all font files are named cannonically. (issue #2196)
 
 
 ## 0.6.3 (2018-Nov-26)

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -138,7 +138,6 @@ def test_example_checkrunner_based(cabin_regular_path):
 def test_check_001():
   """ Files are named canonically. """
   from fontbakery.specifications.googlefonts import com_google_fonts_check_001 as check
-  from fontbakery.specifications.shared_conditions import is_variable_font
 
   canonical_names = [
     "data/test/montserrat/Montserrat-Thin.ttf",
@@ -172,17 +171,13 @@ def test_check_001():
   ]
 
   for canonical in canonical_names:
-    is_var = os.path.exists(canonical) and is_variable_font(TTFont(canonical))
     print(f'Test PASS with "{canonical}" ...')
-    status, message = list(check(canonical,
-                                 is_var))[-1]
+    status, message = list(check(canonical))[-1]
     assert status == PASS
 
   for non_canonical in non_canonical_names:
-    is_var = os.path.exists(non_canonical) and is_variable_font(TTFont(non_canonical))
     print(f'Test FAIL with "{non_canonical}" ...')
-    status, message = list(check(non_canonical,
-                                 is_var))[-1]
+    status, message = list(check(non_canonical))[-1]
     assert status == FAIL
 
 


### PR DESCRIPTION
Refactored check/001 to split out its implementation into two new conditions called `canonical_stylename` and `stylenames_are_canonical`. These can be used to auto-skip other checks such as `com.google.fonts/check/011`.

This pull request addresses the problems described at issue #2196 
