### PR TITLE
enable FontForge checks in Adobe Fonts profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Other important code-changes
   - We temporarily disabled com.google.fonts/check/metadata/match_filename_postscript for variable fonts until we have a clear definition of the VF naming rules as discussed at https://github.com/google/fonts/issues/1817
   - We're now using portable paths on the code-tests. (issue #2398)
+  - The Adobe Fonts profile now includes FontForge checks. (PR #2401)
 
 
 ## 0.6.12 (2019-Mar-11)

--- a/Lib/fontbakery/specifications/adobe_fonts.py
+++ b/Lib/fontbakery/specifications/adobe_fonts.py
@@ -127,9 +127,6 @@ def com_adobe_fonts_check_consistent_upm(ttFonts):
 
 def check_skip_filter(checkid, font=None, **iterargs):
     if font and checkid in (
-        # ToDo: revisit the FontForge checks -- can we filter just some out?
-        'com.google.fonts/check/038',  # FontForge #1 of 2
-        'com.google.fonts/check/039',  # FontForge #2 of 2
         'com.google.fonts/check/064',  # Is there a caret position declared for every ligature?
         'com.google.fonts/check/065',  # Is there kerning info for non-ligated sequences?
         'com.google.fonts/check/163'   # Combined length of family and style must not exceed 20 characters.


### PR DESCRIPTION
## Description
Enable FontForge checks in Adobe Fonts profile.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

