### PR TITLE
add support for getting a list of family-level checks from a FontsSpec

### DIFF
--- a/Lib/fontbakery/fonts_spec.py
+++ b/Lib/fontbakery/fonts_spec.py
@@ -44,6 +44,11 @@ class FontsSpec(Spec):
 
     return ('fonts', )
 
+  def get_family_checks(self):
+    family_checks = self.get_checks_by_dependencies('ttFonts', 'vmetrics')
+    return family_checks
+
+
 fonts_expected_value = ExpectedValue(
       'fonts'
     , default=[]

--- a/Lib/fontbakery/fonts_spec.py
+++ b/Lib/fontbakery/fonts_spec.py
@@ -45,7 +45,7 @@ class FontsSpec(Spec):
     return ('fonts', )
 
   def get_family_checks(self):
-    family_checks = self.get_checks_by_dependencies('ttFonts', 'vmetrics')
+    family_checks = self.get_checks_by_dependencies('ttFonts')
     return family_checks
 
 

--- a/tests/specifications/adobe_fonts_test.py
+++ b/tests/specifications/adobe_fonts_test.py
@@ -46,3 +46,20 @@ def test_check_consistent_upm():
     test_fonts[1]['head'].unitsPerEm = 2048
     status, message = list(check(test_fonts))[-1]
     assert status == FAIL
+
+
+def test_get_family_checks():
+    from fontbakery.specifications.adobe_fonts import specification
+    family_checks = specification.get_family_checks()
+    family_check_ids = {check.id for check in family_checks}
+    expected_family_check_ids = {
+        'com.adobe.fonts/check/consistent_upm',
+        'com.adobe.fonts/check/max_4_fonts_per_family_name',
+        'com.google.fonts/check/008',
+        'com.google.fonts/check/009',
+        'com.google.fonts/check/010',
+        'com.google.fonts/check/013',
+        'com.google.fonts/check/014',
+        'com.google.fonts/check/040'
+    }
+    assert family_check_ids == expected_family_check_ids


### PR DESCRIPTION
(all credit is due to @graphicore, all blame is due to me)

