### PR TITLE
Filter out the .ttfautohint glyph component from the contour count at com.google.fonts/check/contour_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bug fixes
   - **[com.adobe.fonts/check/cff_call_depth]:** don't assume private subroutines in a CFF (PR #2437)
   - **[com.adobe.fonts/cff2_call_depth]:** fixed handling of font dicts (and private subroutines) in a CFF2 (PR #2441)
+  - **[com.google.fonts/check/contour_count]:** Filter out the .ttfautohint glyph component from the contour count (issue #2443)
 
 ### Dependencies
   - Removed the unidecode dependency. It is better to read log messages with the actual unicode strings instead of transliterations of them.

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -104,7 +104,8 @@ def glyph_contour_count(font, name):
         g = items.pop(0)
         if g.isComposite():
             for comp in g.components:
-                items.append(font['glyf'][comp.glyphName])
+                if comp.glyphName != ".ttfautohint":
+                    items.append(font['glyf'][comp.glyphName])
         if g.numberOfContours != -1:
             contour_count += g.numberOfContours
     return contour_count


### PR DESCRIPTION
This pull request addresses the problems described at issue #2443
