### PR TITLE
new check: com.google.fonts/check/tnum_horizontal_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.6.7 (2019-Jan-21)
+### New checks
+  - **[com.google.fonts/check/tnum_horizontal_metrics]:** "All tabular figures must have the same width across the whole family." (issue #2278)
+
 ### Changes to existing checks
   - **[com.google.fonts/check/092 & 108]:** Use *Typographic Family Name* instead of *Font Family Name* if it exists in the font's name table.
 

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -171,6 +171,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/varfont_has_instances' # A variable font must have named instances.
       , 'com.google.fonts/check/varfont_weight_instances' # Variable font weight coordinates must be multiples of 100.
       , 'com.google.fonts/check/wght_valid_range' # Weight axis coordinate must be within spec range of 1 to 1000 on all instances.
+      , 'com.google.fonts/check/tnum_horizontal_metrics' # All tabular figures must have the same width across the whole family.
 ]
 
 specification = spec_factory(default_section=Section("Google Fonts"))
@@ -3658,6 +3659,53 @@ def com_google_fonts_check_varfont_weight_instances(ttFont):
                    " This should instead be a multiple of 100.")
 
   if not failed:
+    yield PASS, "OK"
+
+
+@check(
+  id = 'com.google.fonts/check/tnum_horizontal_metrics',
+  rationale = """
+    Tabular figures need to have the same metrics in all styles
+    in order to allow tables to be set with proper
+    typographic control, but to maintain the placement of
+    decimals and numeric columns between rows.
+
+    Here's a good explanation of this:
+    https://www.typography.com/techniques/fonts-for-financials/#tabular-figs
+  """,
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2278'
+  }
+)
+def com_google_fonts_check_tnum_horizontal_metrics(ttFonts):
+  """All tabular figures must have the same width across the whole family."""
+
+  tnum_widths = {}
+  for ttFont in ttFonts:
+    glyphs = ttFont.getGlyphSet()
+    tnum_glyphs = [glyphs[glyph_id]
+                   for glyph_id in glyphs.keys()
+                   if glyph_id.endswith(".tnum")]
+    for glyph in tnum_glyphs:
+
+      if glyph.width not in tnum_widths:
+        tnum_widths[glyph.width] = [glyph]
+      else:
+        tnum_widths[glyph.width].append(glyph)
+
+  if len(tnum_widths.keys()) > 1:
+    max_num = 0
+    most_common_width = None
+    for width, glyphs in tnum_widths.items():
+      if len(glyphs) > max_num:
+        max_num = len(glyphs)
+        most_common_width = width
+
+    del tnum_widths[most_common_width]
+    yield FAIL, ("The most common tabular glyph width is {most_common_width}."
+                 " But there are other tabular glyphs with different widths"
+                f" such as the following ones:\n\t{tnum_widths}.")
+  else:
     yield PASS, "OK"
 
 


### PR DESCRIPTION
"All tabular figures must have the same width across the whole family."

This pull request addresses the problems described at issue #2278