### PR TITLE
New check: com.google.fonts/check/glyf_non_transformed_duplicate_components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
+## 0.7.17 (2019-Dec-13)
+### New checks
+  - **[com.google.fonts/check/glyf_non_transformed_duplicate_components]:** Check glyphs do not have duplicate components which have the same x,y coordinates.
 ## 0.7.16 (2019-Dec-06)
 ### Note-worthy changes
   - New experimental notofonts profile. Some checks from this profile may be promoted into the universal profile later (issue #2676)

--- a/Lib/fontbakery/profiles/glyf.py
+++ b/Lib/fontbakery/profiles/glyf.py
@@ -82,3 +82,39 @@ def com_google_fonts_check_points_out_of_bounds(ttFont):
                   f" other fonts. So it is common to ignore this message.")
   else:
     yield PASS, "All glyph paths have coordinates within bounds!"
+
+
+@check(
+  id = 'com.google.fonts/check/glyf_non_transformed_duplicate_components',
+  conditions = ['is_ttf']
+)
+def com_google_fonts_check_glyf_non_transformed_duplicate_components(ttFont):
+    """Check glyphs do not have duplicate components which have the same
+    x,y coordinates."""
+    from fontbakery.utils import pretty_print_list
+    failed = []
+    for glyph_name in ttFont['glyf'].keys():
+        glyph = ttFont['glyf'][glyph_name]
+        if not glyph.isComposite():
+            continue
+        seen = []
+        for comp in glyph.components:
+            comp_info = {
+                "glyph": glyph_name,
+                "component": comp.glyphName,
+                "x": comp.x,
+                "y": comp.y
+            }
+            if comp_info in seen:
+                failed.append(comp_info)
+            else:
+                seen.append(comp_info)
+    if failed:
+        formatted_list = "\t* " + pretty_print_list(failed,
+                                                shorten=10,
+                                                sep="\n\t* ")
+        yield FAIL, (f"The following glyphs have duplicate components which"
+                     f" have the same x,y coordinates:\n{formatted_list}")
+    else:
+        yield PASS, ("Glyphs do not contain duplicate components which have"
+                     " the same x,y coordinates.")

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -66,6 +66,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/family_naming_recommendations',
     'com.google.fonts/check/maxadvancewidth',
     'com.google.fonts/check/points_out_of_bounds',
+    'com.google.fonts/check/glyf_non_transformed_duplicate_components',
     'com.google.fonts/check/all_glyphs_have_codepoints',
     'com.google.fonts/check/monospace_max_advancewidth',
     'com.google.fonts/check/code_pages',

--- a/tests/profiles/glyf_test.py
+++ b/tests/profiles/glyf_test.py
@@ -60,3 +60,19 @@ def test_check_points_out_of_bounds():
   test_font2 = TTFont(TEST_FILE("familysans/FamilySans-Regular.ttf"))
   status, _ = list(check(test_font2))[-1]
   assert status == PASS
+
+def test_check_glyf_non_transformed_duplicate_components():
+  """Check glyphs do not have duplicate components which have the same x,y coordinates."""
+  from fontbakery.profiles.glyf import com_google_fonts_check_glyf_non_transformed_duplicate_components as check
+
+  test_font = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
+  status, message = list(check(test_font))[-1]
+  assert status == PASS
+
+  # Set qutodbl's components to have the same x,y values
+  glyph = test_font['glyf']['quotedbl'].components[0].x = 0
+  glyph = test_font['glyf']['quotedbl'].components[1].x = 0
+  glyph = test_font['glyf']['quotedbl'].components[0].y = 0
+  glyph = test_font['glyf']['quotedbl'].components[1].y = 0
+  status, message = list(check(test_font))[-1]
+  assert status == FAIL


### PR DESCRIPTION
We recently pushed a family to production which had faulty double quote marks. Each double quote mark contained two single quote marks as components. However, each component had the same x, y coordinates which makes them visually look like single quote marks.

This pr will ensure that glyphs do not contain duplicate components which have the same x,y coordinates.

If I run the check on the offending fonts, I get the following output.

```
 >> com.google.fonts/check/glyf_non_transformed_duplicate_components
    Check glyphs do not have duplicate components which have the same x, y coordinates.
    with /Users/marcfoley/Type/upstream_families/karmilla/sources/fonts/variable/Karla-Roman-VF.ttf

    * FAIL: The following glyphs have duplicate components which have the same x,y coordinates:
	* {'glyph': 'quotedblbase', 'component': 'comma', 'x': 0, 'y': 0}
	* {'glyph': 'quotedblleft', 'component': 'quoteleft', 'x': 0, 'y': 0} and {'glyph': 'quotedblright', 'component': 'quoteright', 'x': 0, 'y': 0}

    Result: FAIL
```

cc @bghryct