### PR TITLE
fix checkID variable in ghmarkdown reporter

### DIFF
--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -45,8 +45,7 @@ class GHMarkdownReporter(SerializeReporter):
 
     check["logs"].sort(key=lambda c: c["status"])
     logs = "".join(map(self.log_md, check["logs"]))
-    github_search_url = (f"[{checkid}](https://github.com/googlefonts/fontbakery/"
-                          "search?q={checkid})")
+    github_search_url = (f"[{checkid}](https://github.com/googlefonts/fontbakery/search?q={checkid})")
     return self.html5_collapsible("{} <b>{}:</b> {}".format(self.emoticon(check["result"]),
                                                             check["result"],
                                                             check["description"]),


### PR DESCRIPTION
This pull request addresses the problems described at issue #2272.

In my own tests, this seems to solve the issue. I am now getting URLs that search for the actual check ID, e.g. https://github.com/googlefonts/fontbakery/search?q=com.google.fonts/check/007.