### PR TITLE
display full list of missing required codepoints in INFO log message (com.google.fonts/check/glyph_coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.16 (2019-Nov-15)
-### Note-worthy changes
-  - ...
+### Bugfixes
+  - **[com.google.fonts/check/glyph_coverage]:** display full list of missing required codepoints in INFO log message (issue #2690)
 
 
 ## 0.7.15 (2019-Nov-03)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -761,7 +761,13 @@ def com_google_fonts_check_glyph_coverage(ttFont):
     yield FAIL,\
           Message("missing-codepoints",
                   f"Missing required codepoints:"
-                  f" {pretty_print_list(missing)}")
+                  f" {pretty_print_list(missing, shorten=4)}")
+    if len(missing) > 4:
+      missing_list = "\n\t\t".join(missing)
+      yield INFO,\
+            Message("missing-codepoints-verbose",
+                    f"Here's the full list of required codepoints"
+                    f" still missing:\n\t\t{missing_list}")
   else:
     yield PASS, "OK"
 


### PR DESCRIPTION
(issue #2690)