### PR TITLE
removing defusedxml dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## 0.7.4 (2019-Apr-29)
-  ...
+## 0.7.4 (2019-May-06)
+  - Removed defusedxml dependency. We were only using it for its `defused.lxml` module which is now deprecated (issue #2477)
 
 
 ## 0.7.3 (2019-Apr-19)

--- a/Lib/fontbakery/profiles/fontval.py
+++ b/Lib/fontbakery/profiles/fontval.py
@@ -143,10 +143,9 @@ def com_google_fonts_check_fontvalidator(font):
 
   grouped_msgs = {}
   with open(xml_report_file, "rb") as xml_report:
-    import defusedxml.lxml
-    doc = defusedxml.lxml.parse(xml_report)
-
-    for report in doc.iter('Report'):
+    from lxml import etree
+    doc = etree.fromstring(xml_report.read())
+    for report in doc.iterfind('.//Report'):
       msg = report.get("Message")
       details = report.get("Details")
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -319,12 +319,12 @@ def description(descfile):
 )
 def com_google_fonts_check_description_broken_links(description):
   """Does DESCRIPTION file contain broken links?"""
-  from lxml.html import HTMLParser
-  import defusedxml.lxml
   import requests
-  doc = defusedxml.lxml.fromstring(description, parser=HTMLParser())
+  from lxml import etree
+  doc = etree.fromstring("<html>" + description + "</html>")
   broken_links = []
-  for link in doc.xpath('//a/@href'):
+  for a_href in doc.iterfind('.//a[@href]'):
+    link = a_href.get("href")
     if link.startswith("mailto:") and \
        "@" in link and \
        "." in link.split("@")[1]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 --index-url https://pypi.python.org/simple/
 beautifulsoup4==4.7.1
 defcon==0.6.0
-defusedxml==0.6.0
 font-v==0.7.1
 fontTools[ufo,lxml,unicode]==3.41.0
 lxml==4.3.3

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
     install_requires=[
         'beautifulsoup4',
         'defcon',
-        'defusedxml',
         'font-v',
         'fontTools[ufo,lxml,unicode]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
         'lxml',


### PR DESCRIPTION
We were only using it for its `defused.lxml` module which is now deprecated.
(issue #2477)
