### PR TITLE
new check: com.google.fonts/check/integer_ppem_if_hinted "PPEM must be an integer on hinted fonts."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.6.11 (2019-Feb-18)
+### New checks
+  - **[com.google.fonts/check/integer_ppem_if_hinted]:** "PPEM must be an integer on hinted fonts." (issue #2338)
+
+### New conditions
+  - **[is_hinted]:** allows restricting certain checks to only run on hinted fonts. Detection is based on the presence of an "fpgm" (Font Program) table.
+
 ### Bugfixes
   - **[fontbakery.utils.download_file]:** Fix error message when ssl certificates are not installed. (issue #2346)
 

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -1359,7 +1359,6 @@ def test_check_099():
     assert status == FAIL
 
 
-@pytest.mark.wip
 def test_check_100():
   """ METADATA.pb font.filename field contains font name in right format ? """
   from fontbakery.specifications.googlefonts import (com_google_fonts_check_100 as check,
@@ -2711,6 +2710,28 @@ def test_check_varfont_weight_instances():
   # Let's then change the weight coordinates to make it PASS the check:
   for i, instance in enumerate(ttFont["fvar"].instances):
     ttFont["fvar"].instances[i].coordinates['wght'] -= instance.coordinates['wght'] % 100
+
+  print ("Test PASS with a good font...")
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+
+def test_check_integer_ppem_if_hinted():
+  """ PPEM must be an integer on hinted fonts. """
+  from fontbakery.specifications.googlefonts import com_google_fonts_check_integer_ppem_if_hinted as check
+
+  # Our reference Merriweather Regular is hinted, but does not set
+  # the "rounded PPEM" flag (bit 3 on the head table flags) as
+  # described at https://docs.microsoft.com/en-us/typography/opentype/spec/head
+  ttFont = TTFont("data/test/merriweather/Merriweather-Regular.ttf")
+
+  # So it must FAIL the check:
+  print ("Test FAIL with a bad font...")
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL
+
+  # hotfixing it should make it PASS:
+  ttFont["head"].flags |= (1 << 3)
 
   print ("Test PASS with a good font...")
   status, message = list(check(ttFont))[-1]


### PR DESCRIPTION
This pull request addresses the problems described at issue #2338 
