### PR TITLE
fixed handling of font dicts in a CFF in cff_call_depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.adobe.fonts/check/find_empty_letters]:** Letters in font have glyphs that are not empty? (PR #2460)
 
+### Bug fixes
+  - **[com.adobe.fonts/cff_call_depth]:** fixed handling of font dicts in a CFF (PR #2461)
+
 ## 0.7.2 (2019-Apr-09)
 ### Note-worthy code changes
   - **[com.google.fonts/check/name/family_and_style_max_length]:** increased max length to 27 chars. After discussing the problem in more detail at issue #2179 we decided that allowing up to 27 chars would still be on the safe side. Please also see issue #2447


### PR DESCRIPTION
## Description

This pull request fixes handling of font dicts in a CFF in the `cff_call_depth` check.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

