### PR TITLE
Fix for mistakenly renamed method calls identified in #2511

### DIFF
--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -173,8 +173,8 @@ def get_module_from_file(filename):
   # filename = 'my/path/to/file.py'
   # module_name = 'file_module.file_py'
   module_name = 'file_module.{}'.format(os.path.basename(filename).replace('.', '_'))
-  profile = importlib.util.profile_from_file_location(module_name, filename)
-  module = importlib.util.module_from_profile(profile)
+  profile = importlib.util.spec_from_file_location(module_name, filename)
+  module = importlib.util.module_from_spec(profile)
   profile.loader.exec_module(module)
   return module
 


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #2511

## To Do
- [ ] update `CHANGELOG.md`
- [?] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

