### PR TITLE
fix/rename script for running checks against a full collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.21 (2020-Mar-06)
+### Note-worthy changes
+  - The snippet for checking collections is just an example shell script and it is specific to the directory structure of the Google Fonts git repo. We've made this clearer by renaming the script to **snippets/fontbakery-check-gfonts-collection.sh** (issue #2740)
+  - The script was also fixed to run properly on MacOS, as it was originally only working on GNU+Linux.
+
 ### Changes to existing checks
   - **[[com.google.fonts/check/varfont_instance_*]]**: Clean up output and ensure that unregistered axes produce a warning
   - **[[com.google.fonts/check/fontdata_namecheck]]**: improve log messages when query fails (issue #2719)

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -10,7 +10,6 @@ This has several subcommands, described in the help function:
     Run fontbakery subcommands:
         build-contributors
         check-adobefonts
-        check-collection
         check-fontval
         check-googlefonts
         check-notofonts
@@ -136,9 +135,11 @@ Here's the output of `fontbakery check-googlefonts -h`:
 
 Note: on Windows, color and progress bar output is disabled because the standard Windows terminal displays the escape characters instead. Pull Requests to fix this are welcome.
 
-If you need to generate a list of all issues in a font family collection, such as the Google Fonts collection, checkout that repo and then run:
+If you need to generate a list of all issues in a font family collection, the FontBakery repo has a small script to do so for the Google Fonts collection. Feel free to use that snippet and adapt it to the directory structure of your collection.
 
-    sh bin/fontbakery-check-collection.sh path-to-collection-directory
+For checking the GFonts collection the script is used like this:
+
+    sh snippets/fontbakery-check-gfonts-collection.sh path-to-collection-directory
 
 This will create a folder called `check_results/` then run the `check-googlefonts` subcommand on every family, saving individual per-family reports in json format into subdirectories.
 

--- a/snippets/fontbakery-check-gfonts-collection.sh
+++ b/snippets/fontbakery-check-gfonts-collection.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+echo "This script expects to find font-families organized in the same directory structure as the Google Fonts git repo at https://github.com/google/fonts/"
+echo "The collection_folder specified in the command-line must contain sub-directories with license names ('ofl', 'ufl' or 'apache') and familyname directories within those."
+
 if [ "$1" ]; then
   COLLECTION_FOLDER=$1
 else
@@ -11,10 +14,10 @@ OFL_FOLDERS=$COLLECTION_FOLDER/ofl/*
 UFL_FOLDERS=$COLLECTION_FOLDER/ufl/*
 RESULTS_FOLDER=$COLLECTION_FOLDER/check_results
 
-mkdir $RESULTS_FOLDER -p
-rm $RESULTS_FOLDER/issues.txt -f
-rm $RESULTS_FOLDER/all_fonts.txt -f
-rm $COLLECTION_FOLDER/*/*/*fontbakery.*
+mkdir -p $RESULTS_FOLDER
+rm -f $RESULTS_FOLDER/issues.txt
+rm -f $RESULTS_FOLDER/all_fonts.txt
+rm -f $COLLECTION_FOLDER/*/*/*fontbakery.json
 
 for f in $APACHE_FOLDERS $OFL_FOLDERS $UFL_FOLDERS
 do


### PR DESCRIPTION
Also update documentation to make it clear that this is only an example snippet targeted at checking the Google Fonts collection.
(issue #2740)