### PR TITLE
new check: com.google.fonts/check/code_pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - We now autocomplete check IDs on the command line (issue #2457)
 
 ### New checks
+  - **[com.google.fonts/check/code_pages]:** Detects when no code page was declared on the OS/2 table, fields ulCodePageRange1 and ulCodePageRange2 (issue #2474)
   - **[com.adobe.fonts/check/find_empty_letters]:** "Letters in font have glyphs that are not empty?" (PR #2460)
   - **[com.google.fonts/check/repo/dirname_matches_nameid_1]:** "Directory name in GFonts repo structure must match NameID 1." (issue #2302)
   - **[com.google.fonts/check/family/vertical_metrics]:** "Each font in a family must have the same vertical metrics values." (PR #2468)

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -65,7 +65,8 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/points_out_of_bounds',
     'com.google.fonts/check/all_glyphs_have_codepoints',
     'com.google.fonts/check/monospace_max_advancewidth',
-    'com.google.fonts/check/wght_valid_range'
+    'com.google.fonts/check/wght_valid_range',
+    'com.google.fonts/check/code_pages',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/os2.py
+++ b/Lib/fontbakery/profiles/os2.py
@@ -219,3 +219,34 @@ def com_adobe_fonts_check_family_bold_italic_unique_for_nameid1(ttFonts):
   if not failed:
     yield PASS, ("The OS/2.fsSelection bold & italic settings were unique "
                  "within each compatible family group.")
+
+
+@check(
+  id = 'com.google.fonts/check/code_pages',
+  rationale = """
+  At least some programs (such as Word and Sublime Text) under Windows 7
+  do not recognize fonts unless code page bits are properly set on the
+  ulCodePageRange1 (and/or ulCodePageRange2) fields of the OS/2 table.
+
+  More specifically, the fonts are selectable in the font menu, but
+  whichever Windows API these applications use considers them unsuitable
+  for any character set, so anything set in these fonts is rendered
+  with a fallback font of Arial.
+
+  This check currently does not identify which code pages should be set.
+  Auto-detecting coverage is not trivial since the OpenType specification
+  leaves the interpretation of whether a given code page is "functional"
+  or not open to the font developer to decide.
+
+  So here we simply detect as a FAIL when a given font has no code page
+  declared at all.
+  """
+)
+def com_google_fonts_check_code_pages(ttFont):
+  """Check code page character ranges"""
+
+  if ttFont['OS/2'].ulCodePageRange1 == 0 and ttFont['OS/2'].ulCodePageRange2 == 0:
+    yield FAIL, ("No code pages defined in the OS/2 table"
+                 " ulCodePageRage1 and CodePageRage2 fields.")
+  else:
+    yield PASS, "At least one code page is defined."

--- a/Lib/fontbakery/profiles/os2.py
+++ b/Lib/fontbakery/profiles/os2.py
@@ -245,7 +245,10 @@ def com_adobe_fonts_check_family_bold_italic_unique_for_nameid1(ttFonts):
 def com_google_fonts_check_code_pages(ttFont):
   """Check code page character ranges"""
 
-  if ttFont['OS/2'].ulCodePageRange1 == 0 and ttFont['OS/2'].ulCodePageRange2 == 0:
+  if not hasattr(ttFont['OS/2'], "ulCodePageRange1") or \
+     not hasattr(ttFont['OS/2'], "ulCodePageRange2") or \
+     (ttFont['OS/2'].ulCodePageRange1 == 0 and \
+      ttFont['OS/2'].ulCodePageRange2 == 0):
     yield FAIL, ("No code pages defined in the OS/2 table"
                  " ulCodePageRage1 and CodePageRage2 fields.")
   else:

--- a/tests/profiles/os2_test.py
+++ b/tests/profiles/os2_test.py
@@ -203,3 +203,21 @@ def test_check_family_bold_italic_unique_for_nameid1():
                      "bold & italic settings: Bold=True, Italic=True"
   assert message == expected_message
   assert status == FAIL
+
+
+def test_check_code_pages():
+  """ Check code page character ranges """
+  from fontbakery.profiles.os2 import com_google_fonts_check_code_pages as check
+
+  print('Test PASS with good font.')
+  ttFont = TEST_FILE("merriweather/Merriweather-Regular.ttf")
+  status, message = list(check(ttFont))[-1]
+  assert(ttFont['OS/2'].ulCodePageRange1 != 0 or
+         ttFont['OS/2'].ulCodePageRange2 != 0) # It has got at least 1 code page range declared
+  assert status == PASS
+
+  print('Test FAIL with a font with no code page declared.')
+  ttFont['OS/2'].ulCodePageRange1 = 0 # remove all code pages to make the check FAIL
+  ttFont['OS/2'].ulCodePageRange2 = 0
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL

--- a/tests/profiles/os2_test.py
+++ b/tests/profiles/os2_test.py
@@ -210,7 +210,7 @@ def test_check_code_pages():
   from fontbakery.profiles.os2 import com_google_fonts_check_code_pages as check
 
   print('Test PASS with good font.')
-  ttFont = TEST_FILE("merriweather/Merriweather-Regular.ttf")
+  ttFont = TTFont(TEST_FILE("merriweather/Merriweather-Regular.ttf"))
   status, message = list(check(ttFont))[-1]
   assert(ttFont['OS/2'].ulCodePageRange1 != 0 or
          ttFont['OS/2'].ulCodePageRange2 != 0) # It has got at least 1 code page range declared


### PR DESCRIPTION
Detects when no code page was declared on the OS/2 table, fields ulCodePageRange1 and ulCodePageRange2
(issue #2474)