### PR TITLE
disable checks: equal_numbers_of_glyphs & equal_glyph_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.7.9 (2019-Jul-01)
-  - ...
+  - Disabled family checks: **com.google.fonts/check/family/equal_numbers_of_glyphs** and **com.google.fonts/check/family/equal_glyph_names** These will be reintroduced after known problems are addressed. (issue #2567)
 
 
 ## 0.7.8 (2019-Jun-22)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -69,8 +69,8 @@ DESCRIPTION_CHECKS = [
 ]
 
 FAMILY_CHECKS = [
-   'com.google.fonts/check/family/equal_numbers_of_glyphs',
-   'com.google.fonts/check/family/equal_glyph_names',
+#   'com.google.fonts/check/family/equal_numbers_of_glyphs',
+#   'com.google.fonts/check/family/equal_glyph_names',
    'com.google.fonts/check/family/has_license',
    'com.google.fonts/check/family/control_chars',
    'com.google.fonts/check/family/tnum_horizontal_metrics',
@@ -458,6 +458,7 @@ def com_google_fonts_check_metadata_broken_links(family_metadata):
     yield PASS, "All links in the METADATA.pb file look good!"
 
 
+@disable # TODO: re-enable after addressing issue #1998
 @check(
   id = 'com.google.fonts/check/family/equal_numbers_of_glyphs',
   conditions = ['are_ttf',
@@ -509,6 +510,7 @@ def com_google_fonts_check_family_equal_numbers_of_glyphs(ttFonts):
                  " an equal total ammount of glyphs.")
 
 
+@disable # TODO: re-enable after addressing issue #1998
 @check(
   id = 'com.google.fonts/check/family/equal_glyph_names',
   conditions = ['are_ttf']

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -436,7 +436,8 @@ def test_check_metadata_designer_values():
   assert status == FAIL
 
 
-def test_check_family_equal_numbers_of_glyphs(mada_ttFonts, cabin_ttFonts):
+# TODO: re-enable after addressing issue #1998
+def DISABLED_test_check_family_equal_numbers_of_glyphs(mada_ttFonts, cabin_ttFonts):
   """ Fonts have equal numbers of glyphs? """
   from fontbakery.profiles.googlefonts import com_google_fonts_check_family_equal_numbers_of_glyphs as check
 
@@ -452,7 +453,8 @@ def test_check_family_equal_numbers_of_glyphs(mada_ttFonts, cabin_ttFonts):
   assert status == FAIL
 
 
-def test_check_family_equal_glyph_names(mada_ttFonts, cabin_ttFonts):
+# TODO: re-enable after addressing issue #1998
+def DISABLED_test_check_family_equal_glyph_names(mada_ttFonts, cabin_ttFonts):
   """ Fonts have equal glyph names? """
   from fontbakery.profiles.googlefonts import com_google_fonts_check_family_equal_glyph_names as check
 


### PR DESCRIPTION
Reintroducing these family checks after addressing known problems will be tracked by issue #1998.
(issue #2567)