### PR TITLE
fix UnboundLocalError on FontBakeryCondition:remote_styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bug fixes
   - **[com.google.fonts/check/011]:** Safeguard against reporting style=`None` by only running the check when all font files are named canonically. (issue #2196)
   - **[com.google.fonts/check/065]:** Fix AttributeError: 'int' object has no attribute 'items'. (issue #2203)
+  - **[FontBakeryCondition:remote_styles]:** fix UnboundLocalError. local variable 'remote_style' was referenced before assignment. (issue #2204)
 
 ### Changes to existing checks
   - **[com.google.fonts/check/011]:** List which glyphs differ among font files (issue #2196)

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2397,8 +2397,9 @@ def remote_styles(family_metadata):
   rstyles = {}
 
   for remote_filename, remote_font in fonts_from_zip(remote_fonts_zip):
-    if '-' in remote_filename[:-4]:
-      remote_style = remote_filename[:-4].split('-')[1]
+    remote_style = os.path.splitext(remote_filename)[0]
+    if '-' in remote_style:
+      remote_style = remote_style.split('-')[1]
     rstyles[remote_style] = remote_font
   return rstyles
 


### PR DESCRIPTION
local variable 'remote_style' was referenced before assignment.

This pull request addresses the problems described at issue #2204 
