### PR TITLE
com.google.fonts/check/034: fix explanation of xAvgWidth on WARN/INFO messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bugfixes ###
   - **[com.google.fonts/check/034]:** fix explanation of xAvgWidth on WARN/INFO messages. (issue #2285)
 
+### Other code changes
+  - Adopting python type hint notation.
+
 
 ## 0.6.8 (2019-Jan-28)
 ### Bugfixes ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
+## 0.6.9 (2019-Fev-04)
+### Bugfixes ###
+  - **[com.google.fonts/check/034]:** fix explanation of xAvgWidth on WARN/INFO messages. (issue #2285)
+
+
 ## 0.6.8 (2019-Jan-28)
 ### Bugfixes ###
   - **[FontBakeryCondition:licenses]:** Do not crash when font project is not in a git repo (issue #2296)

--- a/Lib/fontbakery/specifications/head.py
+++ b/Lib/fontbakery/specifications/head.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 from fontbakery.callable import check
 from fontbakery.checkrunner import FAIL, PASS, WARN
 from fontbakery.message import Message
@@ -72,8 +73,7 @@ def com_google_fonts_check_043(ttFont):
                  " is reasonable.").format(upem)
 
 
-def parse_version_string(name):
-  # type: (str) -> Tuple[str, str]
+def parse_version_string(name: str) -> Tuple[str, str]:
   """Parse a version string (name ID 5) and return (major, minor) strings.
 
   Example of the expected format: 'Version 01.003; Comments'. Version

--- a/Lib/fontbakery/specifications/os2.py
+++ b/Lib/fontbakery/specifications/os2.py
@@ -67,6 +67,7 @@ def com_google_fonts_check_034(ttFont):
 
   # Since version 3, the average is computed using _all_ glyphs in a font.
   if ttFont['OS/2'].version >= 3:
+    calculation_rule = "the average of the widths of all glyphs in the font"
     if not ttFont['hmtx'].metrics:  # May contain just '.notdef', which is valid.
       yield FAIL, Message("missing-glyphs",
                           "CRITICAL: Found no glyph width data in the hmtx table!")
@@ -84,6 +85,8 @@ def com_google_fonts_check_034(ttFont):
 
     expected_value = int(round(width_sum / count))
   else:  # Version 2 and below only consider lowercase latin glyphs and space.
+    calculation_rule = ("the weighted average of the widths of the latin"
+                        " lowercase glyphs in the font")
     weightFactors = {
         'a': 64,
         'b': 14,
@@ -133,19 +136,14 @@ def com_google_fonts_check_034(ttFont):
   if current_value == expected_value or difference == 1:
     yield PASS, "OS/2 xAvgCharWidth value is correct."
   elif difference < ACCEPTABLE_ERROR:
-    yield INFO, ("OS/2 xAvgCharWidth is {} but should be"
-                  " {} which corresponds to the weighted"
-                  " average of the widths of the latin"
-                  " lowercase glyphs in the font."
+    yield INFO, (f"OS/2 xAvgCharWidth is {current_value} but it should be"
+                 f" {expected_value} which corresponds to {calculation_rule}."
                   " These are similar values, which"
                   " may be a symptom of the slightly different"
                   " calculation of the xAvgCharWidth value in"
                   " font editors. There's further discussion on"
                   " this at https://github.com/googlefonts/fontbakery"
-                  "/issues/1622").format(current_value, expected_value)
+                  "/issues/1622")
   else:
-    yield WARN, ("OS/2 xAvgCharWidth is {} but it should be "
-                  "{} which corresponds to the weighted "
-                  "average of the widths of the latin "
-                  "lowercase glyphs in "
-                  "the font").format(current_value, expected_value)
+    yield WARN, (f"OS/2 xAvgCharWidth is {current_value} but it should be"
+                 f" {expected_value} which corresponds to {calculation_rule}.")

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from fontTools.ttLib import TTFont
+from typing import Text, Optional
 
 def pretty_print_list(values):
   if len(values) == 1:
@@ -72,8 +74,7 @@ def name_entry_id(name):
                                   name.platformID)
 
 
-def get_glyph_name(font, codepoint):
-  # type: (fontTools.ttLib.TTFont, int) -> Optional[str]
+def get_glyph_name(font: TTFont, codepoint: int) -> Optional[str]:
   next_best_cmap = font.getBestCmap()
 
   if codepoint in next_best_cmap:
@@ -163,8 +164,7 @@ def download_file(url):
   return BytesIO(urlopen(url).read())
 
 
-def cff_glyph_has_ink(font, glyph_name):
-  # type: (TTFont, Text) -> bool
+def cff_glyph_has_ink(font: TTFont, glyph_name: Text) -> bool:
   if 'CFF2' in font:
     top_dict = font['CFF2'].cff.topDictIndex[0]
   else:
@@ -178,8 +178,7 @@ def cff_glyph_has_ink(font, glyph_name):
   return False
 
 
-def ttf_glyph_has_ink(font, name):
-  # type: (TTFont, Text) -> bool
+def ttf_glyph_has_ink(font: TTFont, name: Text) -> bool:
   glyph = font['glyf'].glyphs[name]
   glyph.expand(font['glyf'])
 
@@ -198,8 +197,7 @@ def ttf_glyph_has_ink(font, name):
   return False
 
 
-def glyph_has_ink(font, name):
-  # type: (TTFont, Text) -> bool
+def glyph_has_ink(font: TTFont, name: Text) -> bool:
   """Checks if specified glyph has any ink.
 
   That is, that it has at least one defined contour associated.


### PR DESCRIPTION
This pull request addresses the problems described at issue #2285
