### PR TITLE
Move name/rfn check to googlefonts profile / add rationale / make it a FAIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## 0.7.21 (2020-Mar-??)
+## 0.7.21 (2020-Mar-06)
 ### Changes to existing checks
   - **[[com.google.fonts/check/varfont_instance_*]]**: Clean up output and ensure that unregistered axes produce a warning
   - **[[com.google.fonts/check/fontdata_namecheck]]**: improve log messages when query fails (issue #2719)
+  - **[[com.google.fonts/check/name/rfn]]**: Add rationale and make it a **FAIL** as it is a strong requirement for Google Fonts that families do not use a "Reserved Font Name" (issue #2779)
+  - **[[com.google.fonts/check/name/line_breaks]]**: Add rationale (issue #2778)
 
 ### Migration of checks between profiles
-  - **[[com.google.fonts/check/name/line_breaks]]**: move it from `opentype` to `googlefonts` profile as it is a vendor-specific policy rather than an OpenType spec requirement. (issue #2778)
+  - **[[com.google.fonts/check/name/line_breaks]]**: From `opentype` to `googlefonts` profile as it is a vendor-specific policy rather than an OpenType spec requirement. (issue #2778)
+  - **[[com.google.fonts/check/name/rfn]]**: From `opentype` to `googlefonts` profile (issue #2779)
 
 
 ## 0.7.20 (2020-Feb-24)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -84,6 +84,7 @@ NAME_TABLE_CHECKS = [
   'com.google.fonts/check/name/license_url',
   'com.google.fonts/check/name/family_and_style_max_length',
   'com.google.fonts/check/name/line_breaks',
+  'com.google.fonts/check/name/rfn',
 ]
 
 REPO_CHECKS = [
@@ -3914,6 +3915,32 @@ def com_google_fonts_check_name_line_breaks(ttFont):
   if not failed:
     yield PASS, ("Name table entries are all single-line"
                  " (no line-breaks found).")
+
+
+@check(
+  id = 'com.google.fonts/check/name/rfn',
+  rationale = """
+    Some designers adopt the "Reserved Font Name" clause of the OFL license. This means that the original author reserves the rights to the family name and other people can only distribute modified versions using a different family name.
+
+    Google Fonts published updates to the fonts in the collection in order to fix issues and/or implement further improvements to the fonts. It is important to keep the family name so that users of the webfonts can benefit from the updates. Since it would forbid such usage scenario, all families in the GFonts collection are required to not adopt the RFN clause.
+
+    This check ensures "Reserved Font Name" is not mentioned in the name table.
+  """
+)
+def com_google_fonts_check_name_rfn(ttFont):
+  """Name table strings must not contain the string 'Reserved Font Name'."""
+  failed = False
+  for entry in ttFont["name"].names:
+    string = entry.toUnicode()
+    if "reserved font name" in string.lower():
+      yield FAIL,\
+            Message("rfn",
+                    f'Name table entry ("{string}")'
+                    f' contains "Reserved Font Name".'
+                    f' This is an error except in a few specific rare cases.')
+      failed = True
+  if not failed:
+    yield PASS, 'None of the name table strings contain "Reserved Font Name".'
 
 
 @check(

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -325,26 +325,6 @@ def com_google_fonts_check_family_naming_recommendations(ttFont):
 
 
 @check(
-  id = 'com.google.fonts/check/name/rfn'
-)
-def com_google_fonts_check_name_rfn(ttFont):
-  """Name table strings must not contain the string 'Reserved Font Name'."""
-  failed = False
-  for entry in ttFont["name"].names:
-    string = entry.toUnicode()
-    if "reserved font name" in string.lower():
-      yield WARN,\
-            Message("rfn",
-                    f'Name table entry ("{string}")'
-                    f' contains "Reserved Font Name".'
-                    f' This is an error except in a few specific rare cases.')
-      failed = True
-  if not failed:
-    yield PASS, ('None of the name table strings'
-                 ' contain "Reserved Font Name".')
-
-
-@check(
   id = 'com.adobe.fonts/check/name/postscript_vs_cff',
   conditions = ['is_cff'],
   rationale = """

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -36,7 +36,6 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/name/postscript_name_consistency',
     'com.adobe.fonts/check/name/empty_records',
     'com.google.fonts/check/name/no_copyright_on_description',
-    'com.google.fonts/check/name/rfn',
     'com.google.fonts/check/name/match_familyname_fullfont',
     'com.google.fonts/check/varfont/regular_wght_coord',
     'com.google.fonts/check/varfont/regular_wdth_coord',

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -420,6 +420,20 @@ def test_check_name_line_breaks():
     assert status == FAIL and message.code == "line-break"
 
 
+def test_check_name_rfn():
+  """ Name table strings must not contain 'Reserved Font Name'. """
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_name_rfn as check
+
+  test_font = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
+
+  status, _ = list(check(test_font))[-1]
+  assert status == PASS
+
+  test_font["name"].setName("Bla Reserved Font Name", 5, 3, 1, 0x409)
+  status, message = list(check(test_font))[-1]
+  assert status == FAIL and message.code == "rfn"
+
+
 def test_check_metadata_parses():
   """ Check METADATA.pb parse correctly. """
   from fontbakery.profiles.googlefonts import com_google_fonts_check_metadata_parses as check

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -288,20 +288,6 @@ def test_check_family_naming_recommendations():
       name_test("A"*31, PASS)
 
 
-def test_check_name_rfn():
-  """ Name table strings must not contain 'Reserved Font Name'. """
-  from fontbakery.profiles.name import com_google_fonts_check_name_rfn as check
-
-  test_font = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
-
-  status, _ = list(check(test_font))[-1]
-  assert status == PASS
-
-  test_font["name"].setName("Bla Reserved Font Name", 5, 3, 1, 0x409)
-  status, message = list(check(test_font))[-1]
-  assert status == WARN and message.code == "rfn"
-
-
 def test_check_name_postscript_vs_cff():
   from fontbakery.profiles.name import com_adobe_fonts_check_name_postscript_vs_cff as check
   test_font = TTFont()


### PR DESCRIPTION
It is now a **FAIL** because it is a strong requirement for Google Fonts that families do not use a "Reserved Font Name"
(issue #2779)