### PR TITLE
[docs: developer/writing-profiles] typo fixes

### DIFF
--- a/docs/source/developer/writing-profiles.md
+++ b/docs/source/developer/writing-profiles.md
@@ -25,7 +25,7 @@ Thus, the presence of the name `profile` disables the automatic use of `profile_
 
 ```py
 # profile = Profile(...)
-# globals is a pythin builtin
+# globals is a Python builtin
 profile.auto_register(globals())
 ```
 

--- a/docs/source/developer/writing-profiles.md
+++ b/docs/source/developer/writing-profiles.md
@@ -10,7 +10,7 @@ A Font Bakery Profile (an instance of the type `fontbakery.checkrunner.Profile`)
 
 ## From automatic discovery to full control
 
-To create your own profile we added tools that reduce boilerplate code to a minimum. These tools are fully optional. But it is possible to use them if you need more control over the creation of a profile. This automatic discovery can be enabledor disabled based on the presence (and value) of some special names in the module of the profile:
+To create your own profile we added tools that reduce boilerplate code to a minimum. These tools are fully optional. But it is possible to use them if you need more control over the creation of a profile. This automatic discovery can be enabled or disabled based on the presence (and value) of some special names in the module of the profile:
 
 * `profile`
 * `profile_factory`


### PR DESCRIPTION
Fixes minor typos in the custom profile documentation