### PR TITLE
WIP: Parse style and instance properties from strings

### DIFF
--- a/Lib/fontbakery/parse.py
+++ b/Lib/fontbakery/parse.py
@@ -1,0 +1,177 @@
+"""Parse GF specific style properties for font styles or font instances."""
+import re
+from collections import namedtuple
+
+
+__all__ = ["style_parse", "instance_parse"]
+
+
+RIBBI_STYLES = ["Regular", "Italic", "Bold", "Bold Italic"] 
+
+_WEIGHT_NAMES = {
+    r"Th?i?n|wt100": "Thin",
+    r"Ext?r?a?Li?g?h?t|wt200": "ExtraLight", 
+    r"Li?g?h?t|wt300": "Light",
+    r"Re?gu?l?a?r?|wt400": "Regular", 
+    r"Me?di?u?m?|wt500":"Medium", 
+    r"Se?m?i?Bo?l?d|wt600": "SemiBold",
+    r"Bo?l?d|wt700": "Bold", 
+    r"Ext?r?a?Bo?l?d|wt800": "ExtraBold", 
+    r"Bla?c?k|wt900": "Black", 
+}
+_WIDTH_NAMES = {
+    r"Ult?r?a?Co?n?d?e?n?s?e?d": "UltraCondensed",
+    r"Ext?r?a?Co?n?d?e?n?s?e?d": "ExtraCondensed",
+    r"Co?n?d?e?n?s?e?d": "Condensed",
+    r"Se?m?i?Co?n?d?e?n?s?e?d": "SemiCondensed",
+    r"Se?m?i?Exp?a?n?d?e?d": "SemiExpanded",
+    r"Exp?a?n?d?e?d": "Expanded",
+    r"Ext?r?a?Exp?a?n?d?e?d": "ExtraExpanded",
+    r"Ult?r?a?Exp?a?n?d?e?d": "UltraExpanded",
+}
+_ITALIC_NAMES = {
+    r"Ita?l?i?c?|Obli?q?u?e?": "Italic" 
+}
+_WEIGHT_VALUES = {
+    "Thin": {"usWeightClass": 250, "fvar": 100.0},
+    "ExtraLight": {"usWeightClass": 275, "fvar": 200.0},
+    "Light": {"usWeightClass": 300, "fvar": 300.0},
+    "Regular": {"usWeightClass": 400, "fvar": 400.0},
+    "": {"usWeightClass": 400, "fvar": 400.0},
+    "Medium": {"usWeightClass": 500, "fvar": 500.0},
+    "SemiBold": {"usWeightClass": 600, "fvar": 600.0},
+    "Bold": {"usWeightClass": 700, "fvar": 700.0},
+    "ExtraBold": {"usWeightClass": 800, "fvar": 800.0},
+    "Black": {"usWeightClass": 900, "fvar": 900.0},
+}
+_WIDTH_VALUES = {
+    "UltraCondensed": {"usWidthClass": 1, "fvar": 50.0},
+    "ExtraCondensed": {"usWidthClass": 2, "fvar": 62.5},
+    "Condensed": {"usWidthClass": 3, "fvar": 75.0},
+    "SemiCondensed": {"usWidthClass": 4, "fvar": 87.5},
+    "": {"usWidthClass": 5, "fvar": 100.0},
+    "SemiExpanded": {"usWidthClass": 6, "fvar": 112.5},
+    "Expanded": {"usWidthClass": 7, "fvar": 125.0},
+    "ExtraExpanded": {"usWidthClass": 8, "fvar": 150.0},
+    "UltraExpanded": {"usWidthClass": 9, "fvar": 200.0},
+}
+
+def _re_string_tokenizer(string, mapping):
+    found = []
+    for k, v in mapping.items():
+        result = re.search(k, string)
+        if result:
+            found.append(v)
+    if not found:
+        return None
+    return sorted(found, key=lambda k: len(k), reverse=True)[0]
+
+
+def _style_tokens(string):
+    string = re.sub(r"\W", "", string)
+    wdth = _re_string_tokenizer(string, _WIDTH_NAMES) or ""
+    wght = _re_string_tokenizer(string, _WEIGHT_NAMES) or ""
+    ital = _re_string_tokenizer(string, _ITALIC_NAMES) or ""
+    return wdth, wght, ital
+
+
+def _parse_name(wdth, wght, ital):
+    if wght == "Regular" and ital == "Italic":
+        return ital
+    return "{} {} {}".format(wdth, wght, ital).lstrip().rstrip()
+
+
+def _win_style_name(string):
+    if "Italic" in string:
+        if string in ["Italic", "Bold Italic"]:
+            return string
+        return "Italic"
+    elif string not in ["Regular", "Bold"]:
+        return "Regular"
+    return string
+
+
+def _win_typo_style_name(string):
+    if string not in RIBBI_STYLES:
+        return string
+    return None
+
+
+def _fsSelection(string):
+    result = 0b0
+    if string == "Bold":
+        result |= 0b100000
+    if "Italic" in string:
+        result |= 0b1
+    if result == 0b0:
+        result |= 0b1000000
+    return result
+
+
+def _macStyle(string):
+    result = 0b0
+    if string == "Bold":
+        result |= 0b1
+    if "Italic" in string:
+        result |= 0b10
+    return result
+
+
+def _style_parse(string):
+    """Parse a string into a GF font style object. All parsed properties
+    conform to the Google Fonts specification.
+    """
+    _GFStyle = namedtuple("GFStyle",
+                          """name
+                          usWeightClass
+                          usWidthClass
+                          win_style_name
+                          mac_style_name
+                          win_typo_style_name
+                          fsSelection
+                          macStyle
+                          is_ribbi
+                          filename""")
+    wdth, wght, ital = _style_tokens(string)
+    name = _parse_name(wdth, wght, ital)
+    return _GFStyle(name=name,
+                    usWeightClass=_WEIGHT_VALUES[wght]['usWeightClass'],
+                    usWidthClass=_WIDTH_VALUES[wdth]["usWidthClass"],
+                    win_style_name=_win_style_name(name),
+                    mac_style_name=name,
+                    win_typo_style_name=_win_typo_style_name(name),
+                    fsSelection=_fsSelection(wght),
+                    macStyle=_macStyle(wght),
+                    is_ribbi=True if name in RIBBI_STYLES else False,
+                    filename=name.replace(" ", ""))
+
+
+def style_parse(ttFont):
+    """Get style properites from a TTFont object. If the font is a static font,
+    use the filename to get style info, else if the font is a variable font,
+    use the default instance's subfamilyNameID record"""
+    if 'fvar' in ttFont:
+        dflt_instance_coords = {a.axisTag: a.defaultValue for a in ttFont['fvar'].axes}
+        for instance in ttFont['fvar'].instances:
+            if instance.coordinates == dflt_instance_coords:
+                name = ttFont['name'].getName(instance.subfamilyNameID, 3, 1, 1033).toUnicode()
+                return _style_parse(name)
+    filename = ttFont.reader.file.name
+    if len(filename.split("-")) != 2:
+        style = "Regular"
+    else:
+        style = filename.split("-")[1].replace(".ttf", "")
+    return _style_parse(style)
+
+
+def instance_parse(string):
+    """Derive instance properties from a string."""
+    _GFInstance = namedtuple("GFStyle",
+                             """name
+                             coordinates""")
+    wdth, wght, ital = _style_tokens(string)
+    name = _parse_name(wdth, wght, ital)
+    return _GFInstance(name=name,
+                       coordinates={'wght': _WEIGHT_VALUES[wght]['fvar'],
+                                    'wdth': _WIDTH_VALUES[wdth]['fvar']})
+

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -564,14 +564,14 @@ def com_google_fonts_check_name_unwanted_chars(ttFont):
 
 @check(
   id = 'com.google.fonts/check/usweightclass',
-  conditions=['style']
+  conditions=['expected_style']
 )
-def com_google_fonts_check_usweightclass(font, ttFont, style):
+def com_google_fonts_check_usweightclass(ttFont, expected_style):
   """Checking OS/2 usWeightClass."""
   from fontbakery.profiles.shared_conditions import is_ttf
-  from .googlefonts_conditions import expected_os2_weight
 
-  weight_name, expected_value = expected_os2_weight(style)
+  expected_value = expected_style.usWeightClass
+  weight_name = expected_style.name
   value = ttFont['OS/2'].usWeightClass
 
   if value != expected_value:

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -24,6 +24,11 @@ def style_with_spaces(font):
     return style(font).replace('Italic',
                                ' Italic').strip()
 
+@condition
+def expected_style(ttFont):
+    from fontbakery.parse import style_parse
+    return style_parse(ttFont)
+
 
 @condition
 def expected_os2_weight(style):

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -526,34 +526,34 @@ def test_check_name_unwanted_chars():
 
 def test_check_usweightclass():
   """ Checking OS/2 usWeightClass. """
-  from fontbakery.profiles.googlefonts import (com_google_fonts_check_usweightclass as check,
-                                                     style)
+  from fontbakery.profiles.googlefonts import (com_google_fonts_check_usweightclass as check)
+  from fontbakery.profiles.googlefonts_conditions import expected_style
   # Our reference Mada Regular is know to be bad here.
   font = TEST_FILE("mada/Mada-Regular.ttf")
   print(f"Test FAIL with bad font '{font}' ...")
   ttFont = TTFont(font)
-  status, message = list(check(font, ttFont, style(font)))[-1]
+  status, message = list(check(ttFont, expected_style(ttFont)))[-1]
   assert status == FAIL
 
   # All fonts in our reference Cabin family are know to be good here.
   for font in cabin_fonts:
     print(f"Test PASS with good font '{font}' ...")
     ttFont = TTFont(font)
-    status, message = list(check(font, ttFont, style(font)))[-1]
+    status, message = list(check(ttFont, expected_style(ttFont)))[-1]
     assert status == PASS
 
   font = TEST_FILE("montserrat/Montserrat-Thin.ttf")
   ttFont = TTFont(font)
   ttFont["OS/2"].usWeightClass = 100
   print("Test WARN with a Thin:100 TTF...")
-  status, message = list(check(font, ttFont, style(font)))[-1]
+  status, message = list(check(ttFont, expected_style(ttFont)))[-1]
   assert status == WARN
 
   font = TEST_FILE("montserrat/Montserrat-ExtraLight.ttf")
   ttFont = TTFont(font)
   ttFont["OS/2"].usWeightClass = 200
   print("Test WARN with an ExtraLight:200 TTF...")
-  status, message = list(check(font, ttFont, style(font)))[-1]
+  status, message = list(check(ttFont, expected_style(ttFont)))[-1]
   assert status == WARN
 
   # TODO: test FAIL with a Thin:100 OTF

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,49 @@
+import pytest
+from fontbakery.parse import _style_parse, instance_parse
+
+
+def test_name():
+    style = _style_parse("Bold Condensed")
+    assert style.name == "Condensed Bold"
+
+    style = _style_parse("Italic Bold Condensed")
+    assert style.name == "Condensed Bold Italic"
+
+    style = _style_parse("Extra-Bold")
+    assert style.name == "ExtraBold"
+
+    style = _style_parse("Extra Bold")
+    assert style.name == "ExtraBold"
+
+    style = _style_parse("Extra Bold Italic")
+    assert style.name == "ExtraBold Italic"
+
+    style = _style_parse("Semi Condensed Extra Light")
+    assert style.name == "SemiCondensed ExtraLight"
+
+    style = _style_parse("wt400 It")
+    assert style.name == "Italic"
+
+    style = _style_parse("Regular Italic")
+    assert style.name == "Italic"
+
+    style = _style_parse("ExLt ExCd It")
+    assert style.name == "ExtraCondensed ExtraLight Italic"
+
+    style = _style_parse("Thn It")
+    assert style.name == "Thin Italic"
+
+    style = _style_parse("Bold Oblique")
+    assert style.name == "Bold Italic"
+
+    style = _style_parse("UltCndExtBdIt")
+    assert style.name =="UltraCondensed ExtraBold Italic"
+
+
+def test_fvar_coordinates():
+    style = instance_parse("Condensed Regular")
+    assert style.coordinates == {"wght": 400.0, 'wdth': 75.0}
+
+    style = instance_parse("UltraCondensed Black Italic")
+    assert style.coordinates == {"wght": 900.0, 'wdth': 50.0}
+


### PR DESCRIPTION
Our current implementation to determine a font's style name is too primitive for supporting variable fonts with multiple axes. It also doesn't allow style names which do not conform to our specification e.g if a user's font is named "MyFamily-BoldOblique" many of our checks won't work. This pr aims to address both these issues by implementing a style parser and instance parser.

The parsers work by tokenising a string. The order is discarded and reassembled to match our spec e.g "Bold Condensed" and "Condensed Bold" will both be turned into "Condensed Bold". Style abbreviations are also possible e.g "Cdn" will be changed to "Condensed". I studied how other vendors name their fonts so I should've covered most name cases.

@felipesanches keep this open for the time being.