### PR TITLE
fixed handling of font dicts in cff2_call_depth check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.7.2 (2019-Apr-08)
 ### Bug fixes
-  - **[com.adobe.fonts/check/cff_call_depth]: don't assume private subroutines in a CFF (PR #2437)
+  - **[com.adobe.fonts/check/cff_call_depth]:** don't assume private subroutines in a CFF (PR #2437)
+  - **[com.adobe.fonts/cff2_call_depth]:** fixed handling of font dicts (and private subroutines) in a CFF2 (PR #2441)
 
 ### Dependencies
   - Removed the unidecode dependency. It is better to read log messages with the actual unicode strings instead of transliterations of them.


### PR DESCRIPTION
## Description
This pull request addresses fixes handling of font dicts in the `cff2_call_depth` check:
* confirm font dict has private subroutines before trying to use them
* confirm glyph's font dict selection index matches current font dict before processing

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

