### PR TITLE
only store width in glyph_metrics_stats most_common_width (not count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+## 0.6.13 (2019-??-??)
+### Bug fixes
+  - Fix bug in handling of `most_common_width` in `glyph_metrics_stats` which affected checking of monospaced metadata. (PR #2391)
 
 ## 0.6.12 (2019-Mar-11)
 ### Bug fixes

--- a/Lib/fontbakery/specifications/shared_conditions.py
+++ b/Lib/fontbakery/specifications/shared_conditions.py
@@ -90,7 +90,7 @@ def glyph_metrics_stats(ttFont):
   seems_monospaced = ascii_most_common_width >= len(ascii_widths) * 0.8
 
   width_max = max([adv for k, (adv, lsb) in glyph_metrics.items()])
-  most_common_width = Counter(glyph_metrics.values()).most_common(1)[0][0]
+  most_common_width = Counter(glyph_metrics.values()).most_common(1)[0][0][0]
   return {
       "seems_monospaced": seems_monospaced,
       "width_max": width_max,

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -94,6 +94,7 @@ def test_check_033():
   # a monospaced font with good metadata here.
   ttFont = TTFont("data/test/overpassmono/OverpassMono-Regular.ttf")
   stats = glyph_metrics_stats(ttFont)
+  assert stats['most_common_width'] == 616
   status, message = list(check(ttFont, stats))[-1]
   # WARN is emitted when there's at least one outlier.
   # I don't see a good reason to be picky and also test that one separately here...


### PR DESCRIPTION
## Description
Prior to this change, the `most_common_width` in `glyph_metrics_stats` contained a tuple of `(width, count)`, but was being used in `com.google.fonts/check/033` _Checking correctness of monospaced metadata_ as if it were just `width`. Also, there was no test for `most_common_width`. Now it's just `width` and there is a test for it.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

