### PR TITLE
tweaking expected contour counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Deprecated checks
   - **[com.google.fonts/check/119]:** "TTFAutohint x-height increase value is same as in previous release on Google Fonts?". Marc Foley said: "Since we now have visual diffing, I would like to remove it. This test is also bunk because ttfautohint's results are not consistent when they update it." (issue #2280)
 
+### Other code changes
+  - Added more valid options of contour count values for Oslash and f_f_i glyphs (issue #1851)
+
 
 ## 0.6.6 (2018-Dec-20)
 ### New Checks

--- a/Lib/fontbakery/glyphdata.py
+++ b/Lib/fontbakery/glyphdata.py
@@ -1426,6 +1426,7 @@ desired_glyph_data = \
         "name": "Oslash", 
         "unicode": 216, 
         "contours": [
+            2,
             3
         ]
     }, 
@@ -11934,7 +11935,8 @@ desired_glyph_data = \
         "unicode": 64259, 
         "contours": [
             1, 
-            2, 
+            2,
+            3,
             4
         ]
     }, 


### PR DESCRIPTION
More valid options of contour count values for Oslash and f_f_i glyphs

This pull request addresses the problems described at issue #1851
 