### PR TITLE
Make sure canonical style name checks are strongly enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.10 (2019-Jul-22)
+### Note-worthy code changes
+  - Make sure canonical style name checks are strongly enforced. Improve wording of FAIL log message on check/varfont_instance_names (issue #2573)
+
 ### Bug fixes
   - fix ERROR on check/metadata/broken_links (issue #2585)
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3739,6 +3739,10 @@ def com_google_fonts_check_varfont_instances_names(ttFont):
                      ' It should be "{}"').format(name, expected_name)
   if not failed:
     yield PASS, "Instances have correct names"
+  else:
+    yield FAIL, ("This will cause problems with some of the Google Fonts"
+                 " systems that look up fonts by their style names."
+                 " This must be fixed!")
 
 
 ###############################################################################


### PR DESCRIPTION
Improve wording of FAIL log message on check/varfont_instance_names (issue #2573)

