### PR TITLE
fixed a minor typo: subcommnds -> subcommands

### DIFF
--- a/Lib/fontbakery/cli.py
+++ b/Lib/fontbakery/cli.py
@@ -35,7 +35,7 @@ def main():
         parser.add_argument(
             '--list-subcommands',
             action='store_true',
-            help='print the list of subcommnds '
+            help='print the list of subcommands '
             'to stdout, separated by a space character. This is '
             'usually only used to generate the shell completion code.')
         parser.add_argument(

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -26,7 +26,7 @@ This has several subcommands, described in the help function:
     
     optional arguments:
       -h, --help          show this help message and exit
-      --list-subcommands  print the list of subcommnds to stdout, separated 
+      --list-subcommands  print the list of subcommands to stdout, separated 
                           by a space character. This is usually only used to 
                           generate the shell completion code.
 


### PR DESCRIPTION
## Description

This pull request fixes a minor typo (`subcommnds` -> `subcommands`) in the help text and in the documentation.

## To Do
* ~update `CHANGELOG.md`~ -- I think this is too minor to warrant a change log edit, let me know if you think otherwise
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

