### PR TITLE
fix f-string syntax and only check filename (not full path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Bugfixes
   - **[com.google.fonts/check/usweightclass]:** Italics should not affect the results. (issue #2650)
+  - **[com.google.fonts/check/canonical_filename]:** Fix f-string syntax and only check filename (not full path) (issue #2649)
 
 ### Changes to checks
   - **[com.google.fonts/check/canonical_filename]:** filenames with underscore characters are considered invalid. (issue #2615)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -192,12 +192,12 @@ def com_google_fonts_check_canonical_filename(font):
     return f"{familyname}{tags}.ttf"
 
   failed = False
-  if "_" in font:
+  if "_" in os.path.basename(font):
     failed = True
     yield FAIL,\
           Message("invalid-char",
-                  'font filename "{font}" is invalid.'
-                  ' It must not contain underscore characters!')
+                  f'font filename "{font}" is invalid.'
+                  f' It must not contain underscore characters!')
     return
 
   ttFont = TTFont(font)


### PR DESCRIPTION
on com.google.fonts/check/canonical_filename
(issue #2649)