### PR TITLE
new check: com.google.fonts/check/wght_valid_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.6.6 (2018-Dec-17)
+### New Checks
+  - **[com.google.fonts/check/wght_valid_range]:** Weight axis coordinate must be within spec range of 1 to 1000 on all instances. (issue #2264)
+
 ### Changes to existing checks
   - **[com.google.fonts/check/153]:** Disable "expected contour count" check for variable fonts. There's plenty of alternative ways of constructing glyphs with multiple outlines for each feature in a VarFont. The expected contour count data for this check is currently optimized for the typical construction of glyphs in static fonts. (issue #2262)
 

--- a/Lib/fontbakery/specifications/fvar.py
+++ b/Lib/fontbakery/specifications/fvar.py
@@ -183,3 +183,35 @@ def com_google_fonts_check_172(ttFont, bold_wght_coord):
                  " the 'Bold' instance must be 700."
                  " Got a '{}' coordinate instead."
                  "").format(bold_wght_coord)
+
+
+@check(
+  id = 'com.google.fonts/check/wght_valid_range',
+  rationale = """
+    According to the Open-Type spec's registered
+    design-variation tag 'wght' available at
+    https://docs.microsoft.com/en-gb/typography/opentype/spec/dvaraxistag_wght
+
+    On the 'wght' (Weight) axis, the valid coordinate range is 1-1000.
+  """,
+  conditions = ['is_variable_font'],
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2264'
+  }
+)
+def com_google_fonts_check_wght_valid_range(ttFont):
+  """The variable font 'wght' (Weight) axis coordinate
+     must be within spec range of 1 to 1000 on all instances."""
+
+  Failed = False
+  for instance in ttFont['fvar'].instances:
+    if 'wght' in instance.coordinates:
+      value = instance.coordinates['wght']
+      if value < 1 or value > 1000:
+        Failed = True
+        yield FAIL, (f"Found a bad wght coordinate with value '{value}'"
+                      " outside of the valid range from 1 to 1000.") 
+        break
+
+  if not Failed:
+    yield PASS, ("OK")

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -171,6 +171,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/fvar_name_entries' # All name entries referenced by fvar instances exist on the name table?
       , 'com.google.fonts/check/varfont_has_instances' # A variable font must have named instances.
       , 'com.google.fonts/check/varfont_weight_instances' # Variable font weight coordinates must be multiples of 100.
+      , 'com.google.fonts/check/wght_valid_range' # Weight axis coordinate must be within spec range of 1 to 1000 on all instances.
 ]
 
 specification = spec_factory(default_section=Section("Google Fonts"))

--- a/tests/specifications/fvar_test.py
+++ b/tests/specifications/fvar_test.py
@@ -219,3 +219,34 @@ def test_check_172():
   print('Test PASS with a good Bold:wght coordinage (700)...')
   status, message = list(check(ttFont, bold_weight_coord))[-1]
   assert status == PASS
+
+
+def test_check_wght_valid_range():
+  """ The variable font 'wght' (Weight) axis coordinate
+      must be within spec range of 1 to 1000 on all instances. """
+  from fontbakery.specifications.fvar import com_google_fonts_check_wght_valid_range as check
+
+  # Our reference varfont, CabinVFBeta.ttf, has
+  # all instances within the 1-1000 range
+  ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
+
+  # so it must PASS the test:
+  print('Test PASS with a good varfont...')
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+  # We then introduce a bad value:
+  ttFont["fvar"].instances[0].coordinates["wght"] = 0
+
+  # And it must FAIL the test
+  print('Test FAIL with wght=0...')
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL
+
+  # And yet another bad value:
+  ttFont["fvar"].instances[0].coordinates["wght"] = 1001
+
+  # Should also FAIL:
+  print('Test FAIL with wght=1001...')
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL


### PR DESCRIPTION
Weight axis coordinate must be within spec range of 1 to 1000 on all instances.

This pull request addresses the problems described at issue #2264 
