### PR TITLE
new check: com.google.fonts/check/description/variable_font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## 0.7.6 (2019-Jun-10)
+## 0.7.6 (2019-Jun-07)
 ### Note-worthy code changes
   - **[com.google.fonts/check/name/subfamilyname]:** has been refactored to use parse.style_parse.
   - **[com.google.fonts/check/name/typographicsubfamilyname]:** has been refactored. It is now acceptable to have a typographic subfamily name if the font is RIBBI since it does not cause any issues
@@ -14,7 +14,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - also improved the readability of **com.google.fonts/check/points_out_of_bounds**
 
 ### New Checks
-  - **[com.google.fonts/check/description/git_url]:** Make sure all font families have an upstream git repo URL declared in the DESCRIPTION.en-us.html file
+  - **[com.google.fonts/check/description/variable_font]:** Ensure that variable fonts contain the following message in the DESCRIPTION.en-us.html file: `This family is available as a variable font.` (issue #2538)
+  - **[com.google.fonts/check/description/git_url]:** Make sure all font families have an upstream git repo URL declared in the DESCRIPTION.en-us.html file. (issue #2523)
   - **[com.google.fonts/check/varfont_instance_coordinates]:** Check variable font instances have correct axis coordinates
   - **[com.google.fonts/check/varfont_instance_names]:** Check variable font instances have correct names
   - **[com.google.fonts/check/wdth_valid_range]:** Check variable font wdth axis has correct range

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -64,6 +64,7 @@ DESCRIPTION_CHECKS = [
    'com.google.fonts/check/description/min_length',
    'com.google.fonts/check/description/max_length',
    'com.google.fonts/check/description/git_url',
+   'com.google.fonts/check/description/variable_font'
 ]
 
 FAMILY_CHECKS = [
@@ -263,6 +264,30 @@ def com_google_fonts_check_description_git_url(description):
     yield FAIL, ("Please host your font project on a public Git repo"
                  " (such as GitHub or GitLab) and place a link"
                  " in the DESCRIPTION.en_us.html file.")
+
+
+@check(
+  id = 'com.google.fonts/check/description/variable_font',
+  conditions = ['is_variable_font',
+                'description'],
+  rationale = """
+    Families with variable fonts do not always mention that
+    in their descriptions.
+
+    Therefore, this check ensures that a standard boilerplate
+    sentence is present in the DESCRIPTION files for all
+    those families which are available as variable fonts.
+  """
+)
+def com_google_fonts_check_description_variable_font(description):
+  """Does DESCRIPTION file mention when a family
+     is available as variable font?"""
+  if "variable font" not in description.lower():
+    yield FAIL, ("Please include the following sentence"
+                 " in the DESCRIPTION.en-us.html file:\n\n"
+                 "This family is available as a variable font.")
+  else:
+    yield PASS, "Looks good!"
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -128,10 +128,11 @@ def family_directory(fonts):
 
 
 @condition
-def descfile(family_directory):
+def descfile(font):
   """Get the path of the DESCRIPTION file of a given font project."""
-  if family_directory:
-    descfilepath = os.path.join(family_directory, "DESCRIPTION.en_us.html")
+  if font:
+    directory = os.path.dirname(font)
+    descfilepath = os.path.join(directory, "DESCRIPTION.en_us.html")
     if os.path.exists(descfilepath):
       return descfilepath
 

--- a/data/test/varfont/DESCRIPTION.en_us.html
+++ b/data/test/varfont/DESCRIPTION.en_us.html
@@ -1,0 +1,13 @@
+<p>
+Oswald is a reworking of the classic style historically represented by the 'Alternate Gothic' sans serif typefaces.
+The characters of Oswald were initially re-drawn and reformed to better fit the pixel grid of standard digital screens.
+Oswald is designed to be used freely across the internet by web browsers on desktop computers, laptops and mobile devices.
+</p>
+<p>
+Since the initial launch in 2011, Oswald was updated continually by Vernon Adams until 2014.
+Vernon added Light and Bold weights, support for more Latin languages, tightened the spacing and kerning and made many glyph refinements throughout the family based on hundreds of users' feedback.
+In 2016 the family was updated by Kalapi Gajjar and Alexei Vanyashin to complete the work started by Vernon, and support languages that use the Cyrillic script.
+</p>
+<p>
+To contribute, see <a href="https://github.com/googlefonts/OswaldFont">github.com/googlefonts/OswaldFont</a>
+</p>

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -204,7 +204,7 @@ def test_check_description_broken_links():
     description,
     descfile)
 
-  good_desc = description(descfile(portable_path("data/test/cabin")))
+  good_desc = description(descfile(TEST_FILE("cabin/Cabin-Regular.ttf")))
   print('Test PASS with description file that has no links...')
   status, message = list(check(good_desc))[-1]
   assert status == PASS
@@ -233,7 +233,7 @@ def test_check_description_git_url():
     description,
     descfile)
 
-  bad_desc = description(descfile(portable_path("data/test/cabin")))
+  bad_desc = description(descfile(TEST_FILE("cabin/Cabin-Regular.ttf")))
   print('Test FAIL with description file that has no git repo URLs...')
   status, message = list(check(bad_desc))[-1]
   assert status == FAIL
@@ -249,6 +249,26 @@ def test_check_description_git_url():
   status, message = list(check(bad_desc))[-1]
   assert status == FAIL
 
+
+def test_check_description_variable_font():
+  """ Does DESCRIPTION file mention when a family
+      is available as variable font? """
+  from fontbakery.profiles.googlefonts import (
+    com_google_fonts_check_description_variable_font as check,
+    description,
+    descfile)
+
+  bad_desc = description(descfile(TEST_FILE("varfont/Oswald-VF.ttf")))
+  print('Test FAIL when "variable font" is not present in DESC file...')
+  status, message = list(check(bad_desc))[-1]
+  assert status == FAIL
+
+  good_desc = description(descfile(TEST_FILE("cabinvfbeta/Cabin-VF.ttf")))
+  print('Test PASS with description file containing "variable font"...')
+  status, message = list(check(good_desc))[-1]
+  assert status == PASS
+
+
 def test_check_description_valid_html():
   """ DESCRIPTION file is a propper HTML snippet ? """
   from fontbakery.profiles.googlefonts import (
@@ -256,7 +276,7 @@ def test_check_description_valid_html():
     descfile,
     description)
 
-  good_descfile = descfile(portable_path("data/test/nunito"))
+  good_descfile = descfile(TEST_FILE("nunito/Nunito-Regular.ttf"))
   good_desc = description(good_descfile)
   print('Test PASS with description file that contains a good HTML snippet...')
   status, message = list(check(good_descfile, good_desc))[-1]


### PR DESCRIPTION
Ensure that variable fonts contain the following message in the DESCRIPTION.en-us.html file:
This family is available as a variable font.
(issue #2538)