### PR TITLE
enabled CFF2 glyph_has_ink code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[com.google.fonts/check/153]:** Disable "expected contour count" check for variable fonts. There's plenty of alternative ways of constructing glyphs with multiple outlines for each feature in a VarFont. The expected contour count data for this check is currently optimized for the typical construction of glyphs in static fonts. (issue #2262)
+  - **[com.google.fonts/check/046]:** Removed restriction on CFF2 fonts because the helper method `glyph_has_ink` now handles `CFF2`.
+  - **[com.google.fonts/check/049]:** Removed restriction on CFF2 fonts because the helper method `glyph_has_ink` now handles `CFF2`.
+
 
 ## 0.6.5 (2018-Dec-10)
 ### New Checks

--- a/Lib/fontbakery/specifications/general.py
+++ b/Lib/fontbakery/specifications/general.py
@@ -408,8 +408,7 @@ def com_google_fonts_check_039(fontforge_check_results, fontforge_skip_checks):
 
 
 @check(
-  id = 'com.google.fonts/check/046',
-  conditions = ['not is_cff2']
+  id = 'com.google.fonts/check/046'
 )
 def com_google_fonts_check_046(ttFont):
   """Font contains .notdef as first glyph?
@@ -502,8 +501,7 @@ def com_google_fonts_check_048(ttFont):
 
 
 @check(
-  id = 'com.google.fonts/check/049',
-  conditions = ['not is_cff2']
+  id = 'com.google.fonts/check/049'
 )
 def com_google_fonts_check_049(ttFont):
   """Whitespace glyphs have ink?"""

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -212,18 +212,10 @@ def glyph_has_ink(font, name):
   """
   if 'glyf' in font:
     return ttf_glyph_has_ink(font, name)
-  elif 'CFF ' in font:
+  elif ('CFF ' in font) or ('CFF2' in font):
     return cff_glyph_has_ink(font, name)
   else:
-    raise Exception("Could not find 'glyf' or 'CFF ' table.")
-
-  # TODO: replace lines above with lines below once the bug in
-  #       the fonttools CFF2 charstring calcBounds method is fixed
-
-  # elif ('CFF ' in font) or ('CFF2' in font):
-  #   return cff_glyph_has_ink(font, name)
-  # else:
-  #   raise Exception("Could not find 'glyf', 'CFF ', or 'CFF2' table.")
+    raise Exception("Could not find 'glyf', 'CFF ', or 'CFF2' table.")
 
 
 def assert_results_contain(check_results, expected_status, expected_msgcode=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools>=3.19
+fonttools>=3.34
 protobuf>=3.4.0
 requests>=2.20.0
 beautifulsoup4==4.5.1

--- a/tests/specifications/general_test.py
+++ b/tests/specifications/general_test.py
@@ -530,12 +530,9 @@ def test_glyph_has_ink():
   print('Test if TTF glyph without ink has ink')
   assert(glyph_has_ink(ttf_test_font, 'space') is False)
 
-  # TODO: uncomment the lines below once the bug in the
-  #       fonttools CFF2 charstring calcBounds method is fixed
-
-  # cff2_test_font = TTFont(
-  #   'data/test/source-sans-pro/VAR/SourceSansVariable-Roman.otf')
-  # print('Test if CFF2 glyph with ink has ink')
-  # assert(glyph_has_ink(cff2_test_font, '.notdef') is True)
-  # print('Test if CFF2 glyph without ink has ink')
-  # assert(glyph_has_ink(cff2_test_font, 'space') is False)
+  cff2_test_font = TTFont(
+    'data/test/source-sans-pro/VAR/SourceSansVariable-Roman.otf')
+  print('Test if CFF2 glyph with ink has ink')
+  assert(glyph_has_ink(cff2_test_font, '.notdef') is True)
+  print('Test if CFF2 glyph without ink has ink')
+  assert(glyph_has_ink(cff2_test_font, 'space') is False)


### PR DESCRIPTION
(now that the CFF2 calcBounds method is working in the 3.34 release of fonttools)
