### PR TITLE
WIP: Refactor name checks

### DIFF
--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -3091,9 +3091,7 @@ def com_google_fonts_check_162(ttFont, style):
   from unidecode import unidecode
   from fontbakery.utils import name_entry_id
 
-  filename = os.path.basename(ttFont.reader.file.name)
-  expected_value = filename.split('-')[1][:-4]
-
+  expected_value = font_filename(ttFont).split('-')[1][:-4]
   failed = False
 
   if style in ['Regular',
@@ -3112,18 +3110,21 @@ def com_google_fonts_check_162(ttFont, style):
       failed = True
       yield FAIL, ("Font style '{}' is not similar to "
                    "filename '{}'".format(style,
-                                          filename))
+                                          expected_value))
   else:
     has_entry = False
-    for name in ttFont['name'].names:
-      if name.nameID == NameID.TYPOGRAPHIC_SUBFAMILY_NAME:
-        if name.toUnicode().replace(" ", "") == expected_value:
-          has_entry = True
-        else:
-          failed = True
-          yield FAIL, Message("non-ribbi-bad-value",
-                             ("Typographic Style name {} is not similar "
-                              "to filename {}".format(name.toUnicode(), filename)))
+    typo_subfamily_name_records = [ttFont['name'].getName(17, 1, 0, 0),
+                                   ttFont['name'].getName(17, 3, 1, 1033)]
+    typo_subfamily_names = [r for r in typo_subfamily_name_records if r]
+    for name in typo_subfamily_names:
+      if name.toUnicode().replace(" ", "") == expected_value:
+        has_entry = True
+      else:
+        failed = True
+        yield FAIL, Message("non-ribbi-bad-value",
+                           ("Typographic Style name '{}' is not similar "
+                            "to filename '{}'".format(name.toUnicode(),
+                                                      expected_value)))
     if not failed and not has_entry:
       failed = True
       yield FAIL, Message("non-ribbi-lacks-entry",

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2888,50 +2888,21 @@ def get_only_weight(value):
   conditions = ['style',
                 'familyname'],
   rationale = """
-    Checks that the family name infered from the font filename
-    matches the string at nameID 1 (NAMEID_FONT_FAMILY_NAME)
-    if it conforms to RIBBI and otherwise checks that nameID 1
-    is the family name + the style name.
+    Check the font family name plus style name resemble the font
+    filename.
   """,
   misc_metadata = {
     'priority': PriorityLevel.IMPORTANT
   })
 def com_google_fonts_check_157(ttFont, style, familyname):
   """ Check name table: FONT_FAMILY_NAME entries. """
-  from fontbakery.utils import name_entry_id
-  failed = False
-  only_weight = get_only_weight(style)
-  for name in ttFont['name'].names:
-    if name.nameID == NameID.FONT_FAMILY_NAME:
-
-      if name.platformID == PlatformID.MACINTOSH:
-        expected_value = familyname
-
-      elif name.platformID == PlatformID.WINDOWS:
-        if style in ['Regular',
-                     'Italic',
-                     'Bold',
-                     'Bold Italic']:
-          expected_value = familyname
-        else:
-          expected_value = " ".join([familyname,
-                                     only_weight]).strip()
-      else:
-        failed = True
-        yield FAIL, ("Font should not have a "
-                     "{} entry!").format(name_entry_id(name))
-        continue
-
-      string = name.string.decode(name.getEncoding()).strip()
-      if string != expected_value:
-        failed = True
-        yield FAIL, ("Entry {} on the 'name' table: "
-                     "Expected '{}' "
-                     "but got '{}'.").format(name_entry_id(name),
-                                             expected_value,
-                                             string)
-  if not failed:
-    yield PASS, "FONT_FAMILY_NAME entries are all good."
+  target = "{}-{}".format(familyname.replace(" ", ""), style.replace(" ", ""))
+  filename = os.path.basename(ttFont.reader.file.name)[:-4]
+  if target == filename:
+    yield PASS, ("Font family name matches font filename")
+  else:
+    yield FAIL, ("Font family name {} does not match font filename {}".format(
+                 target, filename))
 
 
 @check(

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -3009,16 +3009,18 @@ def com_google_fonts_check_160(ttFont, style, familyname):
   from fontbakery.utils import name_entry_id
 
   failed = False
-  for name in ttFont['name'].names:
-    if name.nameID == NameID.POSTSCRIPT_NAME:
-      expected_value = f"{familyname}-{style}"
-
-      string = name.string.decode(name.getEncoding()).strip()
+  ps_name_records = [ttFont['name'].getName(6, 1, 0, 0),
+                     ttFont['name'].getName(6, 3, 1, 1033)]
+  ps_names = [r for r in ps_name_records if r]
+  expected_value = "{}-{}".format(familyname.replace(" ", ""),
+                                  style.replace(" ", ""))
+  for ps_name in ps_names:
+      string = ps_name.toUnicode().strip()
       if string != expected_value:
         failed = True
         yield FAIL, ("Entry {} on the 'name' table: "
                      "Expected '{}' "
-                     "but got '{}'.").format(name_entry_id(name),
+                     "but got '{}'.").format(name_entry_id(ps_name),
                                              expected_value,
                                              unidecode(string))
   if not failed:

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -3054,21 +3054,22 @@ def com_google_fonts_check_161(ttFont, style, familyname):
                                                  name_entry_id(name)))
   else:
     # Check typographic family name resembles filename
-    expected_value = os.path.basename(ttFont.reader.file.name).split("-")[0]
+    family_filename = font_filename(ttFont).split("-")[0]
     has_entry = False
-    for name in ttFont['name'].names:
-      if name.nameID == NameID.TYPOGRAPHIC_FAMILY_NAME:
-        string = name.toUnicode().replace(" ", "")
-        if string == expected_value:
-          has_entry = True
-        else:
+    typo_family_name_records = [ttFont['name'].getName(16, 1, 0, 0),
+                                ttFont['name'].getName(16, 3, 1, 1033)]
+    typo_family_names = [r for r in typo_family_name_records if r]
+    for name in typo_family_names:
+      if name.toUnicode().replace(" ", "") == family_filename:
+        has_entry = True
+      else:
           failed = True
           yield FAIL, Message("non-ribbi-bad-value",
-                              ("Entry {} on the 'name' table: "
-                               "Expected '{}' "
-                               "but got '{}'.").format(name_entry_id(name),
-                                                       expected_value,
-                                                       unidecode(string)))
+                              ("Entry {} on the 'name' table: '{}' "
+                               "is not similar to "
+                               "filename '{}'").format(name_entry_id(name),
+                                                       family_filename,
+                                                       unidecode(name.toUnicode())))
     if not failed and not has_entry:
       failed = True
       yield FAIL, Message("non-ribbi-lacks-entry",

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -2968,11 +2968,12 @@ def com_google_fonts_check_159(ttFont,
   from unidecode import unidecode
   from fontbakery.utils import name_entry_id
   failed = False
-  for name in ttFont['name'].names:
-    if name.nameID == NameID.FULL_FONT_NAME:
-      expected_value = "{} {}".format(familyname,
-                                      style)
-      string = name.string.decode(name.getEncoding()).strip()
+  full_name_records = [ttFont['name'].getName(4, 1, 0, 0),
+                       ttFont['name'].getName(4, 3, 1, 1033)]
+  full_names = [r for r in full_name_records if r]
+  expected_value = "{} {}".format(familyname, style)
+  for full_name in full_names:
+      string = full_name.toUnicode().strip()
       if string != expected_value:
         failed = True
         # special case
@@ -2982,12 +2983,12 @@ def com_google_fonts_check_159(ttFont,
           yield WARN, ("Entry {} on the 'name' table:"
                        " Got '{}' which lacks 'Regular',"
                        " but it is probably OK in this case."
-                       "").format(name_entry_id(name),
+                       "").format(name_entry_id(full_name),
                                   unidecode(string))
         else:
           yield FAIL, ("Entry {} on the 'name' table: "
                        "Expected '{}' "
-                       "but got '{}'.").format(name_entry_id(name),
+                       "but got '{}'.").format(name_entry_id(full_name),
                                                expected_value,
                                                unidecode(string))
 

--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -361,7 +361,7 @@ def com_google_fonts_check_163(ttFont):
     familyname_str = familyname.string.decode(familyname.getEncoding())
     for stylename_str in get_name_entry_strings(ttFont,
                                                 NameID.FONT_SUBFAMILY_NAME,
-                                                platformID=plat):
+                                                platformID=[plat]):
       if len(familyname_str + stylename_str) > 20:
         failed = True
         yield WARN, ("The combined length of family and style"

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -49,9 +49,9 @@ def get_name_entries(font,
   results = []
   for entry in font['name'].names:
     if entry.nameID == nameID and \
-       (platformID is None or entry.platformID == platformID) and \
-       (encodingID is None or entry.platEncID == encodingID) and \
-       (langID is None or entry.langID == langID):
+       (platformID is None or entry.platformID in platformID) and \
+       (encodingID is None or entry.platEncID in encodingID) and \
+       (langID is None or entry.langID in langID):
       results.append(entry)
   return results
 

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -2169,19 +2169,6 @@ def test_check_158():
                                  familyname(ttFont)))[-1]
     assert status == PASS
 
-  # - FAIL, "invalid-entry" - "Font should not have a certain name table entry."
-  filename = "data/test/montserrat/Montserrat-ThinItalic.ttf"
-  print ("Test FAIL 'invalid-entry'...")
-  ttFont = TTFont(filename)
-  # We setup a bad entry:
-  ttFont["name"].names[0].nameID = NameID.FONT_SUBFAMILY_NAME
-  ttFont["name"].names[0].platformID = PlatformID.CUSTOM
-  # And this should now FAIL:
-  status, message = list(check(ttFont,
-                               style(ttFont),
-                               familyname(ttFont)))[-1]
-  assert status == FAIL and message.code == "invalid-entry"
-
 
   # - FAIL, "bad-familyname" - "Bad familyname value on a FONT_SUBFAMILY_NAME entry."
   filename = "data/test/montserrat/Montserrat-ThinItalic.ttf"

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -2088,7 +2088,6 @@ def test_check_157():
   from fontbakery.constants import PlatformID, NameID
   from fontbakery.specifications.googlefonts import (com_google_fonts_check_157 as check,
                                                      familyname,
-                                                     familyname_with_spaces,
                                                      style)
   test_cases = [
   # expect             filename                                   mac_value        win_value
@@ -2116,7 +2115,7 @@ def test_check_157():
     print (f"Test {expected} with filename='{filename}', value='{value}', style='{style(filename)}'...")
     status, message = list(check(ttFont,
                                  style(filename),
-                                 familyname_with_spaces(familyname(filename))))[-1]
+                                 familyname(ttFont)))[-1]
     assert status == expected
 
 
@@ -2125,7 +2124,6 @@ def test_check_158():
   from fontbakery.constants import PlatformID, NameID
   from fontbakery.specifications.googlefonts import (com_google_fonts_check_158 as check,
                                                      familyname,
-                                                     familyname_with_spaces,
                                                      style_with_spaces)
 
   PASS_test_cases = [
@@ -2168,7 +2166,7 @@ def test_check_158():
     print (f"Test PASS with filename='{filename}', value='{value}', style_with_spaces='{style_with_spaces(filename)}'...")
     status, message = list(check(ttFont,
                                  style_with_spaces(filename),
-                                 familyname_with_spaces(familyname(filename))))[-1]
+                                 familyname(ttFont)))[-1]
     assert status == PASS
 
   # - FAIL, "invalid-entry" - "Font should not have a certain name table entry."
@@ -2181,7 +2179,7 @@ def test_check_158():
   # And this should now FAIL:
   status, message = list(check(ttFont,
                                style_with_spaces(filename),
-                               familyname_with_spaces(familyname(filename))))[-1]
+                               familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "invalid-entry"
 
 
@@ -2195,7 +2193,7 @@ def test_check_158():
   # And this should now FAIL:
   status, message = list(check(ttFont,
                                style_with_spaces(filename),
-                               familyname_with_spaces(familyname(filename))))[-1]
+                               familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "bad-familyname"
 
 
@@ -2258,8 +2256,7 @@ def test_check_161():
   """ Check name table: TYPOGRAPHIC_FAMILY_NAME entries. """
   from fontbakery.specifications.googlefonts import (com_google_fonts_check_161 as check,
                                                      style,
-                                                     familyname,
-                                                     familyname_with_spaces)
+                                                     familyname)
 
   # RIBBI fonts must not have a TYPOGRAPHIC_FAMILY_NAME entry
   font = "data/test/montserrat/Montserrat-BoldItalic.ttf"
@@ -2267,7 +2264,7 @@ def test_check_161():
   print (f"Test PASS with a RIBBI without nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
                                style(font),
-                               familyname_with_spaces(familyname(font))))[-1]
+                               familyname(ttFont)))[-1]
   assert status == PASS
 
   # so we add one and make sure is emits a FAIL:
@@ -2275,7 +2272,7 @@ def test_check_161():
   print (f"Test FAIL with a RIBBI that has got a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
                                style(font),
-                               familyname_with_spaces(familyname(font))))[-1]
+                               familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "ribbi"
 
   # non-RIBBI fonts must have a TYPOGRAPHIC_FAMILY_NAME entry
@@ -2284,7 +2281,7 @@ def test_check_161():
   print (f"Test PASS with a non-RIBBI containing a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
                                style(font),
-                               familyname_with_spaces(familyname(font))))[-1]
+                               familyname(ttFont)))[-1]
   assert status == PASS
 
   # set bad values on all TYPOGRAPHIC_FAMILY_NAME entries:
@@ -2295,7 +2292,7 @@ def test_check_161():
   print (f"Test FAIL with a non-RIBBI with bad nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entries...")
   status, message = list(check(ttFont,
                                style(font),
-                               familyname_with_spaces(familyname(font))))[-1]
+                               familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "non-ribbi-bad-value"
 
   # remove all TYPOGRAPHIC_FAMILY_NAME entries
@@ -2307,7 +2304,7 @@ def test_check_161():
   print (f"Test FAIL with a non-RIBBI lacking a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
                                style(font),
-                               familyname_with_spaces(familyname(font))))[-1]
+                               familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "non-ribbi-lacks-entry"
 
 
@@ -2404,7 +2401,7 @@ def test_check_165():
   # namecheck.fontdata.com database.
   font = "data/test/cabin/Cabin-Regular.ttf"
   ttFont = TTFont(font)
-  status, message = list(check(ttFont, familyname(font)))[-1]
+  status, message = list(check(ttFont, familyname(ttFont)))[-1]
   assert status == INFO
 
   print('Test PASS with a unique family name...')
@@ -2412,7 +2409,7 @@ def test_check_165():
   # registered as a real family.
   font = "data/test/familysans/FamilySans-Regular.ttf"
   ttFont = TTFont(font)
-  status, message = list(check(ttFont, familyname(font)))[-1]
+  status, message = list(check(ttFont, familyname(ttFont)))[-1]
   assert status == PASS
 
 

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -414,28 +414,28 @@ def test_check_020():
   font = "data/test/mada/Mada-Regular.ttf"
   print(f"Test FAIL with bad font '{font}' ...")
   ttFont = TTFont(font)
-  status, message = list(check(font, ttFont, style(font)))[-1]
+  status, message = list(check(font, ttFont, style(ttFont)))[-1]
   assert status == FAIL
 
   # All fonts in our reference Cabin family are know to be good here.
   for font in cabin_fonts:
     print(f"Test PASS with good font '{font}' ...")
     ttFont = TTFont(font)
-    status, message = list(check(font, ttFont, style(font)))[-1]
+    status, message = list(check(font, ttFont, style(ttFont)))[-1]
     assert status == PASS
 
   font = "data/test/montserrat/Montserrat-Thin.ttf"
   ttFont = TTFont(font)
   ttFont["OS/2"].usWeightClass = 100
   print("Test WARN with a Thin:100 TTF...")
-  status, message = list(check(font, ttFont, style(font)))[-1]
+  status, message = list(check(font, ttFont, style(ttFont)))[-1]
   assert status == WARN
 
   font = "data/test/montserrat/Montserrat-ExtraLight.ttf"
   ttFont = TTFont(font)
   ttFont["OS/2"].usWeightClass = 200
   print("Test WARN with an ExtraLight:200 TTF...")
-  status, message = list(check(font, ttFont, style(font)))[-1]
+  status, message = list(check(font, ttFont, style(ttFont)))[-1]
   assert status == WARN
 
   # TODO: test FAIL with a Thin:100 OTF
@@ -1146,7 +1146,7 @@ def test_check_095():
   family_directory = os.path.dirname(font)
   family_meta = family_metadata(family_directory)
   font_meta = font_metadata(family_meta, font)
-  font_style = style(font)
+  font_style = style(ttFont)
   status, message = list(check(ttFont, font_style, font_meta))[-1]
   assert status == PASS
 
@@ -1268,7 +1268,7 @@ def test_check_098():
   # Our reference Montserrat family is a good 18-styles family:
   for fontfile in MONTSERRAT_RIBBI:
     ttFont = TTFont(fontfile)
-    font_style = style(fontfile)
+    font_style = style(ttFont)
     family_directory = os.path.dirname(fontfile)
     family_meta = family_metadata(family_directory)
     font_meta = font_metadata(family_meta, fontfile)
@@ -1289,7 +1289,7 @@ def test_check_098():
   #we do the same for NON-RIBBI styles:
   for fontfile in MONTSERRAT_NON_RIBBI:
     ttFont = TTFont(fontfile)
-    font_style = style(fontfile)
+    font_style = style(ttFont)
     family_directory = os.path.dirname(fontfile)
     family_meta = family_metadata(family_directory)
     font_meta = font_metadata(family_meta, fontfile)
@@ -1319,7 +1319,7 @@ def test_check_099():
   # Our reference Montserrat family is a good 18-styles family:
   for fontfile in MONTSERRAT_RIBBI:
     ttFont = TTFont(fontfile)
-    font_style = style(fontfile)
+    font_style = style(ttFont)
     family_directory = os.path.dirname(fontfile)
     family_meta = family_metadata(family_directory)
     font_meta = font_metadata(family_meta, fontfile)
@@ -1340,7 +1340,7 @@ def test_check_099():
   #we do the same for NON-RIBBI styles:
   for fontfile in MONTSERRAT_NON_RIBBI:
     ttFont = TTFont(fontfile)
-    font_style = style(fontfile)
+    font_style = style(ttFont)
     family_directory = os.path.dirname(fontfile)
     family_meta = family_metadata(family_directory)
     font_meta = font_metadata(family_meta, fontfile)
@@ -1975,7 +1975,7 @@ def test_check_154(cabin_ttFonts):
     if remote:
       for font in cabin_fonts:
         ttFont = TTFont(font)
-        gfont = api_gfonts_ttFont(style(font), remote)
+        gfont = api_gfonts_ttFont(style(ttFont), remote)
 
         # Cabin font hosted on fonts.google.com contains
         # all the glyphs for the font in data/test/cabin
@@ -2112,9 +2112,9 @@ def test_check_157():
 
       if name.nameID == NameID.FONT_FAMILY_NAME:
           ttFont['name'].names[i].string = value.encode(name.getEncoding())
-    print (f"Test {expected} with filename='{filename}', value='{value}', style='{style(filename)}'...")
+    print (f"Test {expected} with filename='{filename}', value='{value}', style='{style(ttFont)}'...")
     status, message = list(check(ttFont,
-                                 style(filename),
+                                 style(ttFont),
                                  familyname(ttFont)))[-1]
     assert status == expected
 
@@ -2124,7 +2124,7 @@ def test_check_158():
   from fontbakery.constants import PlatformID, NameID
   from fontbakery.specifications.googlefonts import (com_google_fonts_check_158 as check,
                                                      familyname,
-                                                     style_with_spaces)
+                                                     style)
 
   PASS_test_cases = [
   #  filename                                                mac_value             win_value
@@ -2163,9 +2163,9 @@ def test_check_158():
 
       if name.nameID == NameID.FONT_SUBFAMILY_NAME:
           ttFont['name'].names[i].string = value.encode(name.getEncoding())
-    print (f"Test PASS with filename='{filename}', value='{value}', style_with_spaces='{style_with_spaces(filename)}'...")
+    print (f"Test PASS with filename='{filename}', value='{value}', style='{style(ttFont)}'...")
     status, message = list(check(ttFont,
-                                 style_with_spaces(filename),
+                                 style(ttFont),
                                  familyname(ttFont)))[-1]
     assert status == PASS
 
@@ -2178,7 +2178,7 @@ def test_check_158():
   ttFont["name"].names[0].platformID = PlatformID.CUSTOM
   # And this should now FAIL:
   status, message = list(check(ttFont,
-                               style_with_spaces(filename),
+                               style(ttFont),
                                familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "invalid-entry"
 
@@ -2192,7 +2192,7 @@ def test_check_158():
   ttFont["name"].names[0].string = "Foo".encode(ttFont["name"].names[0].getEncoding())
   # And this should now FAIL:
   status, message = list(check(ttFont,
-                               style_with_spaces(filename),
+                               style(ttFont),
                                familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "bad-familyname"
 
@@ -2263,7 +2263,7 @@ def test_check_161():
   ttFont = TTFont(font)
   print (f"Test PASS with a RIBBI without nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style(font),
+                               style(ttFont),
                                familyname(ttFont)))[-1]
   assert status == PASS
 
@@ -2271,7 +2271,7 @@ def test_check_161():
   ttFont['name'].names[5].nameID = NameID.TYPOGRAPHIC_FAMILY_NAME # 5 is arbitrary here
   print (f"Test FAIL with a RIBBI that has got a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style(font),
+                               style(ttFont),
                                familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "ribbi"
 
@@ -2280,7 +2280,7 @@ def test_check_161():
   ttFont = TTFont(font)
   print (f"Test PASS with a non-RIBBI containing a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style(font),
+                               style(ttFont),
                                familyname(ttFont)))[-1]
   assert status == PASS
 
@@ -2291,7 +2291,7 @@ def test_check_161():
 
   print (f"Test FAIL with a non-RIBBI with bad nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entries...")
   status, message = list(check(ttFont,
-                               style(font),
+                               style(ttFont),
                                familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "non-ribbi-bad-value"
 
@@ -2303,7 +2303,7 @@ def test_check_161():
 
   print (f"Test FAIL with a non-RIBBI lacking a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style(font),
+                               style(ttFont),
                                familyname(ttFont)))[-1]
   assert status == FAIL and message.code == "non-ribbi-lacks-entry"
 
@@ -2311,21 +2311,21 @@ def test_check_161():
 def test_check_162():
   """ Check name table: TYPOGRAPHIC_SUBFAMILY_NAME entries. """
   from fontbakery.specifications.googlefonts import (com_google_fonts_check_162 as check,
-                                                     style_with_spaces)
+                                                     style)
 
   # RIBBI fonts must not have a TYPOGRAPHIC_SUBFAMILY_NAME entry
   font = "data/test/montserrat/Montserrat-BoldItalic.ttf"
   ttFont = TTFont(font)
   print (f"Test PASS with a RIBBI without nameid={NameID.TYPOGRAPHIC_SUBFAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style_with_spaces(font)))[-1]
+                               style(ttFont)))[-1]
   assert status == PASS
 
   # so we add one and make sure is emits a FAIL:
   ttFont['name'].names[5].nameID = NameID.TYPOGRAPHIC_SUBFAMILY_NAME # 5 is arbitrary here
   print (f"Test FAIL with a RIBBI that has got a nameid={NameID.TYPOGRAPHIC_SUBFAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style_with_spaces(font)))[-1]
+                               style(ttFont)))[-1]
   assert status == FAIL and message.code == "ribbi"
 
   # non-RIBBI fonts must have a TYPOGRAPHIC_SUBFAMILY_NAME entry
@@ -2333,7 +2333,7 @@ def test_check_162():
   ttFont = TTFont(font)
   print (f"Test PASS with a non-RIBBI containing a nameid={NameID.TYPOGRAPHIC_SUBFAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style_with_spaces(font)))[-1]
+                               style(ttFont)))[-1]
   assert status == PASS
 
   # set bad values on all TYPOGRAPHIC_SUBFAMILY_NAME entries:
@@ -2343,7 +2343,7 @@ def test_check_162():
 
   print (f"Test FAIL with a non-RIBBI with bad nameid={NameID.TYPOGRAPHIC_SUBFAMILY_NAME} entries...")
   status, message = list(check(ttFont,
-                               style_with_spaces(font)))[-1]
+                               style(ttFont)))[-1]
   assert status == FAIL and message.code == "non-ribbi-bad-value"
 
   # remove all TYPOGRAPHIC_SUBFAMILY_NAME entries
@@ -2351,11 +2351,11 @@ def test_check_162():
   for i, name in enumerate(ttFont['name'].names):
     if name.nameID == NameID.TYPOGRAPHIC_SUBFAMILY_NAME:
       ttFont['name'].names[i].nameID = 255 # blah! :-)
-
+  
   print (f"Test FAIL with a non-RIBBI lacking a nameid={NameID.TYPOGRAPHIC_SUBFAMILY_NAME} entry...")
   status, message = list(check(ttFont,
-                               style_with_spaces(font)))[-1]
-  assert status == FAIL and message.code == "non-ribbi-lacks-entry"
+                               style(ttFont)))[-1]
+  assert status == FAIL
 
 
 def test_check_164():


### PR DESCRIPTION
I'm refactoring the name checks so the font and style names are no longer derived from the font's filename. By doing this, we will no longer need to maintain a whitelist of families which have camelcase names. I'll also make sure that langIDs other than 1033 won't cause a problem.

@felipesanches I wouldn't review this yet. I'm tempted to simplify some of the checks, there seems to be a lot of boilerplate and redundant statements. Is it possible to merge checks? I don't see the point in having a separate check for the subfamily name and another for the typographic subfamily name because they're so closely related.