### PR TITLE
Fix math in googlefonts check 054

### DIFF
--- a/Lib/fontbakery/fonts_public.proto
+++ b/Lib/fontbakery/fonts_public.proto
@@ -19,7 +19,6 @@ message FamilyProto {
   repeated string subsets = 8;
   optional string ttf_autohint_args = 9;
   repeated AxisProto axes = 10;
-  optional string trademark = 11;
 };
 
 message FontProto {

--- a/Lib/fontbakery/fonts_public.proto
+++ b/Lib/fontbakery/fonts_public.proto
@@ -19,6 +19,7 @@ message FamilyProto {
   repeated string subsets = 8;
   optional string ttf_autohint_args = 9;
   repeated AxisProto axes = 10;
+  optional string trademark = 11;
 };
 
 message FontProto {

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1008,7 +1008,7 @@ def com_google_fonts_check_054(font, ttfautohint_stats):
   hinted = ttfautohint_stats["hinted_size"]
   dehinted = ttfautohint_stats["dehinted_size"]
   increase = hinted - dehinted
-  change = float(hinted)/dehinted - 1
+  change = (float(hinted)/dehinted - 1) * 100
 
   def filesize_formatting(s):
     if s < 1024:


### PR DESCRIPTION
Currently, Check `054` incorrectly tells the font file size change before/after hinting.

## As-is
Change is shown as 0.2%, but should be `(b - a) / a = change`, or  `(234.4 - 197.5)/197.5 = .186835443`.

|  | fonts/encodesans/EncodeSans-VF.ttf |
|:--- | ---:|
| Dehinted Size | 197.5kb |
| Hinted Size | 234.4kb |
| Increase | 36.9kb |
| Change   | 0.2 % |

## With the fix

I multiple the `change` variable by `100` to achieve the correct answer.

|  | fonts/encodesans/EncodeSans-VF.ttf |
|:--- | ---:|
| Dehinted Size | 197.5kb |
| Hinted Size | 234.4kb |
| Increase | 36.9kb |
| Change   | 18.7 % |