### PR TITLE
don't assume private subroutines in a CFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.7.2 (2019-Apr-08)
-  - ...
-
+### Bug fixes
+  - **[com.adobe.fonts/check/cff_call_depth]: don't assume private subroutines in a CFF (PR #2437)
 
 ## 0.7.1 (2019-Apr-02)
 ### Major code-changes

--- a/Lib/fontbakery/profiles/cff.py
+++ b/Lib/fontbakery/profiles/cff.py
@@ -57,8 +57,12 @@ def com_adobe_fonts_check_cff_call_depth(ttFont):
         global_subrs = top_dict.GlobalSubrs
         gsubr_bias = _get_subr_bias(len(global_subrs))
 
-        subrs = top_dict.Private.Subrs
-        subr_bias = _get_subr_bias(len(subrs))
+        if hasattr(top_dict, 'Private') and hasattr(top_dict.Private, 'Subrs'):
+            subrs = top_dict.Private.Subrs
+            subr_bias = _get_subr_bias(len(subrs))
+        else:
+            subrs = None
+            subr_bias = None
 
         char_list = char_strings.keys()
         for key in char_list:


### PR DESCRIPTION
## Description

The `cff_call_depth` routine assumed that the `CFF` table has a private dict which has subroutines. That is not the case in all fonts. This change first checks that the top dict includes a private dict, and then checks that the private dict includes subroutines.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

