### PR TITLE
com.google.fonts/check/unwanted_tables: Include MVAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/contour_count]:** ignore PUA codepoints (issue #2612)
   - **[com.google.fonts/check/contour_count]:** detect glyphs by both glyphnames and codepoints (issue #2612)
 
+### Changes to checks
+  - **[com.google.fonts/check/unwanted_tables]:** Add MVAR table (Issue #2599) and improve FAIL message
+
 
 ## 0.7.11 (2019-Aug-21)
 ### Note-worthy code changes
@@ -24,9 +27,6 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Renamed check IDs:
   - **[com.google.fonts/check/wdth_valid_range]** => com.google.fonts/check/varfont/wdth_valid_range
   - **[com.google.fonts/check/wght_valid_range]** => com.google.fonts/check/varfont/wght_valid_range
-
-### Changes to checks
-  - **[com.google.fonts/check/unwanted_tables]:** Add MVAR table (Issue #2599) and improve FAIL message
 
 
 ## 0.7.10 (2019-Aug-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/wdth_valid_range]** => com.google.fonts/check/varfont/wdth_valid_range
   - **[com.google.fonts/check/wght_valid_range]** => com.google.fonts/check/varfont/wght_valid_range
 
+### Changes to checks
+  - **[com.google.fonts/check/unwanted_tables]:** Add MVAR table (Issue #2599) and improve FAIL message
+
 
 ## 0.7.10 (2019-Aug-06)
 ### Note-worthy code changes

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -531,18 +531,18 @@ def com_google_fonts_check_required_tables(ttFont):
 def com_google_fonts_check_unwanted_tables(ttFont):
   """Are there unwanted tables?"""
   UNWANTED_TABLES = {
-      'FFTM': '(from FontForge)',
-      'TTFA': '(from TTFAutohint)',
-      'TSI0': '(from VTT)',
-      'TSI1': '(from VTT)',
-      'TSI2': '(from VTT)',
-      'TSI3': '(from VTT)',
-      'TSI5': '(from VTT)',
+      'FFTM': 'Table contains redundant FontForge timestamp info',
+      'TTFA': 'Redundant TTFAutohint table',
+      'TSI0': 'Table contains data only used in VTT',
+      'TSI1': 'Table contains data only used in VTT',
+      'TSI2': 'Table contains data only used in VTT',
+      'TSI3': 'Table contains data only used in VTT',
+      'TSI5': 'Table contains data only used in VTT',
       'prop': '', # FIXME: why is this one unwanted?
       # Marc Foley found that VFs containing a MVAR table have very
       # loose vertical metrics, even if the MVAR table hasn't adjusted
       # any vertical metric values.
-      'MVAR': ('Bug in DirectWrite which causes'
+      'MVAR': ('Produces a bug in DirectWrite which causes'
                ' https://bugzilla.mozilla.org/show_bug.cgi?id=1492477,'
                ' https://github.com/google/fonts/issues/2085')
   }
@@ -550,14 +550,13 @@ def com_google_fonts_check_unwanted_tables(ttFont):
   for table in ttFont.keys():
     if table in UNWANTED_TABLES.keys():
       info = UNWANTED_TABLES[table]
-      unwanted_tables_found.append(f"{table} {info}")
+      unwanted_tables_found.append(f'Table: {table}\nReason: {info}\n')
 
   if len(unwanted_tables_found) > 0:
-    yield FAIL, ("Unwanted tables were found"
-                 " in the font and should be removed, either by"
-                 " fonttools/ttx or by editing them using the tool"
-                 " they are from:"
-                 " {}").format(", ".join(unwanted_tables_found))
+    yield FAIL, ("The following unwanted font tables were found:\n"
+                 "{}\n"
+                 "They can be removed by using fonttools/ttx."
+                 ).format("\n".join(unwanted_tables_found))
   else:
     yield PASS, "There are no unwanted tables."
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -538,7 +538,13 @@ def com_google_fonts_check_unwanted_tables(ttFont):
       'TSI2': '(from VTT)',
       'TSI3': '(from VTT)',
       'TSI5': '(from VTT)',
-      'prop': '' # FIXME: why is this one unwanted?
+      'prop': '', # FIXME: why is this one unwanted?
+      # Marc Foley found that VFs containing a MVAR table have very
+      # loose vertical metrics, even if the MVAR table hasn't adjusted
+      # any vertical metric values.
+      'MVAR': ('Bug in DirectWrite which causes'
+               ' https://bugzilla.mozilla.org/show_bug.cgi?id=1492477,'
+               ' https://github.com/google/fonts/issues/2085')
   }
   unwanted_tables_found = []
   for table in ttFont.keys():

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -795,7 +795,8 @@ def test_check_unwanted_tables():
     "TSI2",
     "TSI3",
     "TSI5",
-    "prop" # FIXME: Why is this one unwanted?
+    "prop", # FIXME: Why is this one unwanted?
+    "MVAR", # Bugs in DirectWrite
   ]
   # Our reference Mada Regular font is good here:
   ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))


### PR DESCRIPTION
This check will now ensure that VFs do not contain an MVAR table.


I've also improved the FAIL message so it's more legible. The new formatting allows us to include better descriptions for why we don't want the table (MVAR's is pretty lengthy)

**Before:**

<img width="1432" alt="Screenshot 2019-08-29 at 11 33 36" src="https://user-images.githubusercontent.com/7525512/63933308-e46c2d80-ca50-11e9-8ee0-ad84764f14f6.png">


**After:**

<img width="1431" alt="Screenshot 2019-08-29 at 11 33 11" src="https://user-images.githubusercontent.com/7525512/63933270-cdc5d680-ca50-11e9-9137-51a10255e859.png">

<img width="1431" alt="Screenshot 2019-08-29 at 11 35 07" src="https://user-images.githubusercontent.com/7525512/63933481-3b720280-ca51-11e9-8b14-48ec9e0e4572.png">


Solves #2599 

@felipesanches more than happy to squash the commits.
