### PR TITLE
New check: com.google.fonts/check/metadata/designer_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.4 (2019-May-06)
+### Dependencies
   - Removed defusedxml dependency. We were only using it for its `defused.lxml` module which is now deprecated (issue #2477)
+
+### New checks
+  - **[com.google.fonts/check/metadata/designer_values]:** We must use commas instead of forward slashes because the fonts.google.com directory will segment string to list on comma and display the first item in the list as the "principal designer" and the other items as contributors.
 
 
 ## 0.7.3 (2019-Apr-19)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -16,6 +16,7 @@ profile = profile_factory(default_section=Section("Google Fonts"))
 METADATA_CHECKS = [
         'com.google.fonts/check/metadata/parses'
       , 'com.google.fonts/check/metadata/unknown_designer'
+      , 'com.google.fonts/check/metadata/designer_values'
       , 'com.google.fonts/check/metadata/listed_on_gfonts'
       , 'com.google.fonts/check/metadata/unique_full_name_values'
       , 'com.google.fonts/check/metadata/unique_weight_style_pairs'
@@ -442,6 +443,29 @@ def com_google_fonts_check_metadata_unknown_designer(family_metadata):
     yield FAIL, f"Font designer field is '{family_metadata.designer}'."
   else:
     yield PASS, "Font designer field is not 'unknown'."
+
+
+@check(
+  id = 'com.google.fonts/check/metadata/designer_values',
+  conditions = ['family_metadata'],
+  rationale = """
+    We must use commas instead of forward slashes because the
+    fonts.google.com directory will segment string to list
+    on comma and display the first item in the list as the
+    "principal designer" and the other items as contributors.
+    See eg https://fonts.google.com/specimen/Rubik
+  """
+)
+def com_google_fonts_check_metadata_designer_values(family_metadata):
+  """Multiple values in font designer field in
+     METADATA.pb must be separated by commas."""
+
+  if '/' in family_metadata.designer:
+    yield FAIL, (f"Font designer field contains a forward slash"
+                  " '{family_metadata.designer}'."
+                  " Please use commas to separate multiple names instead.")
+  else:
+    yield PASS, "Looks good."
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -345,7 +345,7 @@ def test_check_metadata_parses():
 def test_check_metadata_unknown_designer():
   """ Font designer field in METADATA.pb must not be 'unknown'. """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_unknown_designer as check,
-                                                     family_metadata)
+                                               family_metadata)
   good = family_metadata(portable_path("data/test/merriweather"))
   print('Test PASS with a good METADATA.pb file...')
   status, message = list(check(good))[-1]
@@ -354,6 +354,29 @@ def test_check_metadata_unknown_designer():
   bad = family_metadata(portable_path("data/test/merriweather"))
   bad.designer = "unknown"
   print('Test FAIL with a bad METADATA.pb file...')
+  status, message = list(check(bad))[-1]
+  assert status == FAIL
+
+
+def test_check_metadata_designer_values():
+  """ Multiple values in font designer field in
+      METADATA.pb must be separated by commas. """
+  from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_designer_values as check,
+                                               family_metadata)
+  good = family_metadata(portable_path("data/test/merriweather"))
+  print('Test PASS with a good METADATA.pb file...')
+  status, message = list(check(good))[-1]
+  assert status == PASS
+
+  good.designer = "Pentagram, MCKL"
+  print('Test PASS with a good multiple-designers string...')
+  status, message = list(check(good))[-1]
+  assert status == PASS
+
+  bad = family_metadata(portable_path("data/test/merriweather"))
+  bad.designer = "Pentagram / MCKL" # This actually happened on an
+                                    # early version of the Red Hat Text family
+  print('Test FAIL with a bad multiple-designers string...')
   status, message = list(check(bad))[-1]
   assert status == FAIL
 


### PR DESCRIPTION
We must use commas instead of forward slashes because the
fonts.google.com directory will segment string to list on
comma and display the first item in the list as the
"principal designer" and the other items as contributors.
(issue #2479)