### PR TITLE
new: com.google.fonts/check/family_has_same_vertical_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.adobe.fonts/check/find_empty_letters]:** "Letters in font have glyphs that are not empty?" (PR #2460)
   - **[com.google.fonts/check/repo/dirname_matches_nameid_1]:** "Directory name in GFonts repo structure must match NameID 1." (issue #2302)
+  - **[com.google.fonts/check/family_has_same_vertical_metrics]:** "Each font in a family must have the same vertical metrics values."
 
 ### Bug fixes
   - **[com.adobe.fonts/cff_call_depth]:** fixed handling of font dicts in a CFF (PR #2461)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2944,3 +2944,14 @@ def test_check_family_control_chars():
   assert status == FAIL
 
 
+def test_check_family_has_same_vertical_metrics(montserrat_ttFonts):
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_family_has_same_vertical_metrics as check
+  print("Test pass with multiple good fonts...")
+  status, message = list(check(montserrat_ttFonts))[-1]
+  assert status == PASS
+
+  print("Test fail with one bad font that has one different vertical metric val...")
+  montserrat_ttFonts[0]['OS/2'].usWinAscent = 4000
+  status, message = list(check(montserrat_ttFonts))[-1]
+  assert status == FAIL
+


### PR DESCRIPTION
## Description
Each font in a family must have the same vertical metrics values.

I'm planning on making a set of checks for https://github.com/googlefonts/fontbakery/issues/1162#issuecomment-451126458 which I proposed earlier this year. I'm hoping this will clear up any vertical metrics convos we've had in the past.

If the family does have inconsistent vertical metrics, the check will report only the attributes which are different.

<img width="1440" alt="Screenshot 2019-04-16 at 09 48 34" src="https://user-images.githubusercontent.com/7525512/56195404-d206cf80-602c-11e9-8f34-5284caa7d04c.png">


## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

