### PR TITLE
accept NULL-padding on vendor-IDs (com.google.fonts/check/vendor_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.7.7 (2019-Jun-17)
 ### Note-worthy code changes
   - **[com.google.fonts/check/family/has_license]:** only run check if the fonts are in a google/fonts repo.
+  - **[com.google.fonts/check/vendor_id]:** accept NULL-padding on vendor-IDs (issue #2548)
 
 ### Bug fixes
   - fix crash on git_gfonts_ttFonts condition (return None when the font is not yet available on GitHub) (issue #2540)
 
 ### New Checks
- - **[com.google.fonts/check/metadata/broken_links]:** Ensure the copyright string in METADATA.pb files does not contain broken URLs. (issue #2550)
+  - **[com.google.fonts/check/metadata/broken_links]:** Ensure the copyright string in METADATA.pb files does not contain broken URLs. (issue #2550)
 
 
 ## 0.7.6 (2019-Jun-10)

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -186,12 +186,20 @@ def registered_vendor_ids():
       cells = row.findAll('td')
       if not cells:
         continue
+
+      labels = [label for label in cells[1].stripped_strings]
+
       # pad the code to make sure it is a 4 char string,
       # otherwise eg "CF  " will not be matched to "CF"
       code = cells[0].string.strip()
       code = code + (4 - len(code)) * ' '
-      labels = [label for label in cells[1].stripped_strings]
       registered_vendor_ids[code] = labels[0]
+
+      # Do the same with NULL-padding:
+      code = cells[0].string.strip()
+      code = code + (4 - len(code)) * chr(0)
+      registered_vendor_ids[code] = labels[0]
+
 
   return registered_vendor_ids
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -512,6 +512,9 @@ def test_condition__registered_vendor_ids():
   print('"MS  ": "Microsoft Corp." is a good vendor id with 2 letters and padded with spaces.')
   assert "MS  " in registered_ids # Microsoft Corp.
 
+  print('"TT\0\0": we also accept vendor-IDs containing NULL-padding.')
+  assert "TT\0\0" in registered_ids # constains NULL bytes
+
   print('All vendor ids must be 4 chars long!')
   assert "GNU" not in registered_ids # 3 chars long is bad
   assert "MS" not in registered_ids # 2 chars long is bad


### PR DESCRIPTION
(issue #2548)

