### PR TITLE
Italic must not affect com.google/fonts/check/usweightclass

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -832,8 +832,8 @@ def com_google_fonts_check_usweightclass(ttFont, expected_style):
   if value != expected_value:
 
     if is_ttf(ttFont) and \
-       (weight_name == 'Thin' and value == 100) or \
-       (weight_name == 'ExtraLight' and value == 200):
+       (weight_name in ['Thin', 'Thin Italic'] and value == 100) or \
+       (weight_name in ['ExtraLight', 'ExtraLight Italic'] and value == 200):
       yield WARN,\
             Message("blur-on-windows",
                     f"{weight_name}:{value} is OK on TTFs, but"

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -694,7 +694,8 @@ def test_check_usweightclass():
 
   # TODO: test FAIL, "bad-value" with a Thin:100 OTF
   # TODO: test FAIL, "bad-value" with an ExtraLight:200 OTF
-
+  # TODO: test italic variants to ensure we do not get regressions of
+  #       this bug: https://github.com/googlefonts/fontbakery/issues/2650
 
 def test_family_directory_condition():
   from fontbakery.profiles.googlefonts import family_directory


### PR DESCRIPTION
(issue #2650)