### PR TITLE
HTML Report: default to "sans-serif" font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Deprecated checks
   - **[com.google.fonts/check/currency_chars]:** we now have a much broader glyph coverage check: com.google.fonts/check/glyph_coverage (issue #2498)
 
+### Bug fixes
+  - The HTML report now actually defaults to "sans-serif" as the body font.
+
 
 ## 0.7.4 (2019-May-06)
 ### Note-worthy code changes

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -128,7 +128,7 @@ def html5_document(body_elements) -> str:
 
     style = """
             html {
-                font-family: "Aktiv Grotesk", sans;
+                font-family: sans-serif;
             }
 
             h2 {


### PR DESCRIPTION
## Description
This pull request changes the default font for the HTML report to "sans-serif", as "sans" isn't actually giving me "sans" in Firefox.

