### PR TITLE
fix ERROR on com.google.fonts/check/family/equal_glyph_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/name/family_and_style_max_length]:** increased max length to 27 chars. After discussing the problem in more detail at issue #2179 we decided that allowing up to 27 chars would still be on the safe side. Please also see issue #2447
 
 ### Bug fixes
+  - **[com.google.fonts/check/family/equal_glyph_names]:** Fix ERROR. When dealing with variable fonts, we end up getting None from the style condition. So we display filenames in those cases. But we still display styles when dealing with statics fonts. (issue #2375)
   - **[com.adobe.fonts/check/cff_call_depth]:** don't assume private subroutines in a CFF (PR #2437)
   - **[com.adobe.fonts/cff2_call_depth]:** fixed handling of font dicts (and private subroutines) in a CFF2 (PR #2441)
   - **[com.google.fonts/check/contour_count]:** Filter out the .ttfautohint glyph component from the contour count (issue #2443)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -509,22 +509,30 @@ def com_google_fonts_check_family_equal_glyph_names(ttFonts):
   failed = False
   for ttFont in fonts:
     fontname = ttFont.reader.file.name
-    stylename = style(fontname)
     these_ones = set(ttFont["glyf"].glyphs.keys())
     for glyphname in all_glyphnames:
       if glyphname not in these_ones:
         failed = True
-        missing[glyphname].append(stylename)
+        missing[glyphname].append(fontname)
       else:
-        available[glyphname].append(stylename)
+        available[glyphname].append(fontname)
 
   for gn in missing.keys():
     if missing[gn]:
-      yield FAIL, ("Glyphname '{}' is defined on {}"
-                   " but is missing on"
-                   " {}.").format(gn,
-                                  ', '.join(available[gn]),
-                                  ', '.join(missing[gn]))
+      available_styles = [style(k) for k in available[gn]]
+      missing_styles = [style(k) for k in missing[gn]]
+      if None not in available_styles + missing_styles:
+          # if possible, use stylenames in the log messages.
+          avail = ', '.join(available_styles)
+          miss = ', '.join(missing_styles)
+      else:
+          # otherwise, print filenames:
+          avail = ', '.join(available[gn])
+          miss = ', '.join(missing[gn])
+
+      yield FAIL, (f"Glyphname '{gn}' is defined on {avail}"
+                   f" but is missing on {miss}.")
+
   if not failed:
     yield PASS, "All font files have identical glyph names."
 


### PR DESCRIPTION
When dealing with variable fonts, we end up getting None from the style condition. So we display filenames in those cases. But we still display styles when dealing with statics fonts.
(issue #2375)