### PR TITLE
HTML reporter: Stylize collapsibles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - We're now using portable paths on the code-tests. (issue #2398)
   - The Adobe Fonts profile now includes FontForge checks. (PR #2401)
 
+### Miscellaneous
+  - The HTML reporter will now display check results more table-like, which makes multi-line check results look better.
 
 ## 0.6.12 (2019-Mar-11)
 ### Bug fixes
@@ -29,7 +31,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### New features
   - We now have an Adobe collection of checks (specification). It will include more checks in future releases. (PR #2369)
-  - The `FontSpec` class now has a `get_family_checks()` method that returns a list of family-level checks. (PR #2380) 
+  - The `FontSpec` class now has a `get_family_checks()` method that returns a list of family-level checks. (PR #2380)
 
 ### New checks
   - **[com.adobe.fonts/check/bold_italic_unique_for_nameid1]:** "OS/2.fsSelection bold & italic are unique for each NameID1" (PR #2388)

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -114,7 +114,12 @@ class HTMLReporter(fontbakery.reporters.serialize.SerializeReporter):
             emoticon = EMOTICON[log["status"]]
             status = log["status"]
             message = html.escape(log["message"]).replace("\n", "<br/>")
-            return f"<li>{emoticon} <strong>{status}</strong> {message}</li>"
+            return (
+                "<li class='details_item'>"
+                f"<span class='details_indicator'>{emoticon} {status}</span>"
+                f"<span class='details_text'>{message}</span>"
+                "</li>"
+            )
         return ""
 
 
@@ -122,25 +127,56 @@ def html5_document(body_elements) -> str:
     """Return complete HTML5 document string."""
 
     style = """
-html {font-family: "Aktiv Grotesk", sans;}
-h2 { margin-top: 2em;}
-h3 { margin-bottom: 1px;}
-.details {text-indent: 1em;}
-ul {
-    margin-top: 0;
-    margin-left: 1em;
-}
-table {
-    border-collapse: collapse;
-}
-th, td {
-    border: 1px solid #ddd;
-    padding: 0.5em
-}
-tr:nth-child(even) {background-color: #f2f2f2;}
-tr {
-    text-align: left;
-}
+            html {
+                font-family: "Aktiv Grotesk", sans;
+            }
+
+            h2 {
+                margin-top: 2em;
+            }
+
+            h3 {
+                margin-bottom: 1px;
+            }
+
+            table {
+                border-collapse: collapse;
+            }
+
+            th,
+            td {
+                border: 1px solid #ddd;
+                padding: 0.5em
+            }
+
+            tr:nth-child(even) {
+                background-color: #f2f2f2;
+            }
+
+            tr {
+                text-align: left;
+            }
+
+            ul {
+                margin-top: 0;
+            }
+
+            .details_item {
+                list-style: none;
+                display: flex;
+                align-items: baseline;
+            }
+
+            .details_indicator {
+                flex: 0 0 5em;
+                font-weight: bold;
+                padding-right: 0.5em;
+                text-align: right;
+            }
+
+            .details_text {
+                flex: 1 0;
+            }
             """
     body = "\n".join(body_elements)
     return f"""<!DOCTYPE html>
@@ -162,12 +198,7 @@ def html5_collapsible(summary, details) -> str:
     """Return nestable, collapsible <detail> tag for check grouping and sub-
     results."""
 
-    return (
-        "<details>"
-        f"<summary>{summary}</summary>"
-        f"<div class='details'>{details}</div>"
-        "</details>"
-    )
+    return f"<details><summary>{summary}</summary><div>{details}</div></details>"
 
 
 def summary_table(


### PR DESCRIPTION
The HTML reporter will now display check results more table-like, which makes multi-line check results look better.