### PR TITLE
[code-test] com.google.fonts/check/076 "unique unicode codepoints"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[fontTools]:** upgraded to 3.37.0
 
 ### new Code-tests
-  - Code-coverage: 62% (down from 63% on v0.6.9)
+  - Code-coverage: 63% (same as on v0.6.9)
   - **[com.google.fonts/check/has_ttfautohint_params]:** (issue #2312)
-  - **[com.google.fonts/check/077]:** "glyphs have codepoints" - I am unaware of any font that actually FAILs this check, though... (issue #2325)
+  - **[com.google.fonts/check/076]:** "glyphs have unique unicode codepoints" - (only PASS code-path) - I am unaware of any font that actually FAILs this check, though... (issue #2324)
+  - **[com.google.fonts/check/077]:** "all glyphs have codepoints" - I am unaware of any font that actually FAILs this check, though... (issue #2325)
 
 
 ## 0.6.9 (2019-Feb-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bugfixes
   - **[fontbakery.utils.download_file]:** Printing a message with a hint of a possible fix to "SSL bad certificate" when trying to download files. (issue #2274)
 
+### Deprecated checks
+  - **[com.google.fonts/check/076]:** "unique unicode codepoints" - This check seemd impossible to FAIL! (issue #2324)
+
 ### Dependencies (concrete deps on requirements.txt)
   - **[fontTools]:** upgraded to 3.37.0
 
 ### new Code-tests
   - Code-coverage: 63% (same as on v0.6.9)
   - **[com.google.fonts/check/has_ttfautohint_params]:** (issue #2312)
-  - **[com.google.fonts/check/076]:** "glyphs have unique unicode codepoints" - (only PASS code-path) - I am unaware of any font that actually FAILs this check, though... (issue #2324)
   - **[com.google.fonts/check/077]:** "all glyphs have codepoints" - I am unaware of any font that actually FAILs this check, though... (issue #2325)
 
 

--- a/Lib/fontbakery/specifications/cmap.py
+++ b/Lib/fontbakery/specifications/cmap.py
@@ -34,33 +34,6 @@ def com_google_fonts_check_013(ttFonts):
 # Mekkablue Preflight Checks available at:
 # https://github.com/mekkablue/Glyphs-Scripts/blob/master/Test/Preflight%20Font.py
 @check(
-  id = 'com.google.fonts/check/076',
-  misc_metadata = {
-    'request': 'https://github.com/googlefonts/fontbakery/issues/735'
-  }
-)
-def com_google_fonts_check_076(ttFont):
-  """Check glyphs have unique unicode codepoints."""
-  failed = False
-  for subtable in ttFont['cmap'].tables:
-    if subtable.isUnicode():
-      codepoints = {}
-      for codepoint, name in subtable.cmap.items():
-        codepoints.setdefault(codepoint, set()).add(name)
-      for value in codepoints.keys():
-        if len(codepoints[value]) >= 2:
-          failed = True
-          yield FAIL, ("These glyphs carry the same"
-                       " unicode value {}:"
-                       " {}").format(value, ", ".join(codepoints[value]))
-  if not failed:
-    yield PASS, "All glyphs have unique unicode codepoint assignments."
-
-
-# This check was originally ported from
-# Mekkablue Preflight Checks available at:
-# https://github.com/mekkablue/Glyphs-Scripts/blob/master/Test/Preflight%20Font.py
-@check(
   id = 'com.google.fonts/check/077',
   misc_metadata = {
     'request': 'https://github.com/googlefonts/fontbakery/issues/735'

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -91,7 +91,6 @@ expected_check_ids = [
       , 'com.google.fonts/check/073' # MaxAdvanceWidth is consistent with values in the Hmtx and Hhea tables?
       , 'com.google.fonts/check/074' # Are there non-ASCII characters in ASCII-only NAME table entries?
       , 'com.google.fonts/check/075' # Check for points out of bounds.
-      , 'com.google.fonts/check/076' # Check glyphs have unique unicode codepoints.
       , 'com.google.fonts/check/077' # Check all glyphs have codepoints assigned.
       #, 'com.google.fonts/check/078' # Check that glyph names do not exceed max length.
       , 'com.google.fonts/check/079' # Monospace font has hhea.advanceWidthMax equal to each glyph's advanceWidth?

--- a/tests/specifications/cmap_test.py
+++ b/tests/specifications/cmap_test.py
@@ -51,17 +51,21 @@ def test_check_013(mada_ttFonts):
   assert status == FAIL
 
 
-def NOT_IMPLEMENTED_test_check_076():
+# Note: I am not aware of any real-case of a font that FAILs this check.
+def test_check_076():
   """ Check glyphs have unique unicode codepoints. """
-  # from fontbakery.specifications.googlefonts import com_google_fonts_check_076 as check
-  # TODO: Implement-me!
-  #
-  # code-paths:
+  from fontbakery.specifications.cmap import com_google_fonts_check_076 as check
+
+  print('Test PASS with a good font.')
+  # our reference Mada SemiBold is know to be good here.
+  ttFont = TTFont("data/test/mada/Mada-SemiBold.ttf")
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+  # TODO: other code-paths:
   # - FAIL, "Some glyphs carry the same unicode value."
-  # - PASS
 
 
-@pytest.mark.focus
 # Note: I am not aware of any real-case of a font that FAILs this check.
 def test_check_077():
   """ Check all glyphs have codepoints assigned. """

--- a/tests/specifications/cmap_test.py
+++ b/tests/specifications/cmap_test.py
@@ -52,21 +52,6 @@ def test_check_013(mada_ttFonts):
 
 
 # Note: I am not aware of any real-case of a font that FAILs this check.
-def test_check_076():
-  """ Check glyphs have unique unicode codepoints. """
-  from fontbakery.specifications.cmap import com_google_fonts_check_076 as check
-
-  print('Test PASS with a good font.')
-  # our reference Mada SemiBold is know to be good here.
-  ttFont = TTFont("data/test/mada/Mada-SemiBold.ttf")
-  status, message = list(check(ttFont))[-1]
-  assert status == PASS
-
-  # TODO: other code-paths:
-  # - FAIL, "Some glyphs carry the same unicode value."
-
-
-# Note: I am not aware of any real-case of a font that FAILs this check.
 def test_check_077():
   """ Check all glyphs have codepoints assigned. """
   from fontbakery.specifications.cmap import com_google_fonts_check_077 as check

--- a/tests/specifications/external_spec_test.py
+++ b/tests/specifications/external_spec_test.py
@@ -56,7 +56,7 @@ def test_spec_imports():
   ]
   # Probe some tests
   expected_tests = [
-      "com.google.fonts/check/076", # in cmap
+      "com.google.fonts/check/077", # in cmap
       "com.google.fonts/check/043"  # in head
   ]
   _test(spec_imports, expected_tests)
@@ -87,7 +87,7 @@ def test_spec_imports():
   )
   # Probe some tests
   expected_tests = [
-      "com.google.fonts/check/076", # in cmap
+      "com.google.fonts/check/077", # in cmap
       "com.google.fonts/check/043"  # in head
   ]
   _test(spec_imports, expected_tests)
@@ -114,7 +114,7 @@ def test_spec_imports():
   )
   # Probe some tests
   expected_tests = [
-      "com.google.fonts/check/076", # in cmap
+      "com.google.fonts/check/077", # in cmap
       "com.google.fonts/check/043"  # in head
   ]
   _test(spec_imports, expected_tests)


### PR DESCRIPTION
I am unaware of any font that actually FAILs this check...

This pull request addresses the problems described at issue #2324 
