### PR TITLE
fix crash on git_gfonts_ttFonts condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
+## 0.7.7 (2019-Jun-17)
+### Bug fixes
+ - fix crash on git_gfonts_ttFonts condition (return None when the font is not yet available on GitHub) (issue #2540)
+
+
 ## 0.7.6 (2019-Jun-10)
 ### Note-worthy code changes
   - **[com.google.fonts/check/name/subfamilyname]:** has been refactored to use parse.style_parse.

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -433,7 +433,7 @@ def github_gfonts_ttFont(ttFont, license):
      from Google Fonts git repository.
   """
   if not license:
-    return
+    return None
 
   from fontbakery.utils import download_file
   from fontTools.ttLib import TTFont
@@ -451,7 +451,8 @@ def github_gfonts_ttFont(ttFont, license):
                              filename)
   try:
     fontfile = download_file(url)
-    return TTFont(fontfile)
+    if fontfile:
+      return TTFont(fontfile)
   except HTTPError:
     return None
 


### PR DESCRIPTION
return None when the font is not yet available on GitHub.
(issue #2540)