### PR TITLE
fix handling of post.isFixedPitch (accept any nonzero value)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.6.13 (2019-??-??)
 ### Bug fixes
   - Fix bug in handling of `most_common_width` in `glyph_metrics_stats` which affected checking of monospaced metadata. (PR #2391)
+  - Fix handling of `post.isFixedPitch` (accept any nonzero value). (PR #2392)
 
 ## 0.6.12 (2019-Mar-11)
 ### Bug fixes

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -118,7 +118,8 @@ class PANOSE_Proportion(enum.IntEnum):
 class IsFixedWidth(enum.IntEnum):
   """ 'post' table / isFixedWidth definitions """
   NOT_MONOSPACED = 0
-  MONOSPACED = 1  # any non-zero value means monospaced
+  # Do NOT use `MONOSPACED = 1` because *any* non-zero value means monospaced.
+  # I've commented it out because we were incorrectly testing against it. - CJC
 
 class PlatformID(enum.IntEnum):
   UNICODE = 0

--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -92,15 +92,14 @@ def com_google_fonts_check_033(ttFont, glyph_metrics_stats):
                          " {} instead."
                          "").format(width_max, ttFont['hhea'].advanceWidthMax))
   if seems_monospaced:
-    if ttFont['post'].isFixedPitch != IsFixedWidth.MONOSPACED:
+    if ttFont['post'].isFixedPitch == IsFixedWidth.NOT_MONOSPACED:
       failed = True
       yield FAIL, Message("mono-bad-post-isFixedPitch",
                           ("On monospaced fonts, the value of"
-                           " post.isFixedPitch must be set to {}"
-                           " (fixed width monospaced),"
+                           " post.isFixedPitch must be set to a non-zero value"
+                           " (meaning 'fixed width monospaced'),"
                            " but got {} instead."
-                           "").format(IsFixedWidth.MONOSPACED,
-                                      ttFont['post'].isFixedPitch))
+                           "").format(ttFont['post'].isFixedPitch))
 
     if ttFont['OS/2'].panose.bProportion != PANOSE_Proportion.MONOSPACED:
       failed = True
@@ -135,7 +134,7 @@ def com_google_fonts_check_033(ttFont, glyph_metrics_stats):
     # it is a non-monospaced font, so lets make sure
     # that all monospace-related metadata is properly unset.
 
-    if ttFont['post'].isFixedPitch == IsFixedWidth.MONOSPACED:
+    if ttFont['post'].isFixedPitch != IsFixedWidth.NOT_MONOSPACED:
       failed = True
       yield FAIL, Message("bad-post-isFixedPitch",
                           ("On non-monospaced fonts, the"

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -72,7 +72,7 @@ def test_check_033():
 
   # We'll mark it as monospaced on the post table and make sure it fails:
   print('Test FAIL with a non-monospaced font with bad post.isFixedPitch value ...')
-  ttFont["post"].isFixedPitch = IsFixedWidth.MONOSPACED
+  ttFont["post"].isFixedPitch = 42 # *any* non-zero value means monospaced
   status, message = list(check(ttFont, stats))[-1]
   assert status == FAIL and message.code == "bad-post-isFixedPitch"
 


### PR DESCRIPTION
## Description
Prior to this change, the code was only accepting a `post.isFixedPitch` value of `1` as meaning monospaced, but the OpenType spec. says:

>Set to 0 if the font is proportionally spaced, non-zero if the font is not proportionally spaced (i.e. monospaced).

So, now the code treats any non-zero value as meaning monospaced, and I've updated one of the test cases to use a non-one, non-zero value for testing.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

