### PR TITLE
New check: Ensure explicit designer names are mentioned on METADATA.pb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### New checks
   - **[[com.google.fonts/check/superfamily/list]]**: A simple & merely informative check that lists detected sibling family directories (issue #1487)
+  - **[[com.google.fonts/check/metadata/multiple_designers]]**: Ensure explicit designer names are mentioned on METADATA.pb (issue #2766)
 
 ### Deprecated checks
   - **[com.google.fonts/check/monospace_max_advancewidth]**: (issue #2749)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -25,6 +25,7 @@ SUPERFAMILY_CHECKS = [
 METADATA_CHECKS = [
   'com.google.fonts/check/metadata/parses',
   'com.google.fonts/check/metadata/unknown_designer',
+  'com.google.fonts/check/metadata/multiple_designers',
   'com.google.fonts/check/metadata/designer_values',
   'com.google.fonts/check/metadata/listed_on_gfonts',
   'com.google.fonts/check/metadata/unique_full_name_values',
@@ -428,6 +429,26 @@ def com_google_fonts_check_metadata_unknown_designer(family_metadata):
                   f"Font designer field is '{family_metadata.designer}'.")
   else:
     yield PASS, "Font designer field is not 'unknown'."
+
+
+@check(
+  id = 'com.google.fonts/check/metadata/multiple_designers',
+  conditions = ['family_metadata'],
+  rationale = """
+    For a while the string "Multiple designers" was used as a placeholder on METADATA.pb files. We should replace all those instances with actual designer names so that proper credits are displayed on the Google Fonts family specimen pages.
+
+    If there's more than a single designer, the designer names must be separated by commas.
+  """
+)
+def com_google_fonts_check_metadata_multiple_designers(family_metadata):
+  """Font designer field in METADATA.pb must not contain 'Multiple designers'."""
+  if 'multiple designer' in family_metadata.designer.lower():
+    yield FAIL,\
+          Message("multiple-designers",
+                  f"Font designer field is '{family_metadata.designer}'."
+                  f" Please add an explicit comma-separated list of designer names.")
+  else:
+    yield PASS, "Looks good."
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -178,10 +178,10 @@ def canonical_stylename(font):
 
 
 @condition
-def family_directory(fonts):
+def family_directory(font):
   """Get the path of font project directory."""
-  if fonts:
-    dirname = os.path.dirname(fonts[0])
+  if font:
+    dirname = os.path.dirname(font)
     if dirname == '':
       dirname = '.'
     return dirname

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -706,11 +706,11 @@ def test_check_usweightclass():
 
 def test_family_directory_condition():
   from fontbakery.profiles.googlefonts import family_directory
-  assert family_directory(["some_directory/Foo.ttf"]) == "some_directory"
-  assert family_directory(["some_directory/subdir/Foo.ttf"]) == "some_directory/subdir"
-  assert family_directory(["Foo.ttf"]) == "." # This is meant to ensure license files
-                                              # are correctly detected on the current
-                                              # working directory.
+  assert family_directory("some_directory/Foo.ttf") == "some_directory"
+  assert family_directory("some_directory/subdir/Foo.ttf") == "some_directory/subdir"
+  assert family_directory("Foo.ttf") == "." # This is meant to ensure license files
+                                            # are correctly detected on the current
+                                            # working directory.
 
 def test_check_family_has_license():
   """ Check font project has a license. """
@@ -1015,8 +1015,8 @@ def test_check_name_ascii_only_entries():
 def test_check_metadata_listed_on_gfonts():
   """ METADATA.pb: Fontfamily is listed on Google Fonts API? """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_listed_on_gfonts as check,
-                                                     listed_on_gfonts_api,
-                                                     family_metadata)
+                                               listed_on_gfonts_api,
+                                               family_metadata)
 
   print ("Test WARN with a family that is not listed on Google Fonts...")
   # Our reference FamilySans family is a just a generic example
@@ -1091,8 +1091,8 @@ def test_check_metadata_license():
                                                family_metadata)
 
   # Let's start with the METADATA.pb file from our reference FamilySans family:
-  fonts = [TEST_FILE("familysans/FamilySans-Regular.ttf")]
-  md = family_metadata(family_directory(fonts))
+  font = TEST_FILE("familysans/FamilySans-Regular.ttf")
+  md = family_metadata(family_directory(font))
 
   good_licenses = ["APACHE2", "UFL", "OFL"]
   some_bad_values = ["APACHE", "Apache", "Ufl", "Ofl", "Open Font License"]
@@ -2281,7 +2281,7 @@ def DISABLED_test_check_production_encoded_glyphs(cabin_ttFonts):
     family_metadata,
     family_directory)
 
-  family_meta = family_metadata(family_directory(cabin_fonts))
+  family_meta = family_metadata(family_directory(cabin_fonts[0]))
   remote = remote_styles(family_meta.name)
   if remote:
     for font in cabin_fonts:
@@ -3190,7 +3190,7 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
     family_directory)
   from copy import copy
 
-  family_meta = family_metadata(family_directory(cabin_fonts))
+  family_meta = family_metadata(family_directory(cabin_fonts[0]))
   remote = remote_styles(family_meta.name)
   if remote:
     ttFonts = [TTFont(f) for f in cabin_fonts]


### PR DESCRIPTION
com.google.fonts/check/metadata/multiple_designers

(issue #2297) 