### PR TITLE
com_google_fonts_check_040: Cap winDescent and winAscent values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix bug in which a singular ttFont condition causes a family-wide (ttFonts) check to be executed once per font. (issue #2370)
   - **[com.google.fonts/check/079]:** Fixed bug in which this check was not confirming that font seemed monospaced before reporting different advance widths. (PR #2368, part of issue #2366)
   - Protect condition ttfautohint_stats against non-ttf fonts (issue #2385)
+  - **[com.google/fonts/check/040]:** Cap accepted winDescent and winAscent values. Both should be less than double their respective bounding box values.
 
 ### New features
   - We now have an Adobe collection of checks (specification). It will include more checks in future releases. (PR #2369)

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -3468,6 +3468,13 @@ def com_google_fonts_check_040(ttFont, vmetrics):
                          " should be equal or greater than {}, but got"
                          " {} instead").format(vmetrics['ymax'],
                                                ttFont['OS/2'].usWinAscent))
+  if ttFont['OS/2'].usWinAscent > vmetrics['ymax'] * 2:
+    failed = True
+    yield FAIL, Message(
+        "ascent", ("OS/2.usWinAscent value {} is too large."
+                   " It should be less than double the yMax"
+                   " which is {}").format(ttFont['OS/2'].usWinDescent,
+                                          abs(vmetrics['ymin'] * 2)))
   # OS/2 usWinDescent:
   if ttFont['OS/2'].usWinDescent < abs(vmetrics['ymin']):
     failed = True
@@ -3476,6 +3483,14 @@ def com_google_fonts_check_040(ttFont, vmetrics):
                     " should be equal or greater than {}, but got"
                     " {} instead").format(
                         abs(vmetrics['ymin']), ttFont['OS/2'].usWinDescent))
+
+  if ttFont['OS/2'].usWinDescent > abs(vmetrics['ymin']) * 2:
+    failed = True
+    yield FAIL, Message(
+        "descent", ("OS/2.usWinDescent value {} is too large."
+                    " It should be less than double the yMin"
+                    " which is {}").format(ttFont['OS/2'].usWinDescent,
+                                           abs(vmetrics['ymin'] * 2)))
   if not failed:
     yield PASS, "OS/2 usWinAscent & usWinDescent values look good!"
 


### PR DESCRIPTION
## Description
This pr will cap the winAscent and winDescent values so neither are double their respective bounding box value. If people think the cap is too high/low, I will adjust it accordingly.

I've modified this test because I pushed b612 which had an insanely high winDescent value. This pr will now raise the following FAIL for the family.

```
>> com.google.fonts/check/040 with (('font[0]', '/Users/marcfoley/Type/upstream_families/b612/fonts/ttf/B612-Regular.ttf'),)
   Checking OS/2 usWinAscent & usWinDescent.
 * FAIL: OS/2.usWinDescent value 64824 is too large. It should be less than double the yMin which is 1420 [code: descent]
```

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

