### PR TITLE
com.google.fonts/check/glyph_coverage: Removed strong requirement of 0x000D (carriage-return) for the GF Latin Core character set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## 0.7.16 (2019-Nov-08)
+## 0.7.16 (2019-Nov-15)
 ### Note-worthy changes
   - ...
 
 
-## 0.7.15 (2019-Oct-30)
+## 0.7.15 (2019-Nov-03)
 ### Note-worthy changes
-  - **Rationale cleanup & render:** Reviewed all rationale metadata entries and added code to properly format them on the github markdown output. The same still need to be done for the text terminal output. And later we should properly parse markdown everywhere. (issue #2681)
+  - **Rationale cleanup & render:** Reviewed all rationale metadata entries and added code to properly format them on the github markdown and text terminal output. Later we probably should parse markdown everywhere. (issue #2681)
+  - **[com.google.fonts/check/glyph_coverage]:** Removed strong requirement of 0x000D (carriage-return) for the GF Latin Core character set. (issue #2677)
 
 ### New features
   - Print rationale of checks (if available) on terminal output (issue #2531)

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -195,7 +195,7 @@ class PriorityLevel(enum.IntEnum):
 
 GF_latin_core = {
   #  NULL
-  0x000D: (None, "CARRIAGE RETURN"),
+  # 0x000D: (None, "CARRIAGE RETURN"),
   0x0020: (" ", "SPACE"),
   0x0021: ("!", "EXCLAMATION MARK"),
   0x0022: ("\"", "QUOTATION MARK"),


### PR DESCRIPTION
(issue #2677)