### PR TITLE
backing out the skip if fewer than 4 fonts

### DIFF
--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.checkrunner import ERROR, FAIL, PASS, WARN, INFO, SKIP
+from fontbakery.checkrunner import ERROR, FAIL, PASS, WARN, INFO
 from fontbakery.message import Message
 from fontbakery.constants import (PriorityLevel,
                                   NameID,
@@ -418,10 +418,6 @@ def com_adobe_fonts_check_max_4_fonts_per_family_name(ttFonts):
   has maximum of 4 fonts"""
   from collections import Counter
   from fontbakery.utils import get_name_entry_strings
-
-  if len(ttFonts) < 4:
-    yield SKIP, ("Fewer than 4 fonts in list, so no need for this check.")
-    return
 
   failed = False
   family_names = list()

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -394,8 +394,3 @@ def test_check_max_4_fonts_per_family_name():
 
   status, message = list(check(test_fonts))[-1]
   assert status == FAIL
-
-  # now try with a set of 3 fonts to make sure we skip the test
-  short_list = test_fonts[:3]
-  status, message = list(check(short_list))[-1]
-  assert status == SKIP


### PR DESCRIPTION
because we can't take the len() of a generator

