### PR TITLE
WIP: Cache invalidation

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -352,13 +352,15 @@ class CheckRunner:
     yield self._check_result(result)
 
   def _evaluate_condition(self, name, iterargs, path=None):
+
     if path is None:
       # top level call
-      path = []
+      path = tuple()
+
     if name in path:
       raise CircularDependencyError('Condition "{}" is a circular dependency in {}'\
                                   .format(name, ' -> '.join(path)))
-    path.append(name)
+    path = path + (name, )
 
     try:
       condition = self._spec.conditions[name]
@@ -372,7 +374,6 @@ class CheckRunner:
       error = FailedConditionError(condition, err)
       return error, None
 
-    path.pop()
     try:
       return None, condition(**args)
     except Exception as err:


### PR DESCRIPTION
This is work in progress to test an idea how to invalidate the condition cache of `Checkrunner`.

The discussion that triggered me doing this for this started in gitter: https://gitter.im/fontbakery/Lobby?at=5c631ced253c2b5ea3ff63a0

related: #1610 #1609

I will post also some python mprof graphs here, hoping that we can see how the memory consumption improves, however, my first adhoc tries didn't look very promising, maybe the reason for the memory consumption lies somewhere else.

The initial commit is **NOT** production ready, don't merge!