### PR TITLE
[name profile : com.google.fonts/check/family_naming_recommendations] Fix name table id 6 (PostScript name for the font) string length value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.17 (2020-Jan-??)
-  - ...
+### Changes to existing checks
+- **[com.google.fonts/check/family_naming_recommendation]:** Increase acceptable characters in nameID 6 string to 63 from 29
 
 
-## 0.7.16 (2019-Dec-11)
+## 0.7.16 (2019-Dec-06)
 ### Note-worthy changes
   - New experimental notofonts profile. Some checks from this profile may be promoted into the universal profile later (issue #2676)
 

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -281,11 +281,11 @@ def com_google_fonts_check_family_naming_recommendations(ttFont):
 
   for string in get_name_entry_strings(ttFont,
                                        NameID.POSTSCRIPT_NAME):
-    if len(string) >= 30:
+    if len(string) >= 64:
       bad_entries.append({
           'field': 'PostScript Name',
           'value': string,
-          'rec': 'exceeds max length (29)'
+          'rec': 'exceeds max length (63)'
       })
 
   for string in get_name_entry_strings(ttFont,

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -257,11 +257,11 @@ def test_check_family_naming_recommendations():
       # The second hyphen char here is the expected rule violation:
       name_test("Big-Bang-Theory", INFO, "bad-entries")
 
-      print ("Test INFO: Exceeds max length (29)...")
-      name_test("A"*30, INFO, "bad-entries")
+      print ("Test INFO: Exceeds max length (63)...")
+      name_test("A"*64, INFO, "bad-entries")
 
-      print ("Test PASS: Does not exceeds max length...")
-      name_test("A"*29, PASS)
+      print ("Test PASS: Does not exceed max length...")
+      name_test("A"*63, PASS)
 
     elif name.nameID == NameID.FULL_FONT_NAME:
       print ("== NameID.FULL_FONT_NAME ==")


### PR DESCRIPTION
Check: `com.google.fonts/check/family_naming_recommendations`

The MS OpenType spec and Apple TrueType Reference define the max number of characters in nameID 6 as 63.  The check currently defines the max value as 29.