### PR TITLE
Keep dependencies abstract on setup.py and concrete on requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ A more detailed list of changes is available in the corresponding milestones for
   - The HTML reporter now places the percentages summary before the check details.
   - updated dependencies on setup.py and requirements.txt to make sure we ship exactly what we test during development (issue #2174)
 
-### New dependencies
-  - **ufo2ft** from PyPI
-
 
 ## 0.6.6 (2018-Dec-20)
 ### New Checks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,21 @@
 --index-url https://pypi.python.org/simple/
+beautifulsoup4==4.7.1
+defcon==0.6.0
+defusedxml==0.5.0
+font-v==0.7.1
+fontTools==3.36.0
+lxml==4.3.0
+opentype-sanitizer==7.1.8
+protobuf==3.6.1
+requests==2.21.0
+ttfautohint-py==0.4.2
+ufolint==0.3.5
+Unidecode==1.0.23
 -e .
+
+# The following module is actually needed by fontTools:
+fs==2.2.1
+
+# This is only needed to run code-tests:
+#ufo2ft==2.6.0
+#pytest==4.1.1

--- a/setup.py
+++ b/setup.py
@@ -57,21 +57,20 @@ setup(
     python_requires='>=3.6',
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'beautifulsoup4==4.7.1',
-        'defcon==0.6.0',
-        'defusedxml==0.5.0',
-        'font-v==0.7.1',
-        'fontTools==3.36.0',  # 3.34 fixed some CFF2 issues, including calcBounds
-        'lxml==4.3.0',
-        'opentype-sanitizer==7.1.8',
-        'protobuf==3.6.1',
-        'requests==2.21.0',
-        'ttfautohint-py==0.4.2',
-        'ufo2ft==2.6.0',
-        'ufolint==0.3.5',
-        'Unidecode==1.0.23',
-        # The following 2 modules are actually needed by fontTools:
-        'fs==2.2.1'
+        'beautifulsoup4',
+        'defcon',
+        'defusedxml',
+        'font-v',
+        'fontTools>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
+        'lxml',
+        'opentype-sanitizer',
+        'protobuf',
+        'requests',
+        'ttfautohint-py',
+        'ufolint',
+        'Unidecode',
+        # The following module is actually needed by fontTools:
+        'fs'
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
Also, do not include dependencies only needed for running code-tests such as pytest and ufo2ft.

This pull request addresses the problems described at issue #2174
