### PR TITLE
Declare fonttools' unicode extra-dependency on our rquirements.txt and setup.py so that unicodedata2 is properly installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.7.3 (2019-Apr-15)
-
 ### New checks
   - **[com.adobe.fonts/check/find_empty_letters]:** Letters in font have glyphs that are not empty? (PR #2460)
 
 ### Bug fixes
   - **[com.adobe.fonts/cff_call_depth]:** fixed handling of font dicts in a CFF (PR #2461)
+  - Declare fonttools' unicode extra-dependency on our rquirements.txt and setup.py so that unicodedata2 is properly installed. (issue #2462)
+
 
 ## 0.7.2 (2019-Apr-09)
 ### Note-worthy code changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.7.1
 defcon==0.6.0
 defusedxml==0.5.0
 font-v==0.7.1
-fontTools[ufo,lxml]==3.39.0
+fontTools[ufo,lxml,unicode]==3.39.0
 lxml==4.3.3
 opentype-sanitizer==7.1.9
 protobuf==3.7.1

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'defcon',
         'defusedxml',
         'font-v',
-        'fontTools[ufo,lxml]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
+        'fontTools[ufo,lxml,unicode]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
         'lxml',
         'opentype-sanitizer>=7.1.9',  # 7.1.9 fixes caret value format = 3 bug
                                       # (see https://github.com/khaledhosny/ots/pull/182)


### PR DESCRIPTION
This pull request addresses the problems described at issue #2462