### PR TITLE
Disable check/153 for variable fonts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+## 0.6.6 (2018-Dec-17)
+### Changes to existing checks
+  - **[com.google.fonts/check/153]:** Disable "expected contour count" check for variable fonts. There's plenty of alternative ways of constructing glyphs with multiple outlines for each feature in a VarFont. The expected contour count data for this check is currently optimized for the typical construction of glyphs in static fonts. (issue #2262)
+
 ## 0.6.5 (2018-Dec-10)
 ### New Checks
   - **[com.google.fonts/check/metadata/parses]:** "Check METADATA.pb parse correctly." (issue #2248)

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2752,7 +2752,8 @@ def com_google_fonts_check_131(ttFont, style):
 
 @check(
   id = 'com.google.fonts/check/153',
-  conditions = ['is_ttf'],
+  conditions = ['is_ttf',
+                'not is_variable_font'],
   rationale = """
     Visually QAing thousands of glyphs by hand is tiring. Most glyphs can only
     be constructured in a handful of ways. This means a glyph's contour count
@@ -2760,6 +2761,11 @@ def com_google_fonts_check_131(ttFont, style):
     be 2 or 3 contours, depending on whether its double story or single story.
     However, a quotedbl should have 2 contours, unless the font belongs to a
     display family.
+
+    This check currently does not cover variable fonts because there's plenty
+    of alternative ways of constructing glyphs with multiple outlines for each
+    feature in a VarFont. The expected contour count data for this check is
+    currently optimized for the typical construction of glyphs in static fonts.
   """
 )
 def com_google_fonts_check_153(ttFont):


### PR DESCRIPTION
This check currently does not cover variable fonts because there's plenty of alternative ways of constructing glyphs with multiple outlines for each feature in a VarFont. The expected contour count data for this check is currently optimized for the typical construction of glyphs in static fonts.

This pull request addresses the problems described at issue #2262 