### PR TITLE
Refactored com.google.fonts/check/102 into two checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+## 0.6.13 (2019-Mar-18)
+### Bug fixes
+  - **[com_google_fonts_check_102]:** Check was being skipped when run on upstream font repos which don't have a METADATA.pb file. This check will now only test METADATA.pb files. A new check has been added to check the copyright string in fonts.
+
+### New checks
+  - **[com.google.fonts/check/font_copyright]: "Copyright notices match canonical pattern in fonts"**
 
 ## 0.6.12 (2019-Mar-07)
 ### Bug fixes

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -1454,14 +1454,13 @@ def test_check_102():
   # Our reference Cabin Regular is known to be bad
   # Since it provides an email instead of a git URL:
   fontfile = "data/test/cabin/Cabin-Regular.ttf"
-  ttFont = TTFont(fontfile)
   family_directory = os.path.dirname(fontfile)
   family_meta = family_metadata(family_directory)
   font_meta = font_metadata(family_meta, fontfile)
 
   # So it must FAIL the check:
-  print ("Test FAIL with a bad copyright notice string...")
-  status, message = list(check(ttFont, font_meta))[-1]
+  print("Test FAIL with a bad copyright notice string...")
+  status, message = list(check(font_meta))[-1]
   assert status == FAIL
 
   # Then we change it into a good string (example extracted from Archivo Black):
@@ -1469,12 +1468,32 @@ def test_check_102():
   #       It only focuses on the string format.
   good_string = "Copyright 2017 The Archivo Black Project Authors (https://github.com/Omnibus-Type/ArchivoBlack)"
   font_meta.copyright = good_string
+  print("Test PASS with a good copyright notice string...")
+  status, message = list(check(font_meta))[-1]
+  assert status == PASS
+
+
+def test_check_font_copyright():
+  """Copyright notices match canonical pattern in fonts"""
+  from fontbakery.specifications.googlefonts import com_google_fonts_check_font_copyright as check
+  # Our reference Cabin Regular is known to be bad
+  # Since it provides an email instead of a git URL:
+  fontfile = "data/test/cabin/Cabin-Regular.ttf"
+  ttFont = TTFont(fontfile)
+
+  # So it must FAIL the check:
+  print("Test FAIL with a bad copyright notice string...")
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL
+
+  # Then we change it into a good string (example extracted from Archivo Black):
+  # note: the check does not actually verify that the project name is correct.
+  #       It only focuses on the string format.
+  good_string = "Copyright 2017 The Archivo Black Project Authors (https://github.com/Omnibus-Type/ArchivoBlack)"
   for i, entry in enumerate(ttFont['name'].names):
     if entry.nameID == NameID.COPYRIGHT_NOTICE:
       ttFont['name'].names[i].string = good_string.encode(entry.getEncoding())
-
-  print ("Test PASS with a good copyright notice string...")
-  status, message = list(check(ttFont, font_meta))[-1]
+  status, message = list(check(ttFont))[-1]
   assert status == PASS
 
 


### PR DESCRIPTION
com.google.fonts/check/102 will not run on upstream font repos since it needs a METADATA.pb file. This check will now only check that METADATA.pb files have the correct copyright string.

com.google.fonts/check/font_copyright will ensure that a font's copyright strings are correct.

Fixes #2210 