### PR TITLE
increase max length to 27 chars on com.google.fonts/check/name/family_and_style_max_length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.7.2 (2019-Apr-08)
+### Note-worthy code changes
+  - **[com.google.fonts/check/name/family_and_style_max_length]:** increased max length to 27 chars. After discussing the problem in more detail at issue #2179 we decided that allowing up to 27 chars would still be on the safe side. Please also see issue #2447
+
 ### Bug fixes
   - **[com.adobe.fonts/check/cff_call_depth]:** don't assume private subroutines in a CFF (PR #2437)
   - **[com.adobe.fonts/cff2_call_depth]:** fixed handling of font dicts (and private subroutines) in a CFF2 (PR #2441)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3750,6 +3750,11 @@ def com_google_fonts_check_kerning_for_non_ligated_sequences(ttFont, ligatures, 
     familyname (NameID.FONT_FAMILY_NAME) and style
     (NameID.FONT_SUBFAMILY_NAME)
     strings in the name table do not exceed 20 characters.
+
+    After discussing the problem in more detail at
+    https://github.com/googlefonts/fontbakery/issues/2179
+    we decided to allowing up to 27 chars would still be
+    on the safe side, though.
     """,
   misc_metadata = {
     # Somebody with access to Windows should make some experiments
@@ -3759,7 +3764,7 @@ def com_google_fonts_check_kerning_for_non_ligated_sequences(ttFont, ligatures, 
   }
 )
 def com_google_fonts_check_name_family_and_style_max_length(ttFont):
-  """Combined length of family and style must not exceed 20 characters."""
+  """Combined length of family and style must not exceed 27 characters."""
   from fontbakery.utils import (get_name_entries,
                                 get_name_entry_strings)
   failed = False
@@ -3771,14 +3776,18 @@ def com_google_fonts_check_name_family_and_style_max_length(ttFont):
     for stylename_str in get_name_entry_strings(ttFont,
                                                 NameID.FONT_SUBFAMILY_NAME,
                                                 platformID=plat):
-      if len(familyname_str + stylename_str) > 20:
+      if len(familyname_str + stylename_str) > 27:
         failed = True
         yield WARN, ("The combined length of family and style"
-                     " exceeds 20 chars in the following '{}' entries:"
+                     " exceeds 27 chars in the following '{}' entries:"
                      " FONT_FAMILY_NAME = '{}' / SUBFAMILY_NAME = '{}'"
                      "").format(PlatformID(plat).name,
                                 familyname_str,
                                 stylename_str)
+        yield WARN, ("Please take a look at the conversation at"
+                     " https://github.com/googlefonts/fontbakery/issues/2179"
+                     " in order to understand the reasoning behing these"
+                     " name table records max-length criteria.")
   if not failed:
     yield PASS, "All name entries are good."
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -288,17 +288,33 @@ def test_check_name_family_and_style_max_length():
   status, message = list(check(ttFont))[-1] 
   assert status == PASS 
  
-  # Then we emit a WARNing with the long family/style names 
-  # that were used as an example on the glyphs tutorial 
-  # (at https://glyphsapp.com/tutorials/multiple-masters-part-3-setting-up-instances): 
+  # Then we emit a WARNing with long family/style names 
+  # Originaly these were based on the example on the glyphs tutorial
+  # (at https://glyphsapp.com/tutorials/multiple-masters-part-3-setting-up-instances)
+  # but later we increased a bit the max allowed length.
+
+  # First we expect a WARN with a bad FAMILY NAME
   for index, name in enumerate(ttFont["name"].names): 
-    if name.nameID == NameID.FONT_FAMILY_NAME: 
-      ttFont["name"].names[index].string = "ImpossibleFamilyNameFont".encode(name.getEncoding()) 
+    if name.nameID == NameID.FONT_FAMILY_NAME:
+      # This has 28 chars, while the max currently allowed is 27.
+      bad = "AnAbsurdlyLongFamilyNameFont"
+      assert len(bad) == 28
+      ttFont["name"].names[index].string = bad.encode(name.getEncoding()) 
       break 
+
+  print ("Test WARN with a bad font...") 
+  status, message = list(check(ttFont))[-1] 
+  assert status == WARN 
+
+  # Now let's restore the good Cabin Regular...
+  ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf")) 
  
+  # ...and break the check again with a bad SUBFAMILY NAME:
   for index, name in enumerate(ttFont["name"].names): 
-    if name.nameID == NameID.FONT_SUBFAMILY_NAME: 
-      ttFont["name"].names[index].string = "WithAVeryLongStyleName".encode(name.getEncoding()) 
+    if name.nameID == NameID.FONT_SUBFAMILY_NAME:
+      bad = "WithAVeryLongAndBadStyleName"
+      assert len(bad) == 28
+      ttFont["name"].names[index].string = bad.encode(name.getEncoding()) 
       break 
  
   print ("Test WARN with a bad font...") 


### PR DESCRIPTION
After discussing the problem in more detail at issue #2179 we decided that allowing up to 27 chars would still be on the safe side.

Please also see issue #2447