### PR TITLE
com.google.fonts/check/name_version_format: Allow fonts to have version numbers less than 1.000.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.google.fonts/check/metadata/designer_values]:** We must use commas instead of forward slashes because the fonts.google.com directory will segment string to list on comma and display the first item in the list as the "principal designer" and the other items as contributors.
 
+### Bug fixes
+  - **[com.google.fonts/check/name_version_format]:** Allow fonts to have version numbers less than v1.000.
+
 
 ## 0.7.3 (2019-Apr-19)
 ### Note-worthy code changes

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1044,7 +1044,13 @@ def com_google_fonts_check_name_version_format(ttFont):
   from fontbakery.utils import get_name_entry_strings
   import re
   def is_valid_version_format(value):
-    return re.match(r'Version\s0*[1-9]+\.\d+', value)
+    return re.match(r'Version\s0*[0-9]+\.\d+', value)
+
+  def is_valid_version_number(value):
+    version_number = re.search(r"[0-9]{1}\.[0-9]{3}", value)
+    if not version_number:
+      return False
+    return float(version_number.group(0)) >= 0.001
 
   failed = False
   version_entries = get_name_entry_strings(ttFont, NameID.VERSION_STRING)
@@ -1054,12 +1060,12 @@ def com_google_fonts_check_name_version_format(ttFont):
                         ("Font lacks a NameID.VERSION_STRING (nameID={})"
                          " entry").format(NameID.VERSION_STRING))
   for ventry in version_entries:
-    if not is_valid_version_format(ventry):
+    if not is_valid_version_format(ventry) or not is_valid_version_number(ventry):
       failed = True
       yield FAIL, Message("bad-version-strings",
                           ("The NameID.VERSION_STRING (nameID={}) value must"
                            " follow the pattern \"Version X.Y\" with X.Y"
-                           " between 1.000 and 9.999."
+                           " between 0.001 and 9.999."
                            " Current version string is:"
                            " \"{}\"").format(NameID.VERSION_STRING,
                                              ventry))

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -705,6 +705,15 @@ def test_check_name_version_format():
   status, message = list(check(ttFont))[-1]
   assert status == FAIL and message.code == "bad-version-strings"
 
+  # then we set the version string to lower than 0.001
+  print ("Test FAIL with fonts that have a version string lower than 0.001...")
+  for i, name in enumerate(ttFont["name"].names):
+    if name.nameID == NameID.VERSION_STRING:
+      invalid = "Version 0.000".encode(name.getEncoding())
+      ttFont["name"].names[i].string = invalid
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL and message.code == "bad-version-strings"
+
   # and finally we remove all version-string entries:
   print ("Test FAIL with font lacking version string entries in name table...")
   for i, name in enumerate(ttFont["name"].names):


### PR DESCRIPTION
Viviana was recently checking an unreleased family which had a version number of 0.440. I don't know if version numbers less than v1.000 cause any issues? if not, this pr will allow fonts to have version numbers which are greater than or equal to v0.001.