### PR TITLE
[code-test] com.google.fonts/check/077 "glyphs have codepoints"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### new Code-tests
   - Code-coverage: 62% (down from 63% on v0.6.9)
-  - **[com.google.fonts/check/has_ttfautohint_params]** (issue #2312)
+  - **[com.google.fonts/check/has_ttfautohint_params]:** (issue #2312)
+  - **[com.google.fonts/check/077]:** "glyphs have codepoints" - Only the PASS code-path. I am unaware of any font that actually FAILs this check... (issue #2325)
 
 
 ## 0.6.9 (2019-Feb-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### new Code-tests
   - Code-coverage: 62% (down from 63% on v0.6.9)
   - **[com.google.fonts/check/has_ttfautohint_params]:** (issue #2312)
-  - **[com.google.fonts/check/077]:** "glyphs have codepoints" - Only the PASS code-path. I am unaware of any font that actually FAILs this check... (issue #2325)
+  - **[com.google.fonts/check/077]:** "glyphs have codepoints" - I am unaware of any font that actually FAILs this check, though... (issue #2325)
 
 
 ## 0.6.9 (2019-Feb-04)

--- a/tests/specifications/cmap_test.py
+++ b/tests/specifications/cmap_test.py
@@ -61,16 +61,22 @@ def NOT_IMPLEMENTED_test_check_076():
   # - PASS
 
 
+@pytest.mark.focus
+# Note: I am not aware of any real-case of a font that FAILs this check.
 def test_check_077():
   """ Check all glyphs have codepoints assigned. """
   from fontbakery.specifications.cmap import com_google_fonts_check_077 as check
 
-  print('Test PASS with good font.')
+  print('Test PASS with a good font.')
   # our reference Mada SemiBold is know to be good here.
   ttFont = TTFont("data/test/mada/Mada-SemiBold.ttf")
   status, message = list(check(ttFont))[-1]
   assert status == PASS
 
-  # TODO: other code-paths:
-  # - FAIL, "A glyph lacks a unicode codepoint assignment."
-  # Note: I am not aware of any real-case of a font that FAILs this check.
+  # This is a silly way to break the font.
+  # A much better test would rather use a real font file that has the problem.
+  ttFont['cmap'].tables[0].cmap[None] = "foo"
+
+  print('Test FAIL with a bad font.')
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL # "A glyph lacks a unicode codepoint assignment."

--- a/tests/specifications/cmap_test.py
+++ b/tests/specifications/cmap_test.py
@@ -61,11 +61,16 @@ def NOT_IMPLEMENTED_test_check_076():
   # - PASS
 
 
-def NOT_IMPLEMENTED_test_check_077():
+def test_check_077():
   """ Check all glyphs have codepoints assigned. """
-  # from fontbakery.specifications.googlefonts import com_google_fonts_check_077 as check
-  # TODO: Implement-me!
-  #
-  # code-paths:
+  from fontbakery.specifications.cmap import com_google_fonts_check_077 as check
+
+  print('Test PASS with good font.')
+  # our reference Mada SemiBold is know to be good here.
+  ttFont = TTFont("data/test/mada/Mada-SemiBold.ttf")
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+  # TODO: other code-paths:
   # - FAIL, "A glyph lacks a unicode codepoint assignment."
-  # - PASS
+  # Note: I am not aware of any real-case of a font that FAILs this check.


### PR DESCRIPTION
I am unaware of any font that actually FAILs this check...

This pull request addresses the problems described at issue #2325 
