### PR TITLE
Fix "metatada" typo on checkid: com.google.fonts/check/metatada/canonical_style_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.7.8 (2019-Jun-24)
 ### Note-worthy code changes
   - Add GlyphsApp hint to com.google.fonts/check/usweightclass (issue #2423)
+  - Fix "metatada" typo on checkid: **com.google.fonts/check/metatada/canonical_style_names** (issue #2561)
 
 ### Changes to checks
   - **[com.google.fonts/check/canonical_filename]:**  update variable fonts naming scheme (issue #2549)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -55,7 +55,7 @@ METADATA_CHECKS = [
       , 'com.google.fonts/check/metadata/match_name_familyname'
       , 'com.google.fonts/check/metadata/canonical_weight_value'
       , 'com.google.fonts/check/metadata/os2_weightclass'
-      , 'com.google.fonts/check/metatada/canonical_style_names'
+      , 'com.google.fonts/check/metadata/canonical_style_names'
       , 'com.google.fonts/check/metadata/broken_links'
 ]
 
@@ -2109,10 +2109,10 @@ def com_google_fonts_check_metadata_match_weight_postscript(font_metadata):
 
 
 @check(
-  id = 'com.google.fonts/check/metatada/canonical_style_names',
+  id = 'com.google.fonts/check/metadata/canonical_style_names',
   conditions = ['font_metadata']
 )
-def com_google_fonts_check_metatada_canonical_style_names(ttFont, font_metadata):
+def com_google_fonts_check_metadata_canonical_style_names(ttFont, font_metadata):
   """METADATA.pb: Font styles are named canonically?"""
   from fontbakery.constants import MacStyle
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1996,10 +1996,10 @@ def NOT_IMPLEMENTED_test_check_metadata_match_weight_postscript():
   # - PASS
 
 
-def NOT_IMPLEMENTED_test_check_metatada_canonical_style_names():
+def NOT_IMPLEMENTED_test_check_metadata_canonical_style_names():
   """ METADATA.pb: Font styles are named canonically? """
   # from fontbakery.profiles.googlefonts import (
-  #   com_google_fonts_check_metatada_canonical_style_names as check)
+  #   com_google_fonts_check_metadata_canonical_style_names as check)
   #
   # TODO: Implement-me!
   #


### PR DESCRIPTION
(issue #2561)

