### PR TITLE
Refactored com.google.fonts/check/metadata/valid_copyright into two checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/canonical_filename]:** Distinguish static from varfont when reporting correctness of fontfile names. There are special naming rules for variable fonts. (issue #2396)
   - Fix bug in handling of `most_common_width` in `glyph_metrics_stats` which affected checking of monospaced metadata. (PR #2391)
   - Fix handling of `post.isFixedPitch` (accept any nonzero value). (PR #2392)
+  - **[com.google.fonts/check/metadata/valid_copyright]:** Check was being skipped when run on upstream font repos which don't have a METADATA.pb file. This check will now only test METADATA.pb files. A new check has been added to check the copyright string in fonts.
 
 ### New checks
+  - **[com.google.fonts/check/font_copyright]: "Copyright notices match canonical pattern in fonts"**
   - **[com.adobe.fonts/check/postscript_name_consistency]:** "Name table ID 6 (PostScript name) must be consistent across platforms." (PR #2394)
 
 ### Renamed numerical check-IDs:

--- a/tests/specifications/googlefonts_test.py
+++ b/tests/specifications/googlefonts_test.py
@@ -1488,8 +1488,8 @@ def test_check_metadata_valid_copyright():
   font_meta = font_metadata(family_meta, fontfile)
 
   # So it must FAIL the check:
-  print ("Test FAIL with a bad copyright notice string...")
-  status, message = list(check(ttFont, font_meta))[-1]
+  print("Test FAIL with a bad copyright notice string...")
+  status, message = list(check(font_meta))[-1]
   assert status == FAIL
 
   # Then we change it into a good string (example extracted from Archivo Black):
@@ -1497,12 +1497,32 @@ def test_check_metadata_valid_copyright():
   #       It only focuses on the string format.
   good_string = "Copyright 2017 The Archivo Black Project Authors (https://github.com/Omnibus-Type/ArchivoBlack)"
   font_meta.copyright = good_string
+  print("Test PASS with a good copyright notice string...")
+  status, message = list(check(font_meta))[-1]
+  assert status == PASS
+
+
+def test_check_font_copyright():
+  """Copyright notices match canonical pattern in fonts"""
+  from fontbakery.specifications.googlefonts import com_google_fonts_check_font_copyright as check
+  # Our reference Cabin Regular is known to be bad
+  # Since it provides an email instead of a git URL:
+  fontfile = TEST_FILE("cabin/Cabin-Regular.ttf")
+  ttFont = TTFont(fontfile)
+
+  # So it must FAIL the check:
+  print("Test FAIL with a bad copyright notice string...")
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL
+
+  # Then we change it into a good string (example extracted from Archivo Black):
+  # note: the check does not actually verify that the project name is correct.
+  #       It only focuses on the string format.
+  good_string = "Copyright 2017 The Archivo Black Project Authors (https://github.com/Omnibus-Type/ArchivoBlack)"
   for i, entry in enumerate(ttFont['name'].names):
     if entry.nameID == NameID.COPYRIGHT_NOTICE:
       ttFont['name'].names[i].string = good_string.encode(entry.getEncoding())
-
-  print ("Test PASS with a good copyright notice string...")
-  status, message = list(check(ttFont, font_meta))[-1]
+  status, message = list(check(ttFont))[-1]
   assert status == PASS
 
 


### PR DESCRIPTION
com.google.fonts/check/metadata/valid_copyright will not run on upstream
font repos since it needs a METADATA.pb file. This check will now only check
that METADATA.pb files have the correct copyright string.

New check com.google.fonts/check/font_copyright will ensure that a font's
copyright strings are correct.

(follow-up to PR #2383 / Fixes #2210)