### PR TITLE
Cap accepted winDescent and winAscent values on com.google.fonts/check/win_ascent_and_descent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix bug in which a singular ttFont condition causes a family-wide (ttFonts) check to be executed once per font. (issue #2370)
   - **[com.google.fonts/check/079]:** Fixed bug in which this check was not confirming that font seemed monospaced before reporting different advance widths. (PR #2368, part of issue #2366)
   - Protect condition ttfautohint_stats against non-ttf fonts (issue #2385)
+  - **[com.google/fonts/check/040]:** Cap accepted winDescent and winAscent values. Both should be less than double their respective bounding box values.
 
 ### New features
   - We now have an Adobe collection of checks (specification). It will include more checks in future releases. (PR #2369)

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -3484,6 +3484,13 @@ def com_google_fonts_check_win_ascent_and_descent(ttFont, vmetrics):
                          " should be equal or greater than {}, but got"
                          " {} instead").format(vmetrics['ymax'],
                                                ttFont['OS/2'].usWinAscent))
+  if ttFont['OS/2'].usWinAscent > vmetrics['ymax'] * 2:
+    failed = True
+    yield FAIL, Message(
+        "ascent", ("OS/2.usWinAscent value {} is too large."
+                   " It should be less than double the yMax."
+                   " Current yMax value is {}").format(ttFont['OS/2'].usWinDescent,
+                                                       vmetrics['ymax']))
   # OS/2 usWinDescent:
   if ttFont['OS/2'].usWinDescent < abs(vmetrics['ymin']):
     failed = True
@@ -3492,6 +3499,14 @@ def com_google_fonts_check_win_ascent_and_descent(ttFont, vmetrics):
                     " should be equal or greater than {}, but got"
                     " {} instead").format(
                         abs(vmetrics['ymin']), ttFont['OS/2'].usWinDescent))
+
+  if ttFont['OS/2'].usWinDescent > abs(vmetrics['ymin']) * 2:
+    failed = True
+    yield FAIL, Message(
+        "descent", ("OS/2.usWinDescent value {} is too large."
+                    " It should be less than double the yMin."
+                    " Current absolute yMin value is {}").format(ttFont['OS/2'].usWinDescent,
+                                                                 abs(vmetrics['ymin'])))
   if not failed:
     yield PASS, "OS/2 usWinAscent & usWinDescent values look good!"
 


### PR DESCRIPTION
(followup to PR #2390)