### PR TITLE
add check for consistency of name ID 6 in TTF and CFF2 fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix bug in handling of `most_common_width` in `glyph_metrics_stats` which affected checking of monospaced metadata. (PR #2391)
   - Fix handling of `post.isFixedPitch` (accept any nonzero value). (PR #2392)
 
+### New checks
+  - **[com.adobe.fonts/check/name_id_6_consistency]:** "Name table ID 6 (PostScript name) must be consistent across platforms." (PR #2394)
+
 ## 0.6.12 (2019-Mar-11)
 ### Bug fixes
   - Fix bug in which a singular ttFont condition causes a family-wide (ttFonts) check to be executed once per font. (issue #2370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix handling of `post.isFixedPitch` (accept any nonzero value). (PR #2392)
 
 ### New checks
-  - **[com.adobe.fonts/check/name_id_6_consistency]:** "Name table ID 6 (PostScript name) must be consistent across platforms." (PR #2394)
+  - **[com.adobe.fonts/check/postscript_name_consistency]:** "Name table ID 6 (PostScript name) must be consistent across platforms." (PR #2394)
 
 ## 0.6.12 (2019-Mar-11)
 ### Bug fixes

--- a/Lib/fontbakery/specifications/adobe_fonts.py
+++ b/Lib/fontbakery/specifications/adobe_fonts.py
@@ -76,7 +76,7 @@ expected_check_ids = [
     'com.google.fonts/check/ftxvalidator_is_available',  # Is the command "ftxvalidator" (Apple Font Tool Suite) available?
     'com.google.fonts/check/wght_valid_range',  # Weight axis coordinate must be within spec range of 1 to 1000 on all instances.
     'com.adobe.fonts/check/postscript_name_cff_vs_name',  # CFF table FontName must match name table ID 6 (PostScript name).
-    'com.adobe.fonts/check/name_id_6_consistency',  # Name table ID 6 (PostScript name) must be consistent across platforms.
+    'com.adobe.fonts/check/postscript_name_consistency',  # Name table ID 6 (PostScript name) must be consistent across platforms.
     'com.adobe.fonts/check/max_4_fonts_per_family_name',  # Verify that each group of fonts with the same nameID 1 has maximum of 4 fonts
     'com.adobe.fonts/check/name_empty_records',  # check 'name' table for empty records
     'com.adobe.fonts/check/consistent_upm'  # fonts have consistent Units Per Em?

--- a/Lib/fontbakery/specifications/adobe_fonts.py
+++ b/Lib/fontbakery/specifications/adobe_fonts.py
@@ -76,6 +76,7 @@ expected_check_ids = [
     'com.google.fonts/check/ftxvalidator_is_available',  # Is the command "ftxvalidator" (Apple Font Tool Suite) available?
     'com.google.fonts/check/wght_valid_range',  # Weight axis coordinate must be within spec range of 1 to 1000 on all instances.
     'com.adobe.fonts/check/postscript_name_cff_vs_name',  # CFF table FontName must match name table ID 6 (PostScript name).
+    'com.adobe.fonts/check/name_id_6_consistency',  # Name table ID 6 (PostScript name) must be consistent across platforms.
     'com.adobe.fonts/check/max_4_fonts_per_family_name',  # Verify that each group of fonts with the same nameID 1 has maximum of 4 fonts
     'com.adobe.fonts/check/name_empty_records',  # check 'name' table for empty records
     'com.adobe.fonts/check/consistent_upm'  # fonts have consistent Units Per Em?

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -167,6 +167,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/aat' # Are there unwanted Apple tables?
       , 'com.google.fonts/check/ftxvalidator_is_available' # Is the command "ftxvalidator" (Apple Font Tool Suite) available?
       , 'com.adobe.fonts/check/postscript_name_cff_vs_name' # CFF table FontName must match name table ID 6 (PostScript name).
+      , 'com.adobe.fonts/check/name_id_6_consistency' # Name table ID 6 (PostScript name) must be consistent across platforms.
       , 'com.adobe.fonts/check/max_4_fonts_per_family_name' # Verify that each group of fonts with the same nameID 1 has maximum of 4 fonts
       , 'com.google.fonts/check/metadata/parses' # Check METADATA.pb parses correctly.
       , 'com.google.fonts/check/fvar_name_entries' # All name entries referenced by fvar instances exist on the name table?

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -167,7 +167,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/aat' # Are there unwanted Apple tables?
       , 'com.google.fonts/check/ftxvalidator_is_available' # Is the command "ftxvalidator" (Apple Font Tool Suite) available?
       , 'com.adobe.fonts/check/postscript_name_cff_vs_name' # CFF table FontName must match name table ID 6 (PostScript name).
-      , 'com.adobe.fonts/check/name_id_6_consistency' # Name table ID 6 (PostScript name) must be consistent across platforms.
+      , 'com.adobe.fonts/check/postscript_name_consistency' # Name table ID 6 (PostScript name) must be consistent across platforms.
       , 'com.adobe.fonts/check/max_4_fonts_per_family_name' # Verify that each group of fonts with the same nameID 1 has maximum of 4 fonts
       , 'com.google.fonts/check/metadata/parses' # Check METADATA.pb parses correctly.
       , 'com.google.fonts/check/fvar_name_entries' # All name entries referenced by fvar instances exist on the name table?
@@ -3483,17 +3483,17 @@ def com_google_fonts_check_040(ttFont, vmetrics):
 
 @check(
   id = 'com.google.fonts/check/042',
-  rationale = """When OS/2 and hhea vertical metrics match, the same 
+  rationale = """When OS/2 and hhea vertical metrics match, the same
   linespacing results on macOS, GNU+Linux and Windows. Unfortunately as of 2018,
-  Google Fonts has released many fonts with vertical metrics that don't match 
-  in this way. When we fix this issue in these existing families, we will 
+  Google Fonts has released many fonts with vertical metrics that don't match
+  in this way. When we fix this issue in these existing families, we will
   create a visible change in line/paragraph layout for either Windows or macOS
-  users, which will upset some of them. 
+  users, which will upset some of them.
 
   But we have a duty to fix broken stuff, and inconsistent paragraph layout is
-  unacceptably broken when it is possible to avoid it. 
-  
-  If users complain and prefer the old broken version, they are libre to take 
+  unacceptably broken when it is possible to avoid it.
+
+  If users complain and prefer the old broken version, they are libre to take
   care of their own situation."""
 )
 def com_google_fonts_check_042(ttFont):
@@ -3585,8 +3585,8 @@ def com_google_fonts_check_vtt_clean(ttFont, vtt_talk_sources):
   (https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html)
   describes SFNT tables not in the Microsoft OpenType specification
   (https://docs.microsoft.com/en-us/typography/opentype/spec/)
-  and these can sometimes sneak into final release files, 
-  but Google Fonts should only have OpenType tables.""" 
+  and these can sometimes sneak into final release files,
+  but Google Fonts should only have OpenType tables."""
 )
 def com_google_fonts_check_aat(ttFont):
   """Are there unwanted Apple tables?"""

--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -378,10 +378,10 @@ def com_google_fonts_check_163(ttFont):
   conditions=['is_cff'],
   rationale="""
   The PostScript name entries in the font's 'name' table should match the
-  FontName string in the 'CFF ' table. 
-  
+  FontName string in the 'CFF ' table.
+
   The 'CFF ' table has a lot of information that is duplicated in other tables.
-  This information should be consistent across tables, because there's no 
+  This information should be consistent across tables, because there's no
   guarantee which table an app will get the data from.
   """,
 )
@@ -407,17 +407,17 @@ def com_adobe_fonts_check_postscript_name_cff_vs_name(ttFont):
 
 
 @check(
-  id='com.adobe.fonts/check/name_id_6_consistency',
+  id='com.adobe.fonts/check/postscript_name_consistency',
   conditions=['not is_cff'],  # e.g. TTF or CFF2
   rationale="""
   The PostScript name entries in the font's 'name' table should be
   consistent across platforms.
 
   This is the TTF/CFF2 equivalent of the CFF 'postscript_name_cff_vs_name'
-  check above.
+  check.
   """,
 )
-def com_adobe_fonts_check_name_id_6_consistency(ttFont):
+def com_adobe_fonts_check_postscript_name_consistency(ttFont):
   """Name table ID 6 (PostScript name) must be consistent across platforms."""
   postscript_names = set()
   for entry in ttFont['name'].names:

--- a/Lib/fontbakery/specifications/name.py
+++ b/Lib/fontbakery/specifications/name.py
@@ -407,6 +407,34 @@ def com_adobe_fonts_check_postscript_name_cff_vs_name(ttFont):
 
 
 @check(
+  id='com.adobe.fonts/check/name_id_6_consistency',
+  conditions=['not is_cff'],  # e.g. TTF or CFF2
+  rationale="""
+  The PostScript name entries in the font's 'name' table should be
+  consistent across platforms.
+
+  This is the TTF/CFF2 equivalent of the CFF 'postscript_name_cff_vs_name'
+  check above.
+  """,
+)
+def com_adobe_fonts_check_name_id_6_consistency(ttFont):
+  """Name table ID 6 (PostScript name) must be consistent across platforms."""
+  postscript_names = set()
+  for entry in ttFont['name'].names:
+    if entry.nameID == NameID.POSTSCRIPT_NAME:
+      postscript_name = entry.toUnicode()
+      postscript_names.add(postscript_name)
+
+  if len(postscript_names) > 1:
+    yield FAIL, ("Entries in the 'name' table for ID 6 (PostScript name) are "
+                 "not consistent. Names found: {}."
+                 .format(sorted(postscript_names)))
+  else:
+    yield PASS, ("Entries in the 'name' table for ID 6 "
+                 "(PostScript name) are consistent.")
+
+
+@check(
   id='com.adobe.fonts/check/max_4_fonts_per_family_name',
   rationale="""Per the OpenType spec. 'The Font Family name ... should be
   shared among at most four fonts that differ only in weight or style ...'

--- a/tests/specifications/adobe_fonts_test.py
+++ b/tests/specifications/adobe_fonts_test.py
@@ -1,11 +1,14 @@
-from fontbakery.checkrunner import (PASS, FAIL)
+import os
+
 from fontTools.ttLib import TTFont
+from fontbakery.checkrunner import (PASS, FAIL)
 
 
 def test_check_name_empty_records():
     from fontbakery.specifications.adobe_fonts import (
         com_adobe_fonts_check_name_empty_records as check)
-    font_path = "data/test/source-sans-pro/OTF/SourceSansPro-Regular.otf"
+    font_path = os.path.join('data', 'test', 'source-sans-pro', 'OTF',
+                             'SourceSansPro-Regular.otf')
     test_font = TTFont(font_path)
 
     # try a font with fully populated name records
@@ -27,14 +30,14 @@ def test_check_consistent_upm():
     from fontbakery.specifications.adobe_fonts import (
         com_adobe_fonts_check_consistent_upm as check)
 
-    base_path = 'data/test/source-sans-pro/OTF/'
+    base_path = os.path.join('data', 'test', 'source-sans-pro', 'OTF')
 
     # these fonts have a consistent unitsPerEm of 1000:
     font_names = ['SourceSansPro-Regular.otf',
                   'SourceSansPro-Bold.otf',
                   'SourceSansPro-It.otf']
 
-    font_paths = [base_path + n for n in font_names]
+    font_paths = [os.path.join(base_path, n) for n in font_names]
 
     test_fonts = [TTFont(x) for x in font_paths]
 

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -357,9 +357,9 @@ def test_check_postscript_name_cff_vs_name():
   assert status == PASS
 
 
-def test_check_name_id_6_consistency():
+def test_check_postscript_name_consistency():
   from fontbakery.specifications.name import \
-    com_adobe_fonts_check_name_id_6_consistency as check
+    com_adobe_fonts_check_postscript_name_consistency as check
 
   base_path = os.path.join('data', 'test', 'source-sans-pro', 'TTF')
 

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -410,7 +410,7 @@ def test_check_max_4_fonts_per_family_name():
     'SourceSansPro-Semibold.otf',
     'SourceSansPro-SemiboldIt.otf']
 
-  font_paths = [base_path + n for n in font_names]
+  font_paths = [os.path.join(base_path, n) for n in font_names]
 
   test_fonts = [TTFont(x) for x in font_paths]
 

--- a/tests/specifications/name_test.py
+++ b/tests/specifications/name_test.py
@@ -357,11 +357,44 @@ def test_check_postscript_name_cff_vs_name():
   assert status == PASS
 
 
+def test_check_name_id_6_consistency():
+  from fontbakery.specifications.name import \
+    com_adobe_fonts_check_name_id_6_consistency as check
+
+  base_path = os.path.join('data', 'test', 'source-sans-pro', 'TTF')
+
+  font_path = os.path.join(base_path, 'SourceSansPro-Regular.ttf')
+  test_font = TTFont(font_path)
+
+  # SourceSansPro-Regular only has one name ID 6 entry (for Windows),
+  # let's add another one for Mac that matches the Windows entry:
+  test_font['name'].setName(
+    'SourceSansPro-Regular',
+    NameID.POSTSCRIPT_NAME,
+    PlatformID.MACINTOSH,
+    WindowsEncodingID.UNICODE_BMP,
+    ENGLISH_LANG_ID
+  )
+  status, message = list(check(test_font))[-1]
+  assert status == PASS
+
+  # ...now let's change the Mac name ID 6 entry to something else:
+  test_font['name'].setName(
+    'YetAnotherFontName',
+    NameID.POSTSCRIPT_NAME,
+    PlatformID.MACINTOSH,
+    WindowsEncodingID.UNICODE_BMP,
+    ENGLISH_LANG_ID
+  )
+  status, message = list(check(test_font))[-1]
+  assert status == FAIL
+
+
 def test_check_max_4_fonts_per_family_name():
   from fontbakery.specifications.name import \
     com_adobe_fonts_check_max_4_fonts_per_family_name as check
 
-  base_path = 'data/test/source-sans-pro/OTF/'
+  base_path = os.path.join('data', 'test', 'source-sans-pro', 'OTF')
 
   font_names = [
     'SourceSansPro-Black.otf',

--- a/tests/specifications/os2_test.py
+++ b/tests/specifications/os2_test.py
@@ -175,7 +175,7 @@ def test_check_bold_italic_unique_for_nameid1():
     com_adobe_fonts_check_bold_italic_unique_for_nameid1 as check
   from fontbakery.constants import FsSelection
 
-  base_path = 'data/test/source-sans-pro/OTF/'
+  base_path = os.path.join('data', 'test', 'source-sans-pro', 'OTF')
 
   # these fonts have the same NameID1
   font_names = ['SourceSansPro-Regular.otf',
@@ -183,7 +183,7 @@ def test_check_bold_italic_unique_for_nameid1():
                 'SourceSansPro-It.otf',
                 'SourceSansPro-BoldIt.otf']
 
-  font_paths = [base_path + n for n in font_names]
+  font_paths = [os.path.join(base_path, n) for n in font_names]
 
   test_fonts = [TTFont(x) for x in font_paths]
 


### PR DESCRIPTION
## Description
The PostScript name entries in the font's `name` table should be consistent across platforms.
This is the TTF/CFF2 equivalent of the CFF-specific `postscript_name_cff_vs_name` check.

(Also replaced some hard-coded file paths with use of `os.path.join()` in the test code.)

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

