### PR TITLE
Do not crash when font project is not in a git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+
+## 0.6.8 (2019-Jan-28)
+### Bugfixes ###
+  - **[FontBakeryCondition:licenses]:** Do not crash when font project is not in a git repo (issue #2296)
+
+
 ## 0.6.7 (2019-Jan-21)
 ### New checks
   - **[com.google.fonts/check/tnum_horizontal_metrics]:** "All tabular figures must have the same width across the whole family." (issue #2278)

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -755,7 +755,7 @@ def git_rootdir(family_dir):
     git_output = subprocess.check_output(git_cmd, stderr=subprocess.STDOUT)
     root_dir = git_output.decode("utf-8").strip()
 
-  except (OSError, IOError):
+  except (OSError, IOError, subprocess.CalledProcessError):
     pass # Not a git repo, or git is not installed.
 
   os.chdir(original_dir)


### PR DESCRIPTION
This pull request addresses the problems described at issue #2296