### PR TITLE
Add link to docs in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Font Bakery has an active community of contributors from foundries around the wo
 Font Bakery is not an official Google project, and Google provides no support for it.
 However, throughout 2018 the core project maintainers Felipe Corrêa da Silva Sanches <juca@members.fsf.org> and Lasse Fister <commander@graphicore.de> were funded by the Google Fonts team.
 
+## Docs
+
+Find the full docs at https://font-bakery.readthedocs.io
+
 ## License
 
 Font Bakery is available under the Apache 2.0 license.


### PR DESCRIPTION
I'm not sure this is the exact best place to add a link, but I couldn't find any link to the docs from the front page of the repo, so I think we should add it here or somewhere easily visible and accessible.