### PR TITLE
com.google.fonts/check/contour_count: Fix listing of glyphnames with unexpected contour counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.14 (2019-Oct-11)
-  - ...
+### Bugfixes
+  - **[com.google.fonts/check/contour_count]:** Fix listing of glyphnames with unexpected contour counts. (issue #2647)
 
 
 ## 0.7.13 (2019-Oct-04)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2746,12 +2746,18 @@ def com_google_fonts_check_contour_count(ttFont):
     if len(bad_glyphs) > 0:
       cmap = ttFont['cmap'].getcmap(PlatformID.WINDOWS,
                                     WindowsEncodingID.UNICODE_BMP).cmap
+
+      def _glyph_name(cmap, name):
+        if name in cmap:
+          return cmap[name]
+        else:
+          return name
+
       bad_glyphs_name = [
-        f"Glyph name: {cmap[name]}\t"
+        f"Glyph name: {_glyph_name(cmap, name)}\t"
         f"Contours detected: {count}\t"
         f"Expected: {pretty_print_list(expected, shorten=None, glue='or')}"
         for name, count, expected in bad_glyphs
-        if name in cmap
       ]
       bad_glyphs_name = '\n'.join(bad_glyphs_name)
       yield WARN,\


### PR DESCRIPTION
(issue #2647)
