### PR TITLE
Restrict com.google.fonts/check/repo/dirname_matches_nameid_1 to static fonts...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Bug fixes
   - The HTML report now actually defaults to "sans-serif" as the body font.
+  - Restrict com.google.fonts/check/repo/dirname_matches_nameid_1 to static fonts as the `fontbakery.util.get_regular` function does not support variable fonts yet. (issue #2509)
 
 
 ## 0.7.4 (2019-May-06)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3420,7 +3420,8 @@ def com_google_fonts_check_family_control_chars(ttFonts):
 
 @check(
   id = 'com.google.fonts/check/repo/dirname_matches_nameid_1',
-  conditions = ['gfonts_repo_structure'],
+  conditions = ['gfonts_repo_structure',
+                'not is_variable_font'],
   misc_metadata = {
     'request': 'https://github.com/googlefonts/fontbakery/issues/2302'
   }
@@ -3436,6 +3437,7 @@ def com_google_fonts_check_repo_dirname_match_nameid_1(fonts,
   regular = get_regular(fonts)
   if not regular:
     yield FAIL, "The font seems to lack a regular."
+    return
 
   entry = get_name_entry_strings(TTFont(regular), NameID.FONT_FAMILY_NAME)[0]
   expected = entry.lower()


### PR DESCRIPTION
...as the `fontbakery.util.get_regular` function does not
support variable fonts yet.
(issue #2509)