### PR TITLE
fix com.google.fonts/check/065 AttributeError: 'int' object has no attribute 'items'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Bug fixes
   - **[com.google.fonts/check/011]:** Safeguard against reporting style=`None` by only running the check when all font files are named canonically. (issue #2196)
+  - **[com.google.fonts/check/065]:** Fix AttributeError: 'int' object has no attribute 'items'. (issue #2203)
 
 ### Changes to existing checks
   - **[com.google.fonts/check/011]:** List which glyphs differ among font files (issue #2196)

--- a/Lib/fontbakery/specifications/gpos.py
+++ b/Lib/fontbakery/specifications/gpos.py
@@ -54,15 +54,6 @@ def com_google_fonts_check_063(ttFont):
   })
 def com_google_fonts_check_065(ttFont, ligatures, has_kerning_info):
   """Is there kerning info for non-ligated sequences?"""
-  ligature_pairs = []
-  for first, comp in ligatures.items():
-    for components in comp:
-      while components:
-        pair = (first, components[0])
-        if pair not in ligature_pairs:
-          ligature_pairs.append(pair)
-        first = components[0]
-        components.pop(0)
 
   def look_for_nonligated_kern_info(table):
     for pairpos in table.SubTable:
@@ -85,6 +76,16 @@ def com_google_fonts_check_065(ttFont, ligatures, has_kerning_info):
                         " https://github.com"
                         "/googlefonts/fontbakery/issues/1596")
   else:
+    ligature_pairs = []
+    for first, comp in ligatures.items():
+      for components in comp:
+        while components:
+          pair = (first, components[0])
+          if pair not in ligature_pairs:
+            ligature_pairs.append(pair)
+          first = components[0]
+          components.pop(0)
+
     for record in ttFont["GSUB"].table.FeatureList.FeatureRecord:
       if record.FeatureTag == 'kern':
         for index in record.Feature.LookupListIndex:


### PR DESCRIPTION
This pull request addresses the problems described at issue #2203
