### PR TITLE
change emoji names to actual emoji for better readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix bug in handling of `most_common_width` in `glyph_metrics_stats` which affected checking of monospaced metadata. (PR #2391)
   - Fix handling of `post.isFixedPitch` (accept any nonzero value). (PR #2392)
 
+### Other code changes
+  - Improve emoji output of `--ghmarkdown` option, so that actual emoji appear in text editors, rather than the previous emoji names
+
 ## 0.6.12 (2019-Mar-11)
 ### Bug fixes
   - Fix bug in which a singular ttFont condition causes a family-wide (ttFonts) check to be executed once per font. (issue #2370)

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -15,12 +15,12 @@ class GHMarkdownReporter(SerializeReporter):
 
   def emoticon(self, name):
     return {
-      'ERROR': '💔', 
-      'FAIL': '🔥',
-      'WARN': '⚠️',
-      'INFO': 'ℹ️',
-      'SKIP': '💤',
-      'PASS': '🍞',
+      'ERROR': "\U0001F494", # 💔 :broken_heart:
+      'FAIL':  "\U0001F525", # 🔥 :fire:
+      'WARN':  "\U000026A0", # ⚠️ :warning:
+      'INFO':  "\U00002139", # ℹ️ :information_source:
+      'SKIP':  "\U0001F4A4", # 💤 :zzz:
+      'PASS':  "\U0001F35E", # 🍞 :bread:
     }[name]
 
 

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -15,12 +15,12 @@ class GHMarkdownReporter(SerializeReporter):
 
   def emoticon(self, name):
     return {
-      'ERROR': ':broken_heart:',
-      'FAIL': ':fire:',
-      'WARN': ':warning:',
-      'INFO': ':information_source:',
-      'SKIP': ':zzz:',
-      'PASS': ':bread:',
+      'ERROR': '💔', 
+      'FAIL': '🔥',
+      'WARN': '⚠️',
+      'INFO': 'ℹ️',
+      'SKIP': '💤',
+      'PASS': '🍞',
     }[name]
 
 


### PR DESCRIPTION
## Description

Most of the time, I prefer to use FontBakery by generating markdown reports via the `--ghmarkdown` option.

However, these reports have a limitation: the emoji names aren't displayed as emoji outside of GitHub (or at least not in my code editor, VSCode). This doesn't matter that much (either way) in the "code" view, but in a Markdown preview mode, this is a significant disadvantage – I have to somehow get the markdown onto GitHub (either by push or by copy/paste) in order to comfortably use the output. Sometimes, this nudges me to make commits that might be smaller than is truly useful.

So, this is a small change. Instead of placing emoji _names_ into the gfmarkdown report, it inserts actual emoji. So, instead of `:fail:`, `:pass:`, etc, it shows `🔥`, `🍞`, etc. 

### VS Code Markdown Preview, before and after this change:

![image](https://user-images.githubusercontent.com/7355414/54390933-f8c29680-4679-11e9-9ce1-82d6ea39c618.png)

![image](https://user-images.githubusercontent.com/7355414/54390899-e3e60300-4679-11e9-9b84-50e366e44ef6.png)


### Code view, in various editors

The emojis also display in the code view. This isn't a view I use as much, but it's useful to know that it still works.

VS Code, before and after:

![image](https://user-images.githubusercontent.com/7355414/54390962-0b3cd000-467a-11e9-9d51-07a86816ac6d.png)

![image](https://user-images.githubusercontent.com/7355414/54391091-55be4c80-467a-11e9-8977-e47984338ea4.png)

This also provides improvements outside of VS Code.

`vi` command line editor, before and after:

![image](https://user-images.githubusercontent.com/7355414/54391172-81d9cd80-467a-11e9-9685-5c15308acf64.png)

![image](https://user-images.githubusercontent.com/7355414/54391124-6f5f9400-467a-11e9-8360-da80d2bb7654.png)

Sublime, before and after:

![image](https://user-images.githubusercontent.com/7355414/54391377-0d535e80-467b-11e9-98e6-e3e8e17b9a1a.png)

![image](https://user-images.githubusercontent.com/7355414/54391579-9e2a3a00-467b-11e9-9413-7f07ff6fb07e.png)

Atom, before and after:

![image](https://user-images.githubusercontent.com/7355414/54391449-3aa00c80-467b-11e9-9cfa-df9d39933a40.png)

![image](https://user-images.githubusercontent.com/7355414/54391549-8783e300-467b-11e9-9801-17ebc6a7a824.png)

### On Windows

I wanted to check that the emoji also work in VS Code in Windows. This is definitely not a comprehensive test, but it helps show that this has no super-obvious drawbacks:

![image](https://user-images.githubusercontent.com/7355414/54392740-c5363b00-467e-11e9-975e-117aedaab841.png)

If anyone knows of a "gotcha" to this approach, I can accept the names as-is. If support for emoji in text editors is as broad as I think, however, I think this is a small but definite improvement.

## To Do

I'm happy to add this to the Changelog if there aren't issues with this that I've missed. Please let me know if this seems doable, and I'll write a short description of the update.

- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

