### PR TITLE
new check: com.google.fonts/check/varfont_has_instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New Checks
   - **[com.google.fonts/check/metadata/parses]:** "Check METADATA.pb parse correctly." (issue #2248)
   - **[com.google.fonts/check/fvar_name_entries]:** "All name entries referenced by fvar instances exist on the name table?" (issue #2069)
+  - **[com.google.fonts/check/varfont_has_instances:]** "A variable font must have named instances." (issue #2127)
 
 ### Bug fixes
   - **[com.google.fonts/check/054]:** Correct math in report of font file size change by properly converting result to a percentage.
@@ -12,6 +13,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/046]:** Removed restriction on CFF fonts (and added restriction on CFF2 pending a fonttools bug fix) because the helper method `glyph_has_ink` now handles `CFF` as well as `glyf`.
   - **[com.google.fonts/check/049]:** Removed restriction on CFF fonts (and added restriction on CFF2 pending a fonttools bug fix) because the helper method `glyph_has_ink` now handles `CFF` as well as `glyf`.
+
 
 ## 0.6.4 (2018-Dec-03)
 ### New Features
@@ -25,7 +27,6 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/065]:** Fix AttributeError: 'int' object has no attribute 'items'. (issue #2203)
   - **[FontBakeryCondition:remote_styles]:** fix UnboundLocalError. local variable 'remote_style' was referenced before assignment. (issue #2204)
 
-
 ### Changes to existing checks
   - **[com.google.fonts/check/011]:** List which glyphs differ among font files (issue #2196)
   - **[com.google.fonts/check/043]:** unitsPerEm check on OpenType profile is now less opinionated. Only FAILs when strictly invalid according to the spec. (issue #2185)
@@ -35,6 +36,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[setup.py]:** display README.md as long-description on PyPI webpage. (issue #2225)
   - **[README.md]:** mention our new developer chat channel at https://gitter.im/fontbakery/Lobby
   - **[Dependencies]:** The following 2 modules are actually needed by fontTools: fs and unicodedata2.
+
 
 ## 0.6.3 (2018-Nov-26)
 ### Bug fixes

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -169,6 +169,7 @@ expected_check_ids = [
       , 'com.adobe.fonts/check/postscript_name_cff_vs_name' # CFF table FontName must match name table ID 6 (PostScript name).
       , 'com.google.fonts/check/metadata/parses' # Check METADATA.pb parses correctly.
       , 'com.google.fonts/check/fvar_name_entries' # All name entries referenced by fvar instances exist on the name table?
+      , 'com.google.fonts/check/varfont_has_instances' # A variable font must have named instances.
 ]
 
 specification = spec_factory(default_section=Section("Google Fonts"))
@@ -3660,6 +3661,22 @@ def com_google_fonts_check_fvar_name_entries(ttFont):
 
   if not failed:
     yield PASS, "OK"
+
+
+@check(
+  id = 'com.google.fonts/check/varfont_has_instances',
+  conditions = ['is_variable_font'],
+  rationale = """
+  Named instances must be present in all variable fonts.
+  """
+)
+def com_google_fonts_check_varfont_has_instances(ttFont):
+  """A variable font must have named instances."""
+
+  if len(ttFont["fvar"].instances):
+    yield PASS, "OK"
+  else:
+    yield FAIL, "This variable font lacks named instances on the fvar table."
 
 
 def is_librebarcode(font):

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -2672,3 +2672,26 @@ def test_check_fvar_name_entries():
   print ("Test PASS with a good font...")
   status, message = list(check(ttFont))[-1]
   assert status == PASS
+
+
+def test_check_varfont_has_instances():
+  """ A variable font must have named instances. """
+  from fontbakery.specifications.googlefonts import com_google_fonts_check_varfont_has_instances as check
+
+  # ExpletusVF does have instances.
+  # Note: The "broken" in the path name refers to something else.
+  #       (See test_check_fvar_name_entries)
+  ttFont = TTFont("data/test/broken_expletus_vf/ExpletusSansBeta-VF.ttf")
+
+  # So it must PASS the check:
+  print ("Test PASS with a good font...")
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+  # If we delete all instances, then it must FAIL:
+  while len(ttFont["fvar"].instances):
+    del ttFont["fvar"].instances[0]
+
+  print ("Test FAIL with a good font...")
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL


### PR DESCRIPTION
"A variable font must have named instances"

This pull request addresses the problems described at issue #2127 
