### PR TITLE
com.google.fonts/check/description/valid_html: improve fail message

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -307,9 +307,11 @@ def com_google_fonts_check_description_variable_font(description):
   """Does DESCRIPTION file mention when a family
      is available as variable font?"""
   if "variable font" not in description.lower():
-    yield FAIL, ("Please include the following sentence"
-                 " in the DESCRIPTION.en-us.html file:\n\n"
-                 "This family is available as a variable font.")
+    yield FAIL, ("Please mention in the DESCRIPTION.en-us.html"
+                 " that the family is a variable font. This check"
+                 " expects the words 'variable font' to be present"
+                 " in the text e.g 'This font is now available as"
+                 " a variable font.'")
   else:
     yield PASS, "Looks good!"
 


### PR DESCRIPTION
The current fail message for this check is misleading.

The current implementation expects the words 'variable font' to appear in the text. When this check fails, it tells the user to add the following sentence "this family is available as a variable font".

I've changed the fail message to better represent how the check actually works.
