### PR TITLE
Allow ttf name verson string like "Version 10.123"

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1084,7 +1084,7 @@ def com_google_fonts_check_name_version_format(ttFont):
   from fontbakery.utils import get_name_entry_strings
   import re
   def is_valid_version_format(value):
-    return re.match(r'Version\s0*[1-9]+\.\d+', value)
+    return re.match(r'Version\s0*[1-9][0-9]*\.\d+', value)
 
   failed = False
   version_entries = get_name_entry_strings(ttFont, NameID.VERSION_STRING)
@@ -1102,7 +1102,7 @@ def com_google_fonts_check_name_version_format(ttFont):
                     f'The NameID.VERSION_STRING'
                     f' (nameID={NameID.VERSION_STRING}) value must'
                     f' follow the pattern "Version X.Y" with X.Y'
-                    f' between 1.000 and 9.999.'
+                    f' greater than or equal to 1.000.'
                     f' Current version string is: "{ventry}"')
   if not failed:
     yield PASS, "Version format in NAME table entries is correct."


### PR DESCRIPTION
Currently com_google_fonts_check_name_version_format fails if the version string has a 0 between the most significant digit and the decimal point, e.g., version numbers such as 10.123 and 20.123.
Additionally the error message suggests the version number may not be greater than 9.999.
This patch fixes both of these issues.

## Description
This pull request addresses the problems described at issue #xxxx

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

