### PR TITLE
Determine whether a font is monospaced by analysing the ascii charset only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Bugfixes
   - **[fontbakery.utils.download_file]:** Fix error message when ssl certificates are not installed. (issue #2346)
+  - **[fontbakery.specifications.shared_conditions]:** Determine whether a font is monospaced by analysing the ascii character set only.
 
 
 ## 0.6.10 (2019-Feb-11)

--- a/Lib/fontbakery/specifications/hhea.py
+++ b/Lib/fontbakery/specifications/hhea.py
@@ -5,7 +5,7 @@ from fontbakery.message import Message
 from fontbakery.fonts_spec import spec_factory # NOQA pylint: disable=unused-import
 
 spec_imports = [
-    ('.shared_conditions', ('seems_monospaced', 'monospace_stats', 'is_ttf'))
+    ('.shared_conditions', ('glyph_metrics_stats', 'is_ttf'))
 ]
 
 @check(
@@ -45,7 +45,7 @@ def com_google_fonts_check_073(ttFont):
 
 @check(
   id = 'com.google.fonts/check/079',
-  conditions = ['seems_monospaced']
+  conditions = ['glyph_metrics_stats']
 )
 def com_google_fonts_check_079(ttFont):
   """Monospace font has hhea.advanceWidthMax equal to each glyph's

--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -8,7 +8,7 @@ from fontbakery.constants import (PriorityLevel,
 from fontbakery.fonts_spec import spec_factory # NOQA pylint: disable=unused-import
 
 spec_imports = [
-    ('.shared_conditions', ('seems_monospaced', 'monospace_stats'))
+    ('.shared_conditions', ('glyph_metrics_stats', ))
 ]
 
 @check(
@@ -38,10 +38,10 @@ def com_google_fonts_check_031(ttFont):
 
 @check(
   id = 'com.google.fonts/check/033',
-  conditions = ['monospace_stats',
+  conditions = ['glyph_metrics_stats',
                 'is_ttf']
 )
-def com_google_fonts_check_033(ttFont, monospace_stats):
+def com_google_fonts_check_033(ttFont, glyph_metrics_stats):
   """Checking correctness of monospaced metadata.
 
   There are various metadata in the OpenType spec to specify if
@@ -80,9 +80,9 @@ def com_google_fonts_check_033(ttFont, monospace_stats):
   failed = False
   # Note: These values are read from the dict here only to
   # reduce the max line length in the check implementation below:
-  seems_monospaced = monospace_stats["seems_monospaced"]
-  most_common_width = monospace_stats["most_common_width"]
-  width_max = monospace_stats['width_max']
+  seems_monospaced = glyph_metrics_stats["seems_monospaced"]
+  most_common_width = glyph_metrics_stats["most_common_width"]
+  width_max = glyph_metrics_stats['width_max']
 
   if ttFont['hhea'].advanceWidthMax != width_max:
     failed = True

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -51,7 +51,7 @@ def results_contain(results, expected_status, expected_code):
 def test_check_033():
   """ Checking correctness of monospaced metadata. """
   from fontbakery.specifications.name import com_google_fonts_check_033 as check
-  from fontbakery.specifications.shared_conditions import monospace_stats
+  from fontbakery.specifications.shared_conditions import glyph_metrics_stats
   from fontbakery.constants import (PANOSE_Proportion,
                                     IsFixedWidth)
 
@@ -66,7 +66,7 @@ def test_check_033():
   # Our reference Mada Regular is a non-monospace font
   # know to have good metadata for this check.
   ttFont = TTFont("data/test/mada/Mada-Regular.ttf")
-  stats = monospace_stats(ttFont)
+  stats = glyph_metrics_stats(ttFont)
   status, message = list(check(ttFont, stats))[-1]
   assert status == PASS and message.code == "good"
 
@@ -93,7 +93,7 @@ def test_check_033():
   # Our reference OverpassMono Regular is know to be
   # a monospaced font with good metadata here.
   ttFont = TTFont("data/test/overpassmono/OverpassMono-Regular.ttf")
-  stats = monospace_stats(ttFont)
+  stats = glyph_metrics_stats(ttFont)
   status, message = list(check(ttFont, stats))[-1]
   # WARN is emitted when there's at least one outlier.
   # I don't see a good reason to be picky and also test that one separately here...


### PR DESCRIPTION
Some Chinese fonts contain proportional Latin glyphs. These fonts such as Apple's PingFanHK have post.isFixedPitch set to 0. This means [they're not classes as monospace fonts](https://docs.microsoft.com/en-us/typography/opentype/spec/post).

Our current implementation will classify all CJK fonts as being monospaced because every glyph width is taken into consideration. This pr will only count a font as being monospaced if the ascii glyphs have the same width. I set the range to start from 32 onwards because these first 32 glyphs are contrrol characters.


I also did a general tidyup of this function as well.



Fixes #2202