### PR TITLE
added com.adobe.fonts/check/find_empty_letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+## 0.7.3 (2019-Apr-15)
+
+### New checks
+  - **[com.adobe.fonts/check/find_empty_letters]:** Letters in font have glyphs that are not empty? (PR #2460)
+
 ## 0.7.2 (2019-Apr-09)
 ### Note-worthy code changes
   - **[com.google.fonts/check/name/family_and_style_max_length]:** increased max length to 27 chars. After discussing the problem in more detail at issue #2179 we decided that allowing up to 27 chars would still be on the safe side. Please also see issue #2447

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -1,6 +1,8 @@
 """
 Checks for Adobe Fonts (formerly known as Typekit).
 """
+import unicodedata
+
 from fontbakery.callable import check
 from fontbakery.checkrunner import Section, PASS, FAIL
 from fontbakery.fonts_profile import profile_factory
@@ -11,8 +13,10 @@ profile = profile_factory(default_section=Section("Adobe Fonts"))
 
 ADOBEFONTS_PROFILE_CHECKS = \
     UNIVERSAL_PROFILE_CHECKS + [
-    'com.adobe.fonts/check/family/consistent_upm'
-]
+        'com.adobe.fonts/check/family/consistent_upm',
+        'com.adobe.fonts/check/find_empty_letters'
+    ]
+
 
 @check(
     id='com.adobe.fonts/check/family/consistent_upm',
@@ -30,6 +34,74 @@ def com_adobe_fonts_check_family_consistent_upm(ttFonts):
                      ).format(sorted(upm_set))
     else:
         yield PASS, "Fonts have consistent units per em."
+
+
+def _quick_and_dirty_glyph_is_empty(font, glyph_name):
+    """
+    This is meant to be a quick-and-dirty test to see if a glyph is empty.
+    Ideally we'd use the glyph_has_ink() method for this, but for a family of
+    large CJK CFF fonts with tens of thousands of glyphs each, it's too slow.
+
+    Caveat Utilitor:
+    If this method returns True, the glyph is definitely empty.
+    If this method returns False, the glyph *might* still be empty.
+    """
+    if 'glyf' in font:
+        glyph = font['glyf'][glyph_name]
+        if not glyph.isComposite():
+            if glyph.numberOfContours == 0:
+                return True
+        return False
+    elif 'CFF2' in font:
+        top_dict = font['CFF2'].cff.topDictIndex[0]
+    else:
+        top_dict = font['CFF '].cff.topDictIndex[0]
+    char_strings = top_dict.CharStrings
+    char_string = char_strings[glyph_name]
+    if len(char_string.bytecode) <= 1:
+        return True
+    return False
+
+
+@check(
+    id='com.adobe.fonts/check/find_empty_letters',
+    rationale="""Font language, script, and character set tagging approaches
+    typically have an underlying assumption that letters (i.e. characters with
+    Unicode general category 'Ll', 'Lm', 'Lo', 'Lt', or 'Lu', which includes
+    CJK ideographs and Hangul syllables) with entries in the 'cmap' table have
+    glyphs with ink (with a few exceptions, notably the Hangul "filler"
+    characters).
+
+    This check is intended to identify fonts in which such letters have been
+    mapped to empty glyphs (typically done as a form of subsetting). Letters
+    with empty glyphs should have their entries removed from the 'cmap' table,
+    even if the empty glyphs are left in place (e.g. for CID consistency).
+    """
+)
+def com_adobe_fonts_check_find_empty_letters(ttFont):
+    """Letters in font have glyphs that are not empty?"""
+    cmap = ttFont.getBestCmap()
+    passed = True
+
+    # http://unicode.org/reports/tr44/#General_Category_Values
+    letter_categories = {
+        'Ll', 'Lm', 'Lo', 'Lt', 'Lu',
+    }
+    invisible_letters = {
+        0x115F, 0x1160, 0x3164, 0xFFA0,  # Hangul filler chars (category='Lo')
+    }
+    for unicode_val, glyph_name in cmap.items():
+        category = unicodedata.category(chr(unicode_val))
+        if (_quick_and_dirty_glyph_is_empty(ttFont, glyph_name)) \
+                and (category in letter_categories) \
+                and (unicode_val not in invisible_letters):
+            yield FAIL, \
+                ("U+%04X should be visible, but its glyph ('%s') is empty."
+                 % (unicode_val, glyph_name))
+            passed = False
+    if passed:
+        yield PASS, "No empty glyphs for letters found."
+
 
 # ToDo: add many more checks...
 

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -46,3 +46,23 @@ def test_get_family_checks():
         'com.google.fonts/check/family/win_ascent_and_descent'
     }
     assert family_check_ids == expected_family_check_ids
+
+
+def test_check_find_empty_letters():
+    from fontbakery.profiles.adobefonts import \
+        com_adobe_fonts_check_find_empty_letters as check
+
+    # this font has inked glyphs for all letters
+    font_path = TEST_FILE('source-sans-pro/OTF/SourceSansPro-Regular.otf')
+    test_font = TTFont(font_path)
+    status, message = list(check(test_font))[-1]
+    assert status == PASS
+
+    # this font has empty glyphs for several letters
+    font_path = TEST_FILE('familysans/FamilySans-Regular.ttf')
+    test_font = TTFont(font_path)
+
+    expected_message = "U+007A should be visible, but its glyph ('z') is empty."
+    status, message = list(check(test_font))[-1]
+    assert status == FAIL
+    assert message == expected_message


### PR DESCRIPTION
## Description

Font language, script, and character set tagging approaches typically have an underlying assumption that letters (i.e. characters with Unicode general category 'Ll', 'Lm', 'Lo', 'Lt', or 'Lu', which includes CJK ideographs and Hangul syllables) with entries in the 'cmap' table have glyphs with ink (with a few exceptions, notably the Hangul "filler" characters).

This check is intended to identify fonts in which such letters have been mapped to empty glyphs (typically done as a form of subsetting). Letters with empty glyphs should have their entries removed from the 'cmap' table, even if the empty glyphs are left in place (e.g. for CID consistency).

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

