### PR TITLE
Move name/line_breaks check to googlefonts profile as it is a vendor-specific policy rather than an opentype spec requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[[com.google.fonts/check/varfont_instance_*]]**: Clean up output and ensure that unregistered axes produce a warning
   - **[[com.google.fonts/check/fontdata_namecheck]]**: improve log messages when query fails (issue #2719)
 
+### Migration of checks between profiles
+  - **[[com.google.fonts/check/name/line_breaks]]**: move it from `opentype` to `googlefonts` profile as it is a vendor-specific policy rather than an OpenType spec requirement. (issue #2778)
+
 
 ## 0.7.20 (2020-Feb-24)
 ### Emergency bugfix release!

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -83,6 +83,7 @@ NAME_TABLE_CHECKS = [
   'com.google.fonts/check/name/license',
   'com.google.fonts/check/name/license_url',
   'com.google.fonts/check/name/family_and_style_max_length',
+  'com.google.fonts/check/name/line_breaks',
 ]
 
 REPO_CHECKS = [
@@ -3888,6 +3889,31 @@ def com_google_fonts_check_name_family_and_style_max_length(ttFont):
                       f" name table records max-length criteria.")
   if not failed:
     yield PASS, "All name entries are good."
+
+
+@check(
+  id = 'com.google.fonts/check/name/line_breaks',
+  rationale = """
+    There are some entries on the name table that may include more than one line of text. The Google Fonts team, though, prefers to keep the name table entries short and simple without line breaks.
+
+    For instance, some designers like to include the full text of a font license in the "copyright notice" entry, but for the GFonts collection this entry should only mention year, author and other basic info in a manner enforced by com.google.fonts/check/font_copyright
+  """
+)
+def com_google_fonts_check_name_line_breaks(ttFont):
+  """Name table entries should not contain line-breaks."""
+  failed = False
+  for name in ttFont["name"].names:
+    string = name.string.decode(name.getEncoding())
+    if "\n" in string:
+      failed = True
+      yield FAIL,\
+            Message("line-break",
+                    f"Name entry {NameID(name.nameID).name}"
+                    f" on platform {PlatformID(name.platformID).name}"
+                    f" contains a line-break.")
+  if not failed:
+    yield PASS, ("Name table entries are all single-line"
+                 " (no line-breaks found).")
 
 
 @check(

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -182,26 +182,6 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
 
 
 @check(
-  id = 'com.google.fonts/check/name/line_breaks'
-)
-def com_google_fonts_check_name_line_breaks(ttFont):
-  """Name table entries should not contain line-breaks."""
-  failed = False
-  for name in ttFont["name"].names:
-    string = name.string.decode(name.getEncoding())
-    if "\n" in string:
-      failed = True
-      yield FAIL,\
-            Message("line-break",
-                    f"Name entry {NameID(name.nameID).name}"
-                    f" on platform {PlatformID(name.platformID).name}"
-                    f" contains a line-break.")
-  if not failed:
-    yield PASS, ("Name table entries are all single-line"
-                 " (no line-breaks found).")
-
-
-@check(
   id = 'com.google.fonts/check/name/match_familyname_fullfont'
 )
 def com_google_fonts_check_name_match_familyname_fullfont(ttFont):

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -36,7 +36,6 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/name/postscript_name_consistency',
     'com.adobe.fonts/check/name/empty_records',
     'com.google.fonts/check/name/no_copyright_on_description',
-    'com.google.fonts/check/name/line_breaks',
     'com.google.fonts/check/name/rfn',
     'com.google.fonts/check/name/match_familyname_fullfont',
     'com.google.fonts/check/varfont/regular_wght_coord',

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -399,6 +399,27 @@ def test_check_name_family_and_style_max_length():
   assert status == WARN and message.code == "too-long"
 
 
+def test_check_name_line_breaks():
+  """ Name table entries should not contain line-breaks. """
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_name_line_breaks as check
+
+  # Our reference Mada Regular font is good here:
+  ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+
+  # So it must PASS the check:
+  print ("Test PASS with a good font...")
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+
+  print ("Test FAIL with name entries containing a linebreak...")
+  for i in range(len(ttFont["name"].names)):
+    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+    encoding = ttFont["name"].names[i].getEncoding()
+    ttFont["name"].names[i].string = "bad\nstring".encode(encoding)
+    status, message = list(check(ttFont))[-1]
+    assert status == FAIL and message.code == "line-break"
+
+
 def test_check_metadata_parses():
   """ Check METADATA.pb parse correctly. """
   from fontbakery.profiles.googlefonts import com_google_fonts_check_metadata_parses as check

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -154,27 +154,6 @@ def test_check_monospace():
     assert results_contain(results, FAIL, "mono-bad-panose-proportion")
 
 
-def test_check_name_line_breaks():
-  """ Name table entries should not contain line-breaks. """
-  from fontbakery.profiles.name import com_google_fonts_check_name_line_breaks as check
-
-  # Our reference Mada Regular font is good here:
-  ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-
-  # So it must PASS the check:
-  print ("Test PASS with a good font...")
-  status, message = list(check(ttFont))[-1]
-  assert status == PASS
-
-  print ("Test FAIL with name entries containing a linebreak...")
-  for i in range(len(ttFont["name"].names)):
-    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-    encoding = ttFont["name"].names[i].getEncoding()
-    ttFont["name"].names[i].string = "bad\nstring".encode(encoding)
-    status, message = list(check(ttFont))[-1]
-    assert status == FAIL and message.code == "line-break"
-
-
 def test_check_name_match_familyname_fullfont():
   """ Does full font name begin with the font family name? """
   from fontbakery.profiles.name import com_google_fonts_check_name_match_familyname_fullfont as check


### PR DESCRIPTION
(issue #2778)