### PR TITLE
Update documentation with new profiles

### DIFF
--- a/docs/source/fontbakery/profiles/adobefonts.rst
+++ b/docs/source/fontbakery/profiles/adobefonts.rst
@@ -1,0 +1,7 @@
+##########
+adobefonts
+##########
+
+.. automodule:: fontbakery.profiles.adobefonts
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/cff.rst
+++ b/docs/source/fontbakery/profiles/cff.rst
@@ -1,0 +1,7 @@
+###
+cff
+###
+
+.. automodule:: fontbakery.profiles.cff
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/fontval.rst
+++ b/docs/source/fontbakery/profiles/fontval.rst
@@ -1,0 +1,7 @@
+#######
+fontval
+#######
+
+.. automodule:: fontbakery.profiles.fontval
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/gdef.rst
+++ b/docs/source/fontbakery/profiles/gdef.rst
@@ -1,7 +1,0 @@
-####
-gdef
-####
-
-.. automodule:: fontbakery.profiles.gdef
-   :members:
-   :undoc-members:

--- a/docs/source/fontbakery/profiles/index.rst
+++ b/docs/source/fontbakery/profiles/index.rst
@@ -5,8 +5,11 @@ profiles
 .. toctree::
    :maxdepth: 1
 
+   adobefonts
+   cff
    cmap
    dsig
+   fontval
    fvar
    gdef
    general
@@ -24,6 +27,7 @@ profiles
    post
    shared_conditions
    ufo_sources
+   universal
 
 
 .. automodule:: fontbakery.profiles

--- a/docs/source/fontbakery/profiles/index.rst
+++ b/docs/source/fontbakery/profiles/index.rst
@@ -11,7 +11,6 @@ profiles
    dsig
    fontval
    fvar
-   gdef
    general
    glyf
    googlefonts

--- a/docs/source/fontbakery/profiles/universal.rst
+++ b/docs/source/fontbakery/profiles/universal.rst
@@ -1,0 +1,7 @@
+#########
+universal
+#########
+
+.. automodule:: fontbakery.profiles.universal
+   :members:
+   :undoc-members:


### PR DESCRIPTION
This PR modifies the Sphinx documentation for the profiles source with the following changes:

- adds adobefonts profile docs
- adds cff profile docs
- adds fontval profile docs
- adds universal profile docs
- removes gdef profile docs (gdef module removed)
- updates profiles index ToC