### PR TITLE
Fixing/Reimplementing unitsPerEm checks (both in OpenType as well as in GFonts profiles)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[com.google.fonts/check/011]:** List which glyphs differ among font files (issue #2196)
+  - **[com.google.fonts/check/043]:** unitsPerEm check on OpenType profile is now less opinionated. Only FAILs when strictly invalid according to the spec. (issue #2185)
+  - **[com.google.fonts/check/116]:** Implement stricter criteria for the values of unitsPerEm on Google Fonts. (issue #2185)
 
 ### Other relevant code changes
   - **[setup.py]:** display README.md as long-description on PyPI webpage. (issue #2225)

--- a/Lib/fontbakery/specifications/head.py
+++ b/Lib/fontbakery/specifications/head.py
@@ -33,20 +33,43 @@ def com_google_fonts_check_014(ttFonts):
 
 
 @check(
-  id = 'com.google.fonts/check/043'
+  id = 'com.google.fonts/check/043',
+  rationale = """
+  According to the OpenType spec:
+
+  The value of unitsPerEm at the head table must be
+  a value between 16 and 16384. Any value in this
+  range is valid.
+
+  In fonts that have TrueType outlines, a power of 2
+  is recommended as this allows performance
+  optimizations in some rasterizers.
+
+  But 1000 is a commonly used value. And 2000 may
+  become increasingly more common on Variable Fonts.
+  """
 )
 def com_google_fonts_check_043(ttFont):
   """Checking unitsPerEm value is reasonable."""
   upem = ttFont['head'].unitsPerEm
   target_upem = [2**i for i in range(4, 15)]
-  target_upem.insert(0, 1000)
-  if upem not in target_upem:
+  target_upem.append(1000)
+  target_upem.append(2000)
+  if upem < 16 or upem > 16384:
     yield FAIL, ("The value of unitsPerEm at the head table"
-                 " must be either 1000 or a power of"
-                 " 2 between 16 to 16384."
+                 " must be a value between 16 and 16384."
                  " Got '{}' instead.").format(upem)
+  elif upem not in target_upem:
+    yield WARN, ("In order to optimize performance on some"
+                 " legacy renderers, the value of unitsPerEm"
+                 " at the head table should idealy be"
+                 " a power of between 16 to 16384."
+                 " And values of 1000 and 2000 are also"
+                 " common and may be just fine as well."
+                 " But we got upm={} instead.").format(upem)
   else:
-    yield PASS, "unitsPerEm value on the 'head' table is reasonable."
+    yield PASS, ("unitsPerEm value ({}) on the 'head' table"
+                 " is reasonable.").format(upem)
 
 
 def parse_version_string(name):

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -1770,21 +1770,40 @@ def NOT_IMPLEMENTED_test_check_115():
 
 
 def test_check_116():
-  """ Is font em size (ideally) equal to 1000? """
+  """ Stricter unitsPerEm criteria for Google Fonts. """
   from fontbakery.specifications.googlefonts import com_google_fonts_check_116 as check
 
   fontfile = "data/test/cabin/Cabin-Regular.ttf"
   ttFont = TTFont(fontfile)
 
-  print ("Test PASS with unitsPerEm = 1000...")
-  ttFont["head"].unitsPerEm = 1000
-  status, message = list(check(ttFont))[-1]
-  assert status == PASS
+  PASS_VALUES = [2000] # The potential "New Standard" for Variable Fonts!
 
-  print ("Test WARN with unitsPerEm = 1024...")
-  ttFont["head"].unitsPerEm = 1024
-  status, message = list(check(ttFont))[-1]
-  assert status == WARN
+  WARN_VALUES = [16, 32, 64, 128, 256, 512, 1024, 2048] # Good for better performance on legacy renderers
+  WARN_VALUES.extend([500, 1000]) # or common typical values
+
+  # and finally the bad ones, including:
+  FAIL_VALUES = [0, 1, 2, 4, 8, 15, 16385] # simply invalid
+  FAIL_VALUES.extend([100, 2500]) # suboptimal (uncommon and not power of two)
+  FAIL_VALUES.extend([4096, 8192, 16384]) # and valid ones suggested by the opentype spec,
+                                          # but too large, causing undesireable filesize bloat.
+
+  for pass_value in PASS_VALUES:
+    print (f"Test PASS with unitsPerEm = {pass_value}...")
+    ttFont["head"].unitsPerEm = pass_value
+    status, message = list(check(ttFont))[-1]
+    assert status == PASS
+
+  for warn_value in WARN_VALUES:
+    print (f"Test WARN with unitsPerEm = {warn_value}...")
+    ttFont["head"].unitsPerEm = warn_value
+    status, message = list(check(ttFont))[-1]
+    assert status == WARN
+
+  for fail_value in FAIL_VALUES:
+    print (f"Test FAIL with unitsPerEm = {fail_value}...")
+    ttFont["head"].unitsPerEm = fail_value
+    status, message = list(check(ttFont))[-1]
+    assert status == FAIL
 
 
 def NOT_IMPLEMENTED_test_check_117():

--- a/tests/specifications/head_test.py
+++ b/tests/specifications/head_test.py
@@ -58,19 +58,26 @@ def test_check_043():
   # We'll use Mada Regular to start with:
   ttFont = TTFont("data/test/mada/Mada-Regular.ttf")
 
-  for good_value in [1000, 16, 32, 64, 128, 256,
-                     512, 1024, 2048, 4096, 8192, 16384]:
+  for good_value in [16, 32, 64, 128, 256, 512, 1000,
+                     1024, 2000, 2048, 4096, 8192, 16384]:
     print(f"Test PASS with a good value of unitsPerEm = {good_value} ...")
     ttFont['head'].unitsPerEm = good_value
     status, _ = list(check(ttFont))[-1]
     assert status == PASS
 
+  for warn_value in [20, 50, 100, 500, 4000]:
+    print(f"Test WARN with a value of unitsPerEm = {warn_value} ...")
+    ttFont['head'].unitsPerEm = warn_value
+    status, _ = list(check(ttFont))[-1]
+    assert status == WARN
+
   # These are arbitrarily chosen bad values:
-  for bad_value in [0, 1, 2, 4, 8, 10, 100, 10000, 32768]:
+  for bad_value in [0, 1, 2, 4, 8, 10, 15, 16385, 32768]:
     print(f"Test FAIL with a bad value of unitsPerEm = {bad_value} ...")
     ttFont['head'].unitsPerEm = bad_value
     status, message = list(check(ttFont))[-1]
     assert status == FAIL
+
 
 def test_parse_version_string():
   """ Checking font version fields. """


### PR DESCRIPTION
This pull request addresses the problems described at issue #2185 
