### PR TITLE
refactored check: com.google.fonts/check/name/typographicsubfamilyname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.6 (2019-Jun-10)
+### Note-worthy code changes
+  - **[com.google.fonts/check/name/typographicsubfamilyname]:** has been refactored. It is now acceptable to have a typographic subfamily name if the font is RIBBI since it does not cause any issues
+
 ### Bug fixes
   - Render line-breaks on Read The Docs check rationales
   - **[com.adobe.fonts/check/family/bold_italic_unique_for_nameid1]:** restrict check to RIBBI styles only (issue #2501)

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -172,7 +172,8 @@ class PriorityLevel(enum.IntEnum):
   IMPORTANT = 1
   CRITICAL = 0  # ON FIRE! Must immediately fix!
 
-ENGLISH_LANG_ID = 0x0409
+WIN_ENGLISH_LANG_ID = 0x0409
+MAC_ROMAN_LANG_ID = 0x0
 
 GF_latin_core = {
   #  NULL

--- a/Lib/fontbakery/parse.py
+++ b/Lib/fontbakery/parse.py
@@ -91,7 +91,7 @@ def _win_style_name(string):
     return string
 
 
-def _win_typo_style_name(string):
+def _typo_style_name(string):
     if string not in RIBBI_STYLES:
         return string
     return None
@@ -127,7 +127,7 @@ def _style_parse(string):
                           usWidthClass
                           win_style_name
                           mac_style_name
-                          win_typo_style_name
+                          typo_style_name
                           fsSelection
                           macStyle
                           is_ribbi
@@ -139,7 +139,7 @@ def _style_parse(string):
                     usWidthClass=_WIDTH_VALUES[wdth]["usWidthClass"],
                     win_style_name=_win_style_name(name),
                     mac_style_name=name,
-                    win_typo_style_name=_win_typo_style_name(name),
+                    typo_style_name=_typo_style_name(name),
                     fsSelection=_fsSelection(wght),
                     macStyle=_macStyle(wght),
                     is_ribbi=name in RIBBI_STYLES,

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -4,7 +4,7 @@ import fontTools.ttLib
 from fontTools.ttLib import TTFont
 
 from fontbakery.utils import TEST_FILE, portable_path
-from fontbakery.constants import NameID, PlatformID, WindowsEncodingID, ENGLISH_LANG_ID
+from fontbakery.constants import NameID, PlatformID, WindowsEncodingID, WIN_ENGLISH_LANG_ID
 from fontbakery.checkrunner import (
               DEBUG
             , INFO
@@ -335,7 +335,7 @@ def test_check_name_postscript_vs_cff():
     NameID.POSTSCRIPT_NAME,
     PlatformID.WINDOWS,
     WindowsEncodingID.UNICODE_BMP,
-    ENGLISH_LANG_ID
+    WIN_ENGLISH_LANG_ID
   )
   status, message = list(check(test_font))[-1]
   assert status == FAIL
@@ -345,7 +345,7 @@ def test_check_name_postscript_vs_cff():
     NameID.POSTSCRIPT_NAME,
     PlatformID.WINDOWS,
     WindowsEncodingID.UNICODE_BMP,
-    ENGLISH_LANG_ID
+    WIN_ENGLISH_LANG_ID
   )
   status, message = list(check(test_font))[-1]
   assert status == PASS
@@ -366,7 +366,7 @@ def test_check_name_postscript_name_consistency():
     NameID.POSTSCRIPT_NAME,
     PlatformID.MACINTOSH,
     WindowsEncodingID.UNICODE_BMP,
-    ENGLISH_LANG_ID
+    WIN_ENGLISH_LANG_ID
   )
   status, message = list(check(test_font))[-1]
   assert status == PASS
@@ -377,7 +377,7 @@ def test_check_name_postscript_name_consistency():
     NameID.POSTSCRIPT_NAME,
     PlatformID.MACINTOSH,
     WindowsEncodingID.UNICODE_BMP,
-    ENGLISH_LANG_ID
+    WIN_ENGLISH_LANG_ID
   )
   status, message = list(check(test_font))[-1]
   assert status == FAIL


### PR DESCRIPTION
I'm starting to refactor the name checks so they use our new style parser.

This check will now pass fonts which have are RIBBI and have a typographic subfamily name that matches the subfamily name. I came across this edgecase whilst reviewing https://github.com/JuergenWillrodt/Almarai. The fonts caused no issues in any apps I tested.

I'm also limiting the name records it checks to 17, 3, 1, 1033 and 17, 1, 0, 0 since these are the standard English records for Mac and Win. We recently pushed some Chinese fonts which failed these checks because the previous implementation would check every nameID entry, regardless of what languageID the record used.