### PR TITLE
opentype-sanitizer >= 7.1.9: fixes caret format = 3 bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ defusedxml==0.5.0
 font-v==0.7.1
 fontTools[ufo,lxml]==3.38.0
 lxml==4.3.2
-opentype-sanitizer==7.1.8
+opentype-sanitizer==7.1.9
 protobuf==3.7.0
 requests==2.21.0
 ttfautohint-py==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
         'font-v',
         'fontTools[ufo,lxml]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
         'lxml',
-        'opentype-sanitizer',
+        'opentype-sanitizer>=7.1.9',  # 7.1.9 fixes caret value format = 3 bug
+                                      # (see https://github.com/khaledhosny/ots/pull/182)
         'protobuf>=3.7.0',  # 3.7.0 fixed a bug on parsing some METADATA.pb files
                             # (see https://github.com/googlefonts/fontbakery/issues/2200)
         'requests',


### PR DESCRIPTION
(#2379, https://github.com/googlefonts/ots-python/issues/4, https://github.com/khaledhosny/ots/pull/182)