### PR TITLE
modify check: com.google.fonts/check/family/has_license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.7 (2019-Jun-17)
+### Note-worthy code changes
+  - **[com.google.fonts/check/family/has_license]:** only run check if the fonts are in a google/fonts repo.
+
 ### Bug fixes
- - fix crash on git_gfonts_ttFonts condition (return None when the font is not yet available on GitHub) (issue #2540)
+  - fix crash on git_gfonts_ttFonts condition (return None when the font is not yet available on GitHub) (issue #2540)
 
 
 ## 0.7.6 (2019-Jun-10)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -661,7 +661,8 @@ def com_google_fonts_check_usweightclass(ttFont, expected_style):
 
 
 @check(
-  id = 'com.google.fonts/check/family/has_license'
+  id = 'com.google.fonts/check/family/has_license',
+  conditions=['gfonts_repo_structure'],
 )
 def com_google_fonts_check_family_has_license(licenses):
   """Check font has a license."""


### PR DESCRIPTION
This check shouldn't be run on font directories in upstream repos.

This check will now only run if the fonts being checked are in a google/fonts repo. This should lead to less confusion for upstream project maintainers.