### PR TITLE
update changelog and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,7 @@
 This pull request addresses the problems described at issue #xxxx
 
 ## To Do
-- [ ] Update `CHANGELOG.md`
+- [ ] update `CHANGELOG.md`
+- [ ] wait for checks to pass (except `github/pages`, which is stuck)
+- [ ] request a review
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,5 @@
+## Description
 This pull request addresses the problems described at issue #xxxx
+
+## To Do
+- [ ] Update `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### New features
   - We now have an Adobe collection of checks (specification). It will include more checks in future releases. (PR #2369)
+  - The `FontSpec` class now has a `get_family_checks()` method that returns a list of family-level checks. (PR #2380) 
 
 ### New checks
   - **[com.adobe.fonts/check/fsselection_matches_macstyle]:**  "OS/2.fsSelection and head.macStyle bold and italic bits match." (PR #2382)


### PR DESCRIPTION
* update change log with note about new `FontSpec.get_family_checks()` method
* update PR template with a reminder to update change log
