### PR TITLE
new dependencies: fs and unicodedata2 (needed by fonttools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Other relevant code changes
   - **[setup.py]:** display README.md as long-description on PyPI webpage. (issue #2225)
   - **[README.md]:** mention our new developer chat channel at https://gitter.im/fontbakery/Lobby
+  - **[Dependencies]:** The following 2 modules are actually needed by fontTools: fs and unicodedata2.
 
 ## 0.6.3 (2018-Nov-26)
 ### Bug fixes

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,9 @@ setup(
         'ufolint',
         'ttfautohint-py',
         'opentype-sanitizer',
+        # The following 2 modules are actually needed by fontTools:
+        'fs',
+        'unicodedata2'
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
This should have been declared on fontTools' setup.py instead, I think... I will file an issue upstream.
For now we'll install the dependencies ourselves, in order to help our users.
