### PR TITLE
Fix typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'ufolint',
 
     ],
-    extras_requires={
+    extras_require={
         'docs': [
             'sphinx >= 1.4',
             'sphinx_rtd_theme',


### PR DESCRIPTION
## Description
This pull request fixes a typo in setup.py.
```
UserWarning: Unknown distribution option: 'extras_requires'
```