### PR TITLE
fix bug in which a singular ttFont condition causes a family-wide (ttFonts) check to be executed once per font.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+
+## 0.6.12 (2019-Mar-07)
+### Bug fixes
+  - Fix bug in which a singular ttFont condition causes a family-wide (ttFonts) check to be executed once per font. (issue #2370)
+
+### New features
+  - We now have an Adobe collection of checks (specification). It will include more checks in future releases. (PR #2369)
+
+
 ## 0.6.11 (2019-Feb-18)
 ### Documentation
   - Update maintainer notes so that we do not forget to update the cache of vendor ids list. (issue #2359)

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -480,7 +480,7 @@ def com_google_fonts_check_007(family_metadata):
 
 @check(
   id = 'com.google.fonts/check/011',
-  conditions = ['is_ttf',
+  conditions = ['are_ttf',
                 'stylenames_are_canonical']
 )
 def com_google_fonts_check_011(ttFonts):
@@ -529,7 +529,7 @@ def com_google_fonts_check_011(ttFonts):
 
 @check(
   id = 'com.google.fonts/check/012',
-  conditions = ['is_ttf']
+  conditions = ['are_ttf']
 )
 def com_google_fonts_check_012(ttFonts):
   """Fonts have equal glyph names?"""

--- a/Lib/fontbakery/specifications/shared_conditions.py
+++ b/Lib/fontbakery/specifications/shared_conditions.py
@@ -18,6 +18,15 @@ def is_ttf(ttFont):
 
 
 @condition
+def are_ttf(ttFonts):
+  for f in ttFonts:
+    if not is_ttf(f):
+      return False
+  # otherwise:
+  return True
+
+
+@condition
 def is_cff(ttFont):
   return 'CFF ' in ttFont
 


### PR DESCRIPTION
This pull request addresses the problems described at issue #2370 
