### PR TITLE
added two checks: consistent UPM across family, max 4 fonts per name ID 1

### DIFF
--- a/Lib/fontbakery/specifications/adobe_fonts.py
+++ b/Lib/fontbakery/specifications/adobe_fonts.py
@@ -5,20 +5,14 @@ from fontbakery.callable import check
 from fontbakery.checkrunner import (PASS, FAIL, Section)
 from fontbakery.fonts_spec import spec_factory
 
-from fontbakery.specifications.googlefonts import (
-    com_google_fonts_check_040, com_google_fonts_check_042)
-
-spec_imports = ((
-    '.',
-    ('general', 'cmap', 'head', 'os2', 'post', 'name', 'hhea', 'dsig', 'hmtx',
-     'gpos', 'gdef', 'kern', 'glyf', 'fvar', 'shared_conditions', 'loca')
-),)
-
-
-# The line below is to get around the flake8 complaint that these checks
-# are "imported but unused".
-# ToDo: find if there's a better way to handle this.
-_imported_checks = [com_google_fonts_check_040, com_google_fonts_check_042]
+spec_imports = (
+    ('.',
+        ('general', 'cmap', 'head', 'os2', 'post', 'name', 'hhea', 'dsig',
+         'hmtx', 'gpos', 'gdef', 'kern', 'glyf', 'fvar', 'shared_conditions',
+         'loca')),
+    ('fontbakery.specifications.googlefonts',
+        ('com_google_fonts_check_040', 'com_google_fonts_check_042')),
+)
 
 # this is from the output of
 # $ fontbakery check-specification  fontbakery.specifications.googlefonts -L

--- a/Lib/fontbakery/specifications/adobe_fonts.py
+++ b/Lib/fontbakery/specifications/adobe_fonts.py
@@ -4,6 +4,7 @@ Checks for Adobe Fonts (formerly known as Typekit).
 from fontbakery.callable import check
 from fontbakery.checkrunner import (PASS, FAIL, Section)
 from fontbakery.fonts_spec import spec_factory
+
 from fontbakery.specifications.googlefonts import (
     com_google_fonts_check_040, com_google_fonts_check_042)
 
@@ -78,7 +79,9 @@ expected_check_ids = [
     'com.google.fonts/check/ftxvalidator_is_available',  # Is the command "ftxvalidator" (Apple Font Tool Suite) available?
     'com.google.fonts/check/wght_valid_range',  # Weight axis coordinate must be within spec range of 1 to 1000 on all instances.
     'com.adobe.fonts/check/postscript_name_cff_vs_name',  # CFF table FontName must match name table ID 6 (PostScript name).
-    'com.adobe.fonts/check/name_empty_records'  # check 'name' table for empty records
+    'com.adobe.fonts/check/max_4_fonts_per_family_name',  # Verify that each group of fonts with the same nameID 1 has maximum of 4 fonts
+    'com.adobe.fonts/check/name_empty_records',  # check 'name' table for empty records
+    'com.adobe.fonts/check/consistent_upm'  # fonts have consistent Units Per Em?
 ]
 
 specification = spec_factory(default_section=Section("Adobe Fonts"))
@@ -104,6 +107,21 @@ def com_adobe_fonts_check_name_empty_records(ttFont):
                          ).format(name_key)
     if not failed:
         yield PASS, ("No empty name table records found.")
+
+
+@check(
+    id='com.adobe.fonts/check/consistent_upm'
+)
+def com_adobe_fonts_check_consistent_upm(ttFonts):
+    """Fonts have consistent Units Per Em?"""
+    upm_set = set()
+    for ttFont in ttFonts:
+        upm_set.add(ttFont['head'].unitsPerEm)
+    if len(upm_set) > 1:
+        yield FAIL, ("Fonts have different units per em: {}."
+                     ).format(sorted(upm_set))
+    else:
+        yield PASS, "Fonts have consistent units per em."
 
 
 def check_skip_filter(checkid, font=None, **iterargs):

--- a/Lib/fontbakery/specifications/adobe_fonts.py
+++ b/Lib/fontbakery/specifications/adobe_fonts.py
@@ -110,7 +110,10 @@ def com_adobe_fonts_check_name_empty_records(ttFont):
 
 
 @check(
-    id='com.adobe.fonts/check/consistent_upm'
+    id='com.adobe.fonts/check/consistent_upm',
+    rationale="""While not required by the OpenType spec, we (Adobe) expect
+    that a group of fonts designed & produced as a family have consistent
+    units per em. """
 )
 def com_adobe_fonts_check_consistent_upm(ttFonts):
     """Fonts have consistent Units Per Em?"""

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -165,6 +165,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/aat' # Are there unwanted Apple tables?
       , 'com.google.fonts/check/ftxvalidator_is_available' # Is the command "ftxvalidator" (Apple Font Tool Suite) available?
       , 'com.adobe.fonts/check/postscript_name_cff_vs_name' # CFF table FontName must match name table ID 6 (PostScript name).
+      , 'com.adobe.fonts/check/max_4_fonts_per_family_name' # Verify that each group of fonts with the same nameID 1 has maximum of 4 fonts
       , 'com.google.fonts/check/metadata/parses' # Check METADATA.pb parses correctly.
       , 'com.google.fonts/check/fvar_name_entries' # All name entries referenced by fvar instances exist on the name table?
       , 'com.google.fonts/check/varfont_has_instances' # A variable font must have named instances.

--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.checkrunner import ERROR, FAIL, PASS, WARN, INFO
+from fontbakery.checkrunner import ERROR, FAIL, PASS, WARN, INFO, SKIP
 from fontbakery.message import Message
 from fontbakery.constants import (PriorityLevel,
                                   NameID,
@@ -418,6 +418,11 @@ def com_adobe_fonts_check_max_4_fonts_per_family_name(ttFonts):
   has maximum of 4 fonts"""
   from collections import Counter
   from fontbakery.utils import get_name_entry_strings
+
+  if len(ttFonts) < 4:
+    yield SKIP, ("Fewer than 4 fonts in list, so no need for this check.")
+    return
+
   failed = False
   family_names = list()
   for ttFont in ttFonts:

--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -421,7 +421,6 @@ def com_adobe_fonts_check_max_4_fonts_per_family_name(ttFonts):
   failed = False
   family_names = list()
   for ttFont in ttFonts:
-    # family_names.append(ttFont['name'].)
     names_list = get_name_entry_strings(ttFont, NameID.FONT_FAMILY_NAME)
     # names_list will likely contain multiple entries, e.g. multiple copies
     # of the same name in the same language for different platforms, but

--- a/tests/specifications/adobe_fonts_test.py
+++ b/tests/specifications/adobe_fonts_test.py
@@ -3,7 +3,6 @@ from fontTools.ttLib import TTFont
 
 
 def test_check_name_empty_records():
-    """ Checking OS/2.usWeightClass """
     from fontbakery.specifications.adobe_fonts import (
         com_adobe_fonts_check_name_empty_records as check)
     font_path = "data/test/source-sans-pro/OTF/SourceSansPro-Regular.otf"
@@ -21,4 +20,28 @@ def test_check_name_empty_records():
     # now try a string that only has whitespace
     test_font['name'].names[3].string = b' '
     status, message = list(check(test_font))[-1]
+    assert status == FAIL
+
+
+def test_check_consistent_upm():
+    from fontbakery.specifications.adobe_fonts import (
+        com_adobe_fonts_check_consistent_upm as check)
+
+    base_path = 'data/test/source-sans-pro/OTF/'
+
+    font_names = ['SourceSansPro-Regular.otf',
+                  'SourceSansPro-Bold.otf',
+                  'SourceSansPro-It.otf']
+
+    font_paths = [base_path + n for n in font_names]
+
+    test_fonts = [TTFont(x) for x in font_paths]
+
+    # try fonts with consistent UPM
+    status, message = list(check(test_fonts))[-1]
+    assert status == PASS
+
+    # now try with one font with a different UPM
+    test_fonts[1]['head'].unitsPerEm = 2048
+    status, message = list(check(test_fonts))[-1]
     assert status == FAIL

--- a/tests/specifications/adobe_fonts_test.py
+++ b/tests/specifications/adobe_fonts_test.py
@@ -29,6 +29,7 @@ def test_check_consistent_upm():
 
     base_path = 'data/test/source-sans-pro/OTF/'
 
+    # these fonts have a consistent unitsPerEm of 1000:
     font_names = ['SourceSansPro-Regular.otf',
                   'SourceSansPro-Bold.otf',
                   'SourceSansPro-It.otf']
@@ -37,11 +38,11 @@ def test_check_consistent_upm():
 
     test_fonts = [TTFont(x) for x in font_paths]
 
-    # try fonts with consistent UPM
+    # try fonts with consistent UPM (i.e. 1000)
     status, message = list(check(test_fonts))[-1]
     assert status == PASS
 
-    # now try with one font with a different UPM
+    # now try with one font with a different UPM (i.e. 2048)
     test_fonts[1]['head'].unitsPerEm = 2048
     status, message = list(check(test_fonts))[-1]
     assert status == FAIL

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -354,3 +354,43 @@ def test_check_postscript_name_cff_vs_name():
   )
   status, message = list(check(test_font))[-1]
   assert status == PASS
+
+
+def test_check_max_4_fonts_per_family_name():
+  from fontbakery.specifications.name import \
+    com_adobe_fonts_check_max_4_fonts_per_family_name as check
+
+  base_path = 'data/test/source-sans-pro/OTF/'
+
+  font_names = [
+    'SourceSansPro-Black.otf',
+    'SourceSansPro-BlackIt.otf',
+    'SourceSansPro-Bold.otf',
+    'SourceSansPro-BoldIt.otf',
+    'SourceSansPro-ExtraLight.otf',
+    'SourceSansPro-ExtraLightIt.otf',
+    'SourceSansPro-It.otf',
+    'SourceSansPro-Light.otf',
+    'SourceSansPro-LightIt.otf',
+    'SourceSansPro-Regular.otf',
+    'SourceSansPro-Semibold.otf',
+    'SourceSansPro-SemiboldIt.otf']
+
+  font_paths = [base_path + n for n in font_names]
+
+  test_fonts = [TTFont(x) for x in font_paths]
+
+  # try fonts with correct family name grouping
+  status, message = list(check(test_fonts))[-1]
+  assert status == PASS
+
+  # now set 5 of the fonts to have the same family name
+  for font in test_fonts[:5]:
+    name_records = font['name'].names
+    for name_record in name_records:
+      if name_record.nameID == 1:
+        # print(repr(name_record.string))
+        name_record.string = 'foobar'.encode('utf-16be')
+
+  status, message = list(check(test_fonts))[-1]
+  assert status == FAIL

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -394,3 +394,8 @@ def test_check_max_4_fonts_per_family_name():
 
   status, message = list(check(test_fonts))[-1]
   assert status == FAIL
+
+  # now try with a set of 3 fonts to make sure we skip the test
+  short_list = test_fonts[:3]
+  status, message = list(check(short_list))[-1]
+  assert status == SKIP


### PR DESCRIPTION
added two checks:
* an `adobe-fonts` check for consistent units per em across the family
* an `opentype` check for max of 4 fonts per family name (i.e. name ID 1)
