### PR TITLE
New check: com.google.fonts/check/repo/vf_has_static_fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bugfixes
   - **[com.google.fonts/check/glyph_coverage]:** display full list of missing required codepoints in INFO log message (issue #2690)
 
+### New checks
+  - **[com.google.fonts/check/repo/vf_has_static_fonts]:** Check VF family dirs in google/fonts contain static fonts (issue #2654)
 
 ## 0.7.15 (2019-Nov-03)
 ### Note-worthy changes

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -86,6 +86,7 @@ NAME_TABLE_CHECKS = [
 
 REPO_CHECKS = [
   'com.google.fonts/check/repo/dirname_matches_nameid_1',
+  'com.google.fonts/check/repo/vf_has_static_fonts',
 ]
 
 FONT_FILE_CHECKS = [
@@ -3859,6 +3860,37 @@ def com_google_fonts_check_repo_dirname_match_nameid_1(fonts,
                   f"Family name on the name table ('{entry}') does not match"
                   f" directory name in the repo structure ('{familypath}')."
                   f" Expected '{expected}'.")
+
+
+@check(
+  id = 'com.google.fonts/check/repo/vf_has_static_fonts',
+  conditions = ['family_directory',
+                'is_variable_font'],
+  rationale="""
+    Variable font family directories kept in the google/fonts git repo must include a static/ subdir containing static fonts.
+    These files are meant to be served for users that still lack support for variable fonts in their web browsers.
+  """,
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2654'
+  }
+)
+def com_google_fonts_check_repo_vf_has_static_fonts(family_directory):
+  """A static fonts directory with at least two fonts must accompany variable fonts"""
+  static_dir = os.path.join(family_directory, 'static')
+  if os.path.exists(static_dir):
+    has_static_fonts = any([f for f in os.listdir(static_dir)
+                            if f.endswith('.ttf')])
+    if has_static_fonts:
+      yield PASS, 'OK'
+    else:
+      yield FAIL, \
+            Message("empty",
+                    'Static dir is empty')
+  else:
+    yield FAIL, \
+          Message("missing",
+                  'Please create a subdirectory called "static/"'
+                  ' and include in it static font files.')
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3123,6 +3123,37 @@ def NOT_IMPLEMENTED__test_com_google_fonts_check_repo_dirname_match_nameid_1():
 #  assert status == PASS
 
 
+def test_check_repo_vf_has_static_fonts():
+  """Check VF family dirs in google/fonts contain static fonts"""
+  from fontbakery.profiles.googlefonts import (family_directory,
+                                               com_google_fonts_check_repo_vf_has_static_fonts as check)
+  import tempfile
+  import shutil
+  # in order for this check to work, we need to mimmic the folder structure of
+  # the Google Fonts repository
+  with tempfile.TemporaryDirectory() as tmp_gf_dir:
+    family_dir = portable_path(tmp_gf_dir + "/ofl/testfamily")
+    src_family = portable_path("data/test/varfont")
+    shutil.copytree(src_family, family_dir)
+
+    print("Test FAIL for a vf family which does not has a static dir.")
+    status, message = list(check(family_dir))[-1]
+    assert status == FAIL and message.code == "missing"
+
+    print("Test FAIL for a vf family which has a static dir but no fonts in the static dir.")
+    static_dir = portable_path(family_dir + "/static")
+    os.mkdir(static_dir)
+    status, message = list(check(family_dir))[-1]
+    assert status == FAIL and message.code == "empty"
+
+    print("Test PASS for a vf family which has a static dir and static fonts")
+    static_fonts = portable_path("data/test/cabin")
+    shutil.rmtree(static_dir)
+    shutil.copytree(static_fonts, static_dir)
+    status, message = list(check(family_dir))[-1]
+    assert status == PASS
+
+
 def test_check_vertical_metrics_regressions(cabin_ttFonts):
   from fontbakery.profiles.googlefonts import (
     com_google_fonts_check_vertical_metrics_regressions as check,


### PR DESCRIPTION
A static fonts directory with at least two fonts must accompany variable fonts
(issue #2654)