### PR TITLE
[universal] Update unwanted table check fail message fix approach

### DIFF
--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -533,7 +533,7 @@ def com_google_fonts_check_unwanted_tables(ttFont):
   if len(unwanted_tables_found) > 0:
     yield FAIL, ("The following unwanted font tables were found:\n"
                  "{}\n"
-                 "They can be removed by using fonttools/ttx."
+                 "They can be removed with the gftools fix-unwanted-tables script."
                  ).format("\n".join(unwanted_tables_found))
   else:
     yield PASS, "There are no unwanted tables."


### PR DESCRIPTION
Adds reference to our new gftools script for unwanted table removal in the `com.google.fonts/check/unwanted_tables`  check fail message.  Replaces the suggestion to use ttx 