### PR TITLE
This is an initial proposal of some helper classes to facilitate running code tests on fontbakery checks in our test-suite.

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -811,14 +811,14 @@ class Spec:
 
           derived_iterables={'ttFonts': ('ttFont', True)}
           # Then:
-          ttfons = (
+          ttFonts = (
             <TTFont object from font_0>
           , <TTFont object from font_1>
           )
 
           # However
           derived_iterables={'ttFonts': ('ttFont', False)}
-          ttfons = [
+          ttFonts = [
             ((('font', 0), ), <TTFont object from font_0>)
           , ((('font', 1), ), <TTFont object from font_1>)
           ]


### PR DESCRIPTION
The benefit of this new approach is that the CheckRunner machinery
 takes care of computing the conditions for a check, so that there's
 less boilerplate code and thus less opportunity for a developer
 to commit a mistake when crafting the code tests.

Work-in-progress. Please don't merge yet!
