### PR TITLE
perform a hacky fixup to workaround the square-brackets naming scheme...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## 0.7.9 (2019-Jul-12)
+## 0.7.9 (2019-Jul-11)
+### Note-worthy code changes
+  - update varfont naming scheme: use commas to separate axis tags (issue #2570)
+
+### Disables checks
   - Disabled family checks: **com.google.fonts/check/family/equal_numbers_of_glyphs** and **com.google.fonts/check/family/equal_glyph_names** These will be reintroduced after known problems are addressed. (issue #2567)
   - Temporarily disabled **com.google.fonts/check/production_encoded_glyphs** since GFonts hosted Cabin files seem to have changed in ways that break some of the assumptions in its code-test. (issue #2581)
+
+### Re-enabled checks
   - **[com.google.fonts/check/fontdata_namecheck]:** Web service is online again. (issue #2484)
-  - update varfont naming scheme: use commas to separate axis tags (issue #2570)
+
+### Bug fixes
   - **[com.google.fonts/check/fontbakery_version]:** FAIL if unable to detect latest available fontbakery version (issue #2579)
+  - perform a hacky fixup to workaround the square-brackets naming scheme currently in use for varfonts in google fonts. (issue #2570)
 
 
 ## 0.7.8 (2019-Jun-22)

--- a/Lib/fontbakery/fonts_profile.py
+++ b/Lib/fontbakery/fonts_profile.py
@@ -18,6 +18,10 @@ class FontsProfile(Profile):
 
       fonts_to_check = []
       # use glob.glob to accept *.ttf
+      # but perform a hacky fixup to workaround the square-brackets naming scheme
+      # currently in use for varfonts in google fonts...
+      if '].ttf' in pattern:
+        pattern = "*.ttf".join(pattern.split('].ttf'))
 
       for fullpath in glob.glob(pattern):
         if fullpath.lower().rsplit(".", 1)[-1] in ("otf", "ttf"):


### PR DESCRIPTION
... currently in use for varfonts in google fonts.
(issue #2570)
