### PR TITLE
Distinguish static from varfont when reporting correctness of fontfile names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## 0.6.13 (2019-??-??)
+## 0.6.13 (2019-Mar-18)
 ### Bug fixes
+  - **[com.google.fonts/check/001]:** Distinguish static from varfont when reporting correctness of fontfile names. There are special naming rules for variable fonts. (issue #2396)
   - Fix bug in handling of `most_common_width` in `glyph_metrics_stats` which affected checking of monospaced metadata. (PR #2391)
   - Fix handling of `post.isFixedPitch` (accept any nonzero value). (PR #2392)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.adobe.fonts/check/postscript_name_consistency]:** "Name table ID 6 (PostScript name) must be consistent across platforms." (PR #2394)
 
+### Renamed numerical check-IDs:
+  - **[com.google.fonts.check/001]:** com.google.fonts/check/canonical_filename
+
+
 ## 0.6.12 (2019-Mar-11)
 ### Bug fixes
   - Fix bug in which a singular ttFont condition causes a family-wide (ttFonts) check to be executed once per font. (issue #2370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.6.13 (2019-Mar-18)
 ### Bug fixes
-  - **[com.google.fonts/check/001]:** Distinguish static from varfont when reporting correctness of fontfile names. There are special naming rules for variable fonts. (issue #2396)
+  - **[com.google.fonts/check/canonical_filename]:** Distinguish static from varfont when reporting correctness of fontfile names. There are special naming rules for variable fonts. (issue #2396)
   - Fix bug in handling of `most_common_width` in `glyph_metrics_stats` which affected checking of monospaced metadata. (PR #2391)
   - Fix handling of `post.isFixedPitch` (accept any nonzero value). (PR #2392)
 
@@ -11,7 +11,11 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/postscript_name_consistency]:** "Name table ID 6 (PostScript name) must be consistent across platforms." (PR #2394)
 
 ### Renamed numerical check-IDs:
-  - **[com.google.fonts.check/001]:** com.google.fonts/check/canonical_filename
+  - **[com.google.fonts/check/001]:** com.google.fonts/check/canonical_filename
+  - **[com.google.fonts/check/097]:** com.google.fonts/check/metadata/match_filename_postscript
+
+### Other important code-changes
+  - We temporarily disabled com.google.fonts/check/metadata/match_filename_postscript for variable fonts until we have a clear definition of the VF naming rules as discussed at https://github.com/google/fonts/issues/1817
 
 
 ## 0.6.12 (2019-Mar-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Renamed numerical check-IDs:
   - **[com.google.fonts/check/001]:** com.google.fonts/check/canonical_filename
   - **[com.google.fonts/check/097]:** com.google.fonts/check/metadata/match_filename_postscript
+  - **[com.google.fonts/check/105]:** com.google.fonts/check/metadata/canonical_filename
 
 ### Other important code-changes
   - We temporarily disabled com.google.fonts/check/metadata/match_filename_postscript for variable fonts until we have a clear definition of the VF naming rules as discussed at https://github.com/google/fonts/issues/1817

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -18,37 +18,49 @@ import enum
 # =====================================
 # GLOBAL CONSTANTS DEFINITIONS
 
-STYLE_NAMES = ["Thin",
-               "ExtraLight",
-               "Light",
-               "Regular",
-               "Medium",
-               "SemiBold",
-               "Bold",
-               "ExtraBold",
-               "Black",
-               "Thin Italic",
-               "ExtraLight Italic",
-               "Light Italic",
-               "Italic",
-               "Medium Italic",
-               "SemiBold Italic",
-               "Bold Italic",
-               "ExtraBold Italic",
-               "Black Italic"]
+# These variable font naming rules will soon change.
+# For more detail, see:
+# https://github.com/googlefonts/fontbakery/issues/2396#issuecomment-473250089
+VARFONT_SUFFIXES = [
+  "VF",
+  "Italic",
+  "Italic-VF",
+  "Roman",
+  "Roman-VF"]
 
-RIBBI_STYLE_NAMES = ["Regular",
-                     "Italic",
-                     "Bold",
-                     "BoldItalic",
-                     "Bold Italic"]  # <-- Do we really need this one?
+STATIC_STYLE_NAMES = [
+  "Thin",
+  "ExtraLight",
+  "Light",
+  "Regular",
+  "Medium",
+  "SemiBold",
+  "Bold",
+  "ExtraBold",
+  "Black",
+  "Thin Italic",
+  "ExtraLight Italic",
+  "Light Italic",
+  "Italic",
+  "Medium Italic",
+  "SemiBold Italic",
+  "Bold Italic",
+  "ExtraBold Italic",
+  "Black Italic"]
+
+RIBBI_STYLE_NAMES = [
+  "Regular",
+  "Italic",
+  "Bold",
+  "BoldItalic",
+  "Bold Italic"]  # <-- Do we really need this one?
 
 PLACEHOLDER_LICENSING_TEXT = {
-    'UFL.txt': 'Licensed under the Ubuntu Font Licence 1.0.',
-    'OFL.txt': 'This Font Software is licensed under the SIL Open Font '
-               'License, Version 1.1. This license is available with a FAQ '
-               'at: http://scripts.sil.org/OFL',
-    'LICENSE.txt': 'Licensed under the Apache License, Version 2.0'
+  'UFL.txt': 'Licensed under the Ubuntu Font Licence 1.0.',
+  'OFL.txt': 'This Font Software is licensed under the SIL Open Font '
+             'License, Version 1.1. This license is available with a FAQ '
+             'at: http://scripts.sil.org/OFL',
+  'LICENSE.txt': 'Licensed under the Apache License, Version 2.0'
 }
 
 # ANSI color codes for the helper logging class:

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -23,9 +23,7 @@ import enum
 # https://github.com/googlefonts/fontbakery/issues/2396#issuecomment-473250089
 VARFONT_SUFFIXES = [
   "VF",
-  "Italic",
   "Italic-VF",
-  "Roman",
   "Roman-VF"]
 
 STATIC_STYLE_NAMES = [

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -27,7 +27,7 @@ spec_imports = (
 # this is from the output of
 # $ fontbakery check-specification  fontbakery.specifications.googlefonts -L
 expected_check_ids = [
-        'com.google.fonts/check/001' # Checking file is named canonically.
+        'com.google.fonts/check/canonical_filename' # Checking file is named canonically.
       , 'com.google.fonts/check/002' # Checking all files are in the same directory.
       , 'com.google.fonts/check/003' # Does DESCRIPTION file contain broken links?
       , 'com.google.fonts/check/004' # Is this a propper HTML snippet?
@@ -289,12 +289,12 @@ def canonical_stylename(font):
 
 
 @check(
-  id = 'com.google.fonts/check/001',
+  id = 'com.google.fonts/check/canonical_filename',
   misc_metadata = {
     'priority': PriorityLevel.CRITICAL
   }
 )
-def com_google_fonts_check_001(font):
+def com_google_fonts_check_canonical_filename(font):
   """Checking file is named canonically.
 
   A font's filename must be composed in the following manner:

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -119,7 +119,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/102' # Copyright notice on METADATA.pb matches canonical pattern?
       , 'com.google.fonts/check/103' # Copyright notice on METADATA.pb does not contain Reserved Font Name?
       , 'com.google.fonts/check/104' # METADATA.pb: Copyright notice shouldn't exceed 500 chars.
-      , 'com.google.fonts/check/105' # Filename is set canonically in METADATA.pb?
+      , 'com.google.fonts/check/metadata/canonical_filename' # Filename is set canonically in METADATA.pb?
       , 'com.google.fonts/check/106' # METADATA.pb font.style "italic" matches font internals?
       , 'com.google.fonts/check/107' # METADATA.pb font.style "normal" matches font internals?
       , 'com.google.fonts/check/108' # METADATA.pb font.name and font.full_name fields match the values declared on the name table?
@@ -2021,13 +2021,13 @@ def canonical_filename(font_metadata):
 
 
 @check(
-  id = 'com.google.fonts/check/105',
+  id = 'com.google.fonts/check/metadata/canonical_filename',
   conditions = ['font_metadata',
                 'canonical_filename']
 )
-def com_google_fonts_check_105(font_metadata,
-                               canonical_filename,
-                               is_variable_font):
+def com_google_fonts_check_metadata_canonical_filename(font_metadata,
+                                                       canonical_filename,
+                                                       is_variable_font):
   """METADATA.pb: Filename is set canonically?"""
 
   if is_variable_font:

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -111,7 +111,7 @@ expected_check_ids = [
       , 'com.google.fonts/check/094' # METADATA.pb font.full_name value matches fullname declared on the name table?
       , 'com.google.fonts/check/095' # METADATA.pb font.name value should be same as the family name declared on the name table.
       , 'com.google.fonts/check/096' # METADATA.pb font.full_name and font.post_script_name fields have equivalent values ?
-      , 'com.google.fonts/check/097' # METADATA.pb font.filename and font.post_script_name fields have equivalent values?
+      , 'com.google.fonts/check/metadata/match_filename_postscript' # METADATA.pb font.filename and font.post_script_name fields have equivalent values?
       , 'com.google.fonts/check/098' # METADATA.pb font.name field contains font name in right format?
       , 'com.google.fonts/check/099' # METADATA.pb font.full_name field contains font name in right format?
       , 'com.google.fonts/check/100' # METADATA.pb font.filename field contains font name in right format?
@@ -1779,25 +1779,18 @@ def com_google_fonts_check_096(font_metadata):
 
 
 @check(
-  id = 'com.google.fonts/check/097',
-  conditions = ['font_metadata']
+  id = 'com.google.fonts/check/metadata/match_filename_postscript',
+  conditions = ['font_metadata',
+                'not is_variable_font']
+  # FIXME: We'll want to review this once
+  #        naming rules for varfonts are settled.
 )
-def com_google_fonts_check_097(font_metadata, is_variable_font):
+def com_google_fonts_check_metadata_match_filename_postscript(font_metadata):
   """METADATA.pb font.filename and font.post_script_name
      fields have equivalent values?
   """
   post_script_name = font_metadata.post_script_name
   filename = os.path.splitext(font_metadata.filename)[0]
-
-  if is_variable_font:
-    valid_varfont_suffixes = [
-      ("-VF", "Regular"),
-      ("Roman-VF", "Regular"),
-      ("Italic-VF", "Italic"),
-    ]
-    for valid_suffix, style in valid_varfont_suffixes:
-      if valid_suffix in filename:
-        filename = style.join(filename.split(valid_suffix))
 
   if filename != post_script_name:
     yield FAIL, ("METADATA.pb font filename=\"{}\" does not match"
@@ -2039,13 +2032,12 @@ def com_google_fonts_check_105(font_metadata,
 
   if is_variable_font:
     valid_varfont_suffixes = [
-      ("-VF", "Regular"),
       ("Roman-VF", "Regular"),
       ("Italic-VF", "Italic"),
     ]
     for valid_suffix, style in valid_varfont_suffixes:
-      if valid_suffix in canonical_filename:
-        canonical_filename = style.join(canonical_filename.split(valid_suffix))
+      if style in canonical_filename:
+        canonical_filename = valid_suffix.join(canonical_filename.split(style))
 
   if canonical_filename != font_metadata.filename:
     yield FAIL, ("METADATA.pb: filename field (\"{}\")"

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -303,14 +303,12 @@ def com_google_fonts_check_canonical_filename(font):
   e.g. Nunito-Regular.ttf,
        Oswald-BoldItalic.ttf
 
-  Variable fonts must use the "-VF", "Roman" or "Italic" suffixes:
+  Variable fonts must use the "-VF" suffix:
 
   e.g. Roboto-VF.ttf,
        Barlow-VF.ttf,
        Example-Roman-VF.ttf,
        Familyname-Italic-VF.ttf
-       Orbitron-Roman.ttf,
-       Somethingelse-Italic.ttf
   """
   from fontTools.ttLib import TTFont
   from fontbakery.specifications.shared_conditions import is_variable_font
@@ -1794,9 +1792,7 @@ def com_google_fonts_check_097(font_metadata, is_variable_font):
   if is_variable_font:
     valid_varfont_suffixes = [
       ("-VF", "Regular"),
-      ("Roman", "Regular"),
       ("Roman-VF", "Regular"),
-      ("Italic", "Italic"),
       ("Italic-VF", "Italic"),
     ]
     for valid_suffix, style in valid_varfont_suffixes:
@@ -2044,9 +2040,7 @@ def com_google_fonts_check_105(font_metadata,
   if is_variable_font:
     valid_varfont_suffixes = [
       ("-VF", "Regular"),
-      ("Roman", "Regular"),
       ("Roman-VF", "Regular"),
-      ("Italic", "Italic"),
       ("Italic-VF", "Italic"),
     ]
     for valid_suffix, style in valid_varfont_suffixes:

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -139,7 +139,7 @@ def test_check_001():
   """ Files are named canonically. """
   from fontbakery.specifications.googlefonts import com_google_fonts_check_001 as check
 
-  canonical_names = [
+  static_canonical_names = [
     "data/test/montserrat/Montserrat-Thin.ttf",
     "data/test/montserrat/Montserrat-ExtraLight.ttf",
     "data/test/montserrat/Montserrat-Light.ttf",
@@ -158,19 +158,23 @@ def test_check_001():
     "data/test/montserrat/Montserrat-BoldItalic.ttf",
     "data/test/montserrat/Montserrat-ExtraBoldItalic.ttf",
     "data/test/montserrat/Montserrat-BlackItalic.ttf",
+  ]
+
+  varfont_canonical_names = [
     "data/test/cabinvfbeta/Cabin-Italic-VF.ttf",
     "data/test/cabinvfbeta/Cabin-Roman-VF.ttf",
     "data/test/cabinvfbeta/Cabin-VF.ttf",
     "data/test/cabinvfbeta/Cabin-Italic.ttf",
     "data/test/cabinvfbeta/Cabin-Roman.ttf"
   ]
+
   non_canonical_names = [
     "data/test/montserrat/Montserrat/Montserrat.ttf",
     "data/test/montserrat/Montserrat-semibold.ttf",
     "data/test/cabinvfbeta/CabinVFBeta.ttf"
   ]
 
-  for canonical in canonical_names:
+  for canonical in static_canonical_names + varfont_canonical_names:
     print(f'Test PASS with "{canonical}" ...')
     status, message = list(check(canonical))[-1]
     assert status == PASS

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -1265,10 +1265,10 @@ def test_check_096():
   assert status == FAIL
 
 
-def NOT_IMPLEMENTED_test_check_097():
+def NOT_IMPLEMENTED_test_check_match_filename_postscript():
   """ METADATA.pb family.filename and family.post_script_name
       fields have equivalent values? """
-  # from fontbakery.specifications.googlefonts import com_google_fonts_check_097 as check
+  # from fontbakery.specifications.googlefonts import com_google_fonts_check_match_filename_postscript as check
   # TODO: Implement-me!
   #
   # code-paths:
@@ -1559,6 +1559,7 @@ def test_check_105():
     [PASS,   900,    "normal", "data/test/montserrat/Montserrat-Black.ttf"],
     [PASS,   900,    "italic", "data/test/montserrat/Montserrat-BlackItalic.ttf"]
   ]
+  # FIXME: There should also be samples of good and bad variable fonts in this code-test.
 
   for expected, weight, style, filename in test_cases:
     is_var = os.path.exists(filename) and is_variable_font(TTFont(filename))

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -1525,10 +1525,10 @@ def test_check_104():
   assert status == FAIL
 
 
-def test_check_105():
+def test_check_metadata_canonical_filename():
   """ METADATA.pb: Filename is set canonically? """
   from fontbakery.specifications.shared_conditions import is_variable_font
-  from fontbakery.specifications.googlefonts import (com_google_fonts_check_105 as check,
+  from fontbakery.specifications.googlefonts import (com_google_fonts_check_metadata_canonical_filename as check,
                                                      family_metadata,
                                                      font_metadata,
                                                      canonical_filename)

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -164,14 +164,14 @@ def test_check_canonical_filename():
     "data/test/cabinvfbeta/Cabin-Italic-VF.ttf",
     "data/test/cabinvfbeta/Cabin-Roman-VF.ttf",
     "data/test/cabinvfbeta/Cabin-VF.ttf",
-    "data/test/cabinvfbeta/Cabin-Italic.ttf",
-    "data/test/cabinvfbeta/Cabin-Roman.ttf"
   ]
 
   non_canonical_names = [
     "data/test/montserrat/Montserrat/Montserrat.ttf",
     "data/test/montserrat/Montserrat-semibold.ttf",
-    "data/test/cabinvfbeta/CabinVFBeta.ttf"
+    "data/test/cabinvfbeta/CabinVFBeta.ttf",
+    "data/test/cabinvfbeta/Cabin-Italic.ttf",
+    "data/test/cabinvfbeta/Cabin-Roman.ttf"
   ]
 
   for canonical in static_canonical_names + varfont_canonical_names:

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -135,9 +135,9 @@ def test_example_checkrunner_based(cabin_regular_path):
       break
 
 
-def test_check_001():
+def test_check_canonical_filename():
   """ Files are named canonically. """
-  from fontbakery.specifications.googlefonts import com_google_fonts_check_001 as check
+  from fontbakery.specifications.googlefonts import com_google_fonts_check_canonical_filename as check
 
   static_canonical_names = [
     "data/test/montserrat/Montserrat-Thin.ttf",


### PR DESCRIPTION
There are special naming rules for variable fonts.

This pull request addresses the problems described at issue #2396 
