### PR TITLE
WIP: new check: com.google.fonts/check/vertical_metrics_regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### New checks
   - **[com.google.fonts/check/metadata/designer_values]:** We must use commas instead of forward slashes because the fonts.google.com directory will segment string to list on comma and display the first item in the list as the "principal designer" and the other items as contributors.
+  - **[com.google.fonts/check/vertical_metrics_regressions]:** If a family already exists on Google Fonts, the family being checked must have similar vertical metrics. (issue #1162)
 
 ### Bug fixes
   - **[com.google.fonts/check/dsig]:** Mention which gftools script can fix the issue.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -125,6 +125,7 @@ FONT_FILE_CHECKS = [
    'com.google.fonts/check/integer_ppem_if_hinted',
    'com.google.fonts/check/unitsperem_strict',
    'com.google.fonts/check/contour_count',
+   'com.google.fonts/check/vertical_metrics_regressions',
 ]
 
 GOOGLEFONTS_PROFILE_CHECKS = \
@@ -3990,6 +3991,97 @@ def check_skip_filter(checkid, font=None, **iterargs):
     return False, ('LibreBarcode is blacklisted for this check, see '
                   'https://github.com/graphicore/librebarcode/issues/3')
   return True, None
+
+
+def typo_metrics_enabled(ttFont):
+    return ttFont['OS/2'].fsSelection & 0b10000000 > 0
+
+
+@check(
+  id = 'com.google.fonts/check/vertical_metrics_regressions',
+  conditions = ['remote_styles'],
+  rationale="""If the family already exists on Google Fonts, we need to
+  ensure that the checked family's vertical metrics are similar. This
+  check will test the following schema which was outlined in Fontbakery
+  issue 1162:
+  - The family should visually have the same vertical metrics as the
+    Regular style hosted on Google Fonts.
+  - If the family on Google Fonts has differing hhea and typo metrics,
+    the family being checked should use the typo metrics for both the
+    hhea and typo entries.
+  - If the family on Google Fonts has use typo metrics not enabled and the
+    family being checked has it enabled, the hhea and typo metrics
+    should use the family on Google Fonts winAscent and winDescent values.
+  - If the upms differ, the values must be scaled so the visual appearance
+    is the same.
+  """,
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/1162'
+  }
+)
+def com_google_fonts_check_vertical_metrics_regressions(ttFonts, remote_styles):
+  """Check if the vertical metrics of a family are similar to the same
+  family hosted on Google Fonts."""
+  import math
+  failed = False
+
+  ttFonts = list(ttFonts)
+  if "Regular" in remote_styles:
+    gf_font = remote_styles["Regular"]
+  else:
+    gf_font = None
+    for style, font in remote_styles:
+      if is_variable_font(font):
+        if get_instance_axis_value(font, "Regular", "wght"):
+          gf_font = font
+  if not gf_font:
+    gf_font = remote_styles[0][1]
+
+  upm_scale = ttFonts[0]['head'].unitsPerEm / gf_font['head'].unitsPerEm
+
+  gf_has_typo_metrics = typo_metrics_enabled(gf_font)
+  fam_has_typo_metrics = typo_metrics_enabled(ttFonts[0])
+
+  if (gf_has_typo_metrics and fam_has_typo_metrics) or \
+  (not gf_has_typo_metrics and not fam_has_typo_metrics):
+    desired_ascender = math.ceil(gf_font['OS/2'].sTypoAscender * upm_scale)
+    desired_descender = math.ceil(gf_font['OS/2'].sTypoDescender * upm_scale)
+  else:
+    desired_ascender = math.ceil(gf_font["OS/2"].usWinAscent * upm_scale)
+    desired_descender = -math.ceil(gf_font["OS/2"].usWinDescent * upm_scale)
+
+  for ttFont in ttFonts:
+      full_font_name = ttFont['name'].getName(4, 3, 1, 1033).toUnicode()
+      typo_ascender = ttFont['OS/2'].sTypoAscender
+      typo_descender = ttFont['OS/2'].sTypoDescender
+      hhea_ascender = ttFont['hhea'].ascent
+      hhea_descender = ttFont['hhea'].descent
+      if typo_ascender != desired_ascender:
+        failed = True
+        yield FAIL, ("{}: OS/2 sTypoAscender is {} "
+                     "when it should be {}".format(full_font_name,
+                                                   typo_ascender,
+                                                   desired_ascender))
+      if typo_descender != desired_descender:
+        failed = True
+        yield FAIL, ("{}: OS/2 sTypoDescender is {} "
+                     "when it should be {}".format(full_font_name,
+                                                   typo_descender,
+                                                   desired_descender))
+      if hhea_ascender != desired_ascender:
+        failed = True
+        yield FAIL, ("{}: hhea Ascender is {} "
+                     "when it should be {}".format(full_font_name,
+                                                   hhea_ascender,
+                                                   desired_ascender))
+      if hhea_descender != desired_descender:
+        failed = True
+        yield FAIL, ("{}: hhea Descender is {} "
+                     "when it should be {}".format(full_font_name,
+                                                   hhea_descender,
+                                                   desired_descender))
+  if not failed:
+    yield PASS, "Vertical metrics have not regressed."
 
 
 profile.check_skip_filter = check_skip_filter

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1364,13 +1364,13 @@ def com_google_fonts_check_name_ascii_only_entries(ttFont):
 
 
 @condition
-def listed_on_gfonts_api(family_metadata):
-  if not family_metadata:
+def listed_on_gfonts_api(familyname):
+  if not familyname:
     return False
 
   import requests
   url = ('http://fonts.googleapis.com'
-         '/css?family={}').format(family_metadata.name.replace(' ', '+'))
+         '/css?family={}').format(familyname.replace(' ', '+'))
   r = requests.get(url)
   return r.status_code == 200
 
@@ -2414,17 +2414,17 @@ def com_google_fonts_check_unitsperem_strict(ttFont):
 
 
 @condition
-def remote_styles(family_metadata):
+def remote_styles(familyname_with_spaces):
   """Get a dictionary of TTFont objects of all font files of
      a given family as currently hosted at Google Fonts.
   """
 
-  def download_family_from_Google_Fonts(family_name):
+  def download_family_from_Google_Fonts(familyname):
     """Return a zipfile containing a font family hosted on fonts.google.com"""
     from zipfile import ZipFile
     from fontbakery.utils import download_file
     url_prefix = 'https://fonts.google.com/download?family='
-    url = '{}{}'.format(url_prefix, family_name.replace(' ', '+'))
+    url = '{}{}'.format(url_prefix, familyname.replace(' ', '+'))
     return ZipFile(download_file(url))
 
 
@@ -2439,11 +2439,10 @@ def remote_styles(family_metadata):
         fonts.append([file_name, TTFont(file_obj)])
     return fonts
 
-  if (not listed_on_gfonts_api(family_metadata) or
-      not family_metadata):
+  if not listed_on_gfonts_api(familyname_with_spaces):
     return None
 
-  remote_fonts_zip = download_family_from_Google_Fonts(family_metadata.name)
+  remote_fonts_zip = download_family_from_Google_Fonts(familyname_with_spaces)
   rstyles = {}
 
   for remote_filename, remote_font in fonts_from_zip(remote_fonts_zip):

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -892,16 +892,14 @@ def test_check_metadata_listed_on_gfonts():
   print ("Test WARN with a family that is not listed on Google Fonts...")
   # Our reference FamilySans family is a just a generic example
   # and thus is not really hosted (nor will ever be hosted) at Google Fonts servers:
-  family_directory = portable_path("data/test/familysans")
-  listed = listed_on_gfonts_api(family_metadata(family_directory))
+  listed = listed_on_gfonts_api("Family Sans")
   # For that reason, we expect to get a WARN in this case:
   status, message = list(check(listed))[-1]
   assert status == WARN
 
   print ("Test PASS with a family that is available...")
   # Our reference Merriweather family is available on the Google Fonts collection:
-  family_directory = portable_path("data/test/merriweather")
-  listed = listed_on_gfonts_api(family_metadata(family_directory))
+  listed = listed_on_gfonts_api("Merriweather")
   # So it must PASS:
   status, message = list(check(listed))[-1]
   assert status == PASS
@@ -2151,7 +2149,7 @@ def test_check_production_encoded_glyphs(cabin_ttFonts):
     family_directory)
 
   family_meta = family_metadata(family_directory(cabin_fonts))
-  remote = remote_styles(family_meta)
+  remote = remote_styles(family_meta.name)
   if remote:
     for font in cabin_fonts:
       ttFont = TTFont(font)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2963,3 +2963,50 @@ def test_check_family_control_chars():
   print("Test fail with multiple bad fonts that have multiple bad chars...")
   status, message = list(check([tt1, tt2]))[-1]
   assert status == FAIL
+
+
+def test_check_vertical_metrics_regressions(cabin_ttFonts):
+  from fontbakery.profiles.googlefonts import (
+    com_google_fonts_check_vertical_metrics_regressions as check,
+    api_gfonts_ttFont,
+    style,
+    remote_styles,
+    family_metadata,
+    family_directory)
+  from copy import copy
+
+  family_meta = family_metadata(family_directory(cabin_fonts))
+  remote = remote_styles(family_meta.name)
+  if remote:
+    ttFonts = [TTFont(f) for f in cabin_fonts]
+    # Cabin test family should match by default
+    print("Test pass with a good family...")
+    status, message = list(check(ttFonts, remote))[-1]
+    assert status == PASS
+
+    print("Test fail with a family which has an incorrect typoAscender...")
+    ttFonts2 = copy(ttFonts)
+    for ttfont in ttFonts2:
+      ttfont['OS/2'].sTypoAscender = 0
+    status, message = list(check(ttFonts2, remote))[-1]
+    assert status == FAIL
+
+    print("Test fail with a remote family which does not have typo metrics enabled and the "
+          "fonts being checked don't take this fact into consideration...")
+    remote2 = copy(remote)
+    for key, ttfont in remote2.items():
+      ttfont["OS/2"].fsSelection = ttfont["OS/2"].fsSelection ^ 0b10000000
+    status, message = list(check(ttFonts, remote2))[-1]
+    assert status == FAIL
+
+    print("Test pass with a remote family which does not have typo metrics enabled but the "
+          "checked fonts vertical metrics have been set so its typo and hhea metrics match "
+          "the remote fonts win metrics.")
+    ttFonts3 = copy(ttFonts)
+    for ttfont in ttFonts3:
+      ttfont["OS/2"].sTypoAscender = 1139
+      ttfont["OS/2"].sTypoDescender = -314
+      ttfont["hhea"].ascent = 1139
+      ttfont["hhea"].descent = -314
+    status, message = list(check(ttFonts3, remote2))[-1]
+    assert status == PASS


### PR DESCRIPTION
If a family already exists on Google Fonts, the family being checked must have similar vertical metrics. The check's schema follows what I outlined in https://github.com/googlefonts/fontbakery/issues/1162#issuecomment-451126458.

I've also improved the remote_styles condition. Previously, it would only work if the font directory contained a METADATA.pb file. Now it simply uses a font's family name. This means the missing codepoints check can now work on upstream repos. 

@felipesanches I still need to make some small changes and see if there are any outstanding edgecases. I'll let you know when you can review.