### PR TITLE
Pre v0.7.19: minimize disruption of experimental feature: superfamily checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### New checks
   - **[[com.google.fonts/check/superfamily/list]]**: A simple & merely informative check that lists detected sibling family directories (issue #1487)
+  - **[[com.google.fonts/check/superfamily/vertical_metrics]]**: Experimental extended version of **family/vertical_checks**, but only emitting WARNs for now (issues #1487 and #2431)
   - **[[com.google.fonts/check/metadata/multiple_designers]]**: Ensure explicit designer names are mentioned on METADATA.pb (issue #2766)
 
 ### Deprecated checks
@@ -18,7 +19,6 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[[com.google.fonts/check/post_table_version]]**: Support CFF2 OTF Variable Fonts and add rationale (issue #2638)
-  - **[[com.google.fonts/check/family/vertical_metrics]]**: Updated to check across sibling families. Check was also renamed to **com.google.fonts/check/superfamily/vertical_metrics** (issue #1487)
   - **[[com.google.fonts/check/metadata/valid_copyright]]**: Add rationale and make it case insensitive (issue #2736)
   - **[com.google.fonts/check/metadata/undeclared_fonts]**: Clarify rationale (issue #2751)
   - **[com.google.fonts/check/metadata/filenames]**: Add rationale (issue #2751)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -18,10 +18,6 @@ from .googlefonts_conditions import * # pylint: disable=wildcard-import,unused-w
 profile_imports = ('fontbakery.profiles.universal',)
 profile = profile_factory(default_section=Section("Google Fonts"))
 
-SUPERFAMILY_CHECKS = [
-  'com.google.fonts/check/superfamily/list'
-]
-
 METADATA_CHECKS = [
   'com.google.fonts/check/metadata/parses',
   'com.google.fonts/check/metadata/unknown_designer',
@@ -148,7 +144,6 @@ GOOGLEFONTS_PROFILE_CHECKS = \
   UNIVERSAL_PROFILE_CHECKS + \
   METADATA_CHECKS + \
   DESCRIPTION_CHECKS + \
-  SUPERFAMILY_CHECKS + \
   FAMILY_CHECKS + \
   NAME_TABLE_CHECKS + \
   REPO_CHECKS + \
@@ -4164,21 +4159,6 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
                   "This will cause problems with some of the Google Fonts"
                   " systems that look up fonts by their style names."
                   " This must be fixed!")
-
-
-@check(
-  id = 'com.google.fonts/check/superfamily/list',
-  rationale = """
-    This is a merely informative check that lists all sibling families detected by fontbakery.
-
-    Only the fontfiles in these directories will be considered in superfamily-level checks.
-  """
-)
-def com_google_fonts_check_superfamily_list(superfamily):
-  """List all superfamily filepaths"""
-  for family in superfamily:
-    yield INFO,\
-          Message("family-path", os.path.split(family[0])[0])
 
 
 ###############################################################################

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -18,66 +18,6 @@ def style(font):
 
 
 @condition
-def sibling_directories(family_directory):
-  """
-  Given a directory, this function tries to figure out where else in the filesystem
-  other related "sibling" families might be located.
-  This is guesswork and may not be able to find font files in other folders not yet
-  covered by this routine. We may improve this in the future by adding other
-  smarter filesystem lookup procedures or even by letting the user feed explicit
-  sibling family paths.
-
-  This function returs a list of paths to directories where related font files were detected.
-  """
-  SIBLING_SUFFIXES = ["sans",
-                      "sc",
-                      "narrow",
-                      "text",
-                      "display"]
-
-  base_family_dir = family_directory
-  for suffix in SIBLING_SUFFIXES:
-    if family_directory.endswith(suffix):
-      candidate = family_directory[:-len(suffix)]
-      if os.path.isdir(candidate):
-        base_family_dir = candidate
-        break
-
-  directories = [base_family_dir]
-  for suffix in SIBLING_SUFFIXES:
-    candidate = base_family_dir + suffix
-    if os.path.isdir(candidate):
-      directories.append(candidate)
-
-  return directories
-
-
-@condition
-def superfamily(sibling_directories):
-  """
-  Given a list of directories, this functions looks for font files
-  and returs a list of lists of the detected filepaths.
-  """
-  result = []
-  for family_dir in sibling_directories:
-    filepaths = []
-    for entry in os.listdir(family_dir):
-      if entry[-4:] in [".otf", ".ttf"]:
-        filepaths.append(os.path.join(family_dir, entry))
-    result.append(filepaths)
-  return result
-
-
-@condition
-def superfamily_ttFonts(superfamily):
-  from fontTools.ttLib import TTFont
-  result = []
-  for family in superfamily:
-    result.append([TTFont(f) for f in family])
-  return result
-
-
-@condition
 def RIBBI_ttFonts(fonts):
   from fontTools.ttLib import TTFont
   from fontbakery.constants import RIBBI_STYLE_NAMES
@@ -175,16 +115,6 @@ def canonical_stylename(font):
       (s in VARFONT_SUFFIXES and varfont)
       or (s in valid_style_suffixes and not varfont)):
     return s
-
-
-@condition
-def family_directory(font):
-  """Get the path of font project directory."""
-  if font:
-    dirname = os.path.dirname(font)
-    if dirname == '':
-      dirname = '.'
-    return dirname
 
 
 @condition

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 from collections import Counter
 
@@ -33,6 +34,78 @@ def is_cff(ttFont):
 @condition
 def is_cff2(ttFont):
   return 'CFF2' in ttFont
+
+
+@condition
+def family_directory(font):
+  """Get the path of font project directory."""
+  if font:
+    dirname = os.path.dirname(font)
+    if dirname == '':
+      dirname = '.'
+    return dirname
+
+
+@condition
+def sibling_directories(family_directory):
+  """
+  Given a directory, this function tries to figure out where else in the filesystem
+  other related "sibling" families might be located.
+  This is guesswork and may not be able to find font files in other folders not yet
+  covered by this routine. We may improve this in the future by adding other
+  smarter filesystem lookup procedures or even by letting the user feed explicit
+  sibling family paths.
+
+  This function returs a list of paths to directories where related font files were detected.
+  """
+  SIBLING_SUFFIXES = ["sans",
+                      "sc",
+                      "narrow",
+                      "text",
+                      "display",
+                      "condensed"]
+
+  base_family_dir = family_directory
+  for suffix in SIBLING_SUFFIXES:
+    if family_directory.endswith(suffix):
+      candidate = family_directory[:-len(suffix)]
+      if os.path.isdir(candidate):
+        base_family_dir = candidate
+        break
+
+  directories = [base_family_dir]
+  for suffix in SIBLING_SUFFIXES:
+    candidate = base_family_dir + suffix
+    if os.path.isdir(candidate):
+      directories.append(candidate)
+
+  return directories
+
+
+@condition
+def superfamily(sibling_directories):
+  """
+  Given a list of directories, this functions looks for font files
+  and returs a list of lists of the detected filepaths.
+  """
+  result = []
+  for family_dir in sibling_directories:
+    filepaths = []
+    for entry in os.listdir(family_dir):
+      if entry[-4:] in [".otf", ".ttf"]:
+        filepaths.append(os.path.join(family_dir, entry))
+    result.append(filepaths)
+  return result
+
+
+@condition
+def superfamily_ttFonts(superfamily):
+  from fontTools.ttLib import TTFont
+  result = []
+  for family in superfamily:
+    result.append([TTFont(f) for f in family])
+  return result
+
 
 @condition
 def ligatures(ttFont):

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -44,6 +44,7 @@ def test_get_family_checks():
         'com.google.fonts/check/family/equal_unicode_encodings',
         'com.google.fonts/check/family/equal_font_versions',
         'com.google.fonts/check/family/win_ascent_and_descent',
+        'com.google.fonts/check/family/vertical_metrics',
         # 'com.google.fonts/check/superfamily/vertical_metrics', # should it be included here?
                                                                  # or should we have a get_superfamily_checks() method?
     }

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -705,7 +705,7 @@ def test_check_usweightclass():
   #       this bug: https://github.com/googlefonts/fontbakery/issues/2650
 
 def test_family_directory_condition():
-  from fontbakery.profiles.googlefonts import family_directory
+  from fontbakery.profiles.shared_conditions import family_directory
   assert family_directory("some_directory/Foo.ttf") == "some_directory"
   assert family_directory("some_directory/subdir/Foo.ttf") == "some_directory/subdir"
   assert family_directory("Foo.ttf") == "." # This is meant to ensure license files
@@ -1052,7 +1052,7 @@ def NOT_IMPLEMENTED_test_check_metadata_profiles_csv():
 def test_check_metadata_unique_full_name_values():
   """ METADATA.pb: check if fonts field only has unique "full_name" values. """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_unique_full_name_values as check,
-                                                     family_metadata)
+                                               family_metadata)
   print ("Test PASS with a good family...")
   # Our reference FamilySans family is good:
   family_directory = portable_path("data/test/familysans")
@@ -1069,7 +1069,7 @@ def test_check_metadata_unique_full_name_values():
 def test_check_metadata_unique_weight_style_pairs():
   """ METADATA.pb: check if fonts field only contains unique style:weight pairs. """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_unique_weight_style_pairs as check,
-                                                     family_metadata)
+                                               family_metadata)
   print ("Test PASS with a good family...")
   # Our reference FamilySans family is good:
   family_directory = portable_path("data/test/familysans")
@@ -1086,8 +1086,8 @@ def test_check_metadata_unique_weight_style_pairs():
 
 def test_check_metadata_license():
   """ METADATA.pb license is "APACHE2", "UFL" or "OFL"? """
+  from fontbakery.profiles.shared_conditions import family_directory
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_license as check,
-                                               family_directory,
                                                family_metadata)
 
   # Let's start with the METADATA.pb file from our reference FamilySans family:
@@ -1186,7 +1186,7 @@ def test_check_metadata_subsets_order():
 def test_check_metadata_copyright():
   """ METADATA.pb: Copyright notice is the same in all fonts? """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_copyright as check,
-                                                     family_metadata)
+                                               family_metadata)
 
   # Let's start with the METADATA.pb file from our reference FamilySans family:
   family_directory = portable_path("data/test/familysans")
@@ -1232,7 +1232,7 @@ def test_check_metadata_familyname():
 def test_check_metadata_has_regular():
   """ METADATA.pb: According Google Fonts standards, families should have a Regular style. """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_has_regular as check,
-                                                     family_metadata)
+                                               family_metadata)
 
   # Let's start with the METADATA.pb file from our reference FamilySans family:
   family_directory = portable_path("data/test/familysans")
@@ -1257,7 +1257,7 @@ def test_check_metadata_has_regular():
 def test_check_metadata_regular_is_400():
   """ METADATA.pb: Regular should be 400. """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_regular_is_400 as check,
-                                                     family_metadata)
+                                               family_metadata)
 
   # Let's start with the METADATA.pb file from our reference FamilySans family:
   family_directory = portable_path("data/test/familysans")
@@ -2273,13 +2273,13 @@ def test_check_contour_count(montserrat_ttFonts):
 # More info at https://github.com/googlefonts/fontbakery/issues/2581
 def DISABLED_test_check_production_encoded_glyphs(cabin_ttFonts):
   """Check glyphs are not missing when compared to version on fonts.google.com"""
+  from fontbakery.profiles.shared_conditions import family_directory
   from fontbakery.profiles.googlefonts import (
     com_google_fonts_check_production_encoded_glyphs as check,
     api_gfonts_ttFont,
     style,
     remote_styles,
-    family_metadata,
-    family_directory)
+    family_metadata)
 
   family_meta = family_metadata(family_directory(cabin_fonts[0]))
   remote = remote_styles(family_meta.name)
@@ -3151,8 +3151,8 @@ def NOT_IMPLEMENTED__test_com_google_fonts_check_repo_dirname_match_nameid_1():
 
 def test_check_repo_vf_has_static_fonts():
   """Check VF family dirs in google/fonts contain static fonts"""
-  from fontbakery.profiles.googlefonts import (family_directory,
-                                               com_google_fonts_check_repo_vf_has_static_fonts as check)
+  from fontbakery.profiles.shared_conditions import family_directory
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_repo_vf_has_static_fonts as check
   import tempfile
   import shutil
   # in order for this check to work, we need to mimmic the folder structure of
@@ -3181,13 +3181,13 @@ def test_check_repo_vf_has_static_fonts():
 
 
 def test_check_vertical_metrics_regressions(cabin_ttFonts):
+  from fontbakery.profiles.shared_conditions import family_directory
   from fontbakery.profiles.googlefonts import (
     com_google_fonts_check_vertical_metrics_regressions as check,
     api_gfonts_ttFont,
     style,
     remote_styles,
-    family_metadata,
-    family_directory)
+    family_metadata)
   from copy import copy
 
   family_meta = family_metadata(family_directory(cabin_fonts[0]))

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -64,12 +64,12 @@ cabin_condensed_fonts = [
 ]
 
 @pytest.fixture
-  def cabin_ttFonts():
-    return [TTFont(path) for path in cabin_fonts]
+def cabin_ttFonts():
+  return [TTFont(path) for path in cabin_fonts]
 
 @pytest.fixture
-  def cabin_condensed_ttFonts():
-    return [TTFont(path) for path in cabin_condensed_fonts]
+def cabin_condensed_ttFonts():
+  return [TTFont(path) for path in cabin_condensed_fonts]
 
 
 def test_check_valid_glyphnames():
@@ -666,11 +666,11 @@ def test_check_family_vertical_metrics(montserrat_ttFonts):
 def test_check_superfamily_vertical_metrics(montserrat_ttFonts, cabin_ttFonts, cabin_condensed_ttFonts):
   from fontbakery.profiles.universal import com_google_fonts_check_superfamily_vertical_metrics as check
   print("Test pass with multiple good families...")
-  status, message = list(check([montserrat_ttFonts,
-                                montserrat_ttFonts]))[-1]
+  status, message = list(check([cabin_ttFonts,
+                                cabin_condensed_ttFonts]))[-1]
   assert status == PASS
 
   print("Test fail with families that diverge on vertical metric values...")
   status, message = list(check([cabin_ttFonts,
-                                cabin_condensed_ttFonts]))[-1]
-  assert status == FAIL
+                                montserrat_ttFonts]))[-1]
+  assert status == WARN

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -45,6 +45,33 @@ def montserrat_ttFonts():
   return [TTFont(path) for path in paths]
 
 
+cabin_fonts = [
+  TEST_FILE("cabin/Cabin-BoldItalic.ttf"),
+  TEST_FILE("cabin/Cabin-Bold.ttf"),
+  TEST_FILE("cabin/Cabin-Italic.ttf"),
+  TEST_FILE("cabin/Cabin-MediumItalic.ttf"),
+  TEST_FILE("cabin/Cabin-Medium.ttf"),
+  TEST_FILE("cabin/Cabin-Regular.ttf"),
+  TEST_FILE("cabin/Cabin-SemiBoldItalic.ttf"),
+  TEST_FILE("cabin/Cabin-SemiBold.ttf")
+]
+
+cabin_condensed_fonts = [
+  TEST_FILE("cabin/CabinCondensed-Regular.ttf"),
+  TEST_FILE("cabin/CabinCondensed-Medium.ttf"),
+  TEST_FILE("cabin/CabinCondensed-Bold.ttf"),
+  TEST_FILE("cabin/CabinCondensed-SemiBold.ttf")
+]
+
+@pytest.fixture
+  def cabin_ttFonts():
+    return [TTFont(path) for path in cabin_fonts]
+
+@pytest.fixture
+  def cabin_condensed_ttFonts():
+    return [TTFont(path) for path in cabin_condensed_fonts]
+
+
 def test_check_valid_glyphnames():
   """ Glyph names are all valid? """
   import io
@@ -624,13 +651,26 @@ def test_check_os2_metrics_match_hhea(mada_ttFonts):
   assert status == FAIL and message.code == "descender"
 
 
-def test_check_superfamily_vertical_metrics(montserrat_ttFonts):
-  from fontbakery.profiles.universal import com_google_fonts_check_superfamily_vertical_metrics as check
+def test_check_family_vertical_metrics(montserrat_ttFonts):
+  from fontbakery.profiles.universal import com_google_fonts_check_family_vertical_metrics as check
   print("Test pass with multiple good fonts...")
-  status, message = list(check([montserrat_ttFonts]))[-1]
+  status, message = list(check(montserrat_ttFonts))[-1]
   assert status == PASS
 
   print("Test fail with one bad font that has one different vertical metric val...")
   montserrat_ttFonts[0]['OS/2'].usWinAscent = 4000
-  status, message = list(check([montserrat_ttFonts]))[-1]
+  status, message = list(check(montserrat_ttFonts))[-1]
+  assert status == FAIL
+
+
+def test_check_superfamily_vertical_metrics(montserrat_ttFonts, cabin_ttFonts, cabin_condensed_ttFonts):
+  from fontbakery.profiles.universal import com_google_fonts_check_superfamily_vertical_metrics as check
+  print("Test pass with multiple good families...")
+  status, message = list(check([montserrat_ttFonts,
+                                montserrat_ttFonts]))[-1]
+  assert status == PASS
+
+  print("Test fail with families that diverge on vertical metric values...")
+  status, message = list(check([cabin_ttFonts,
+                                cabin_condensed_ttFonts]))[-1]
   assert status == FAIL


### PR DESCRIPTION
* bring back original check-id for family/vertical_metrics
* separate the code of the experimental superfamily/vertical_metrics and keep this new check **WARN-only** instead of **FAIL**
* place it on universal profile because it is useful in general even though still experimental.