### PR TITLE
familyname_with_spaces: Improve familyname parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.22 (2020-Mar-??)
+### Note-worthy changes
+  - Updated function to extract a font family name from a font filename. Code taken from gftools.util.google_fonts.FamilyName
+
 ### documentation
   - clarify that Xcode version can be 9 or later (issue #2784)
 


### PR DESCRIPTION
This func now uses the same method as [gftools.util.googlefonts.FamilyName](https://github.com/googlefonts/gftools/blob/master/Lib/gftools/util/google_fonts.py#L419-L434). I've found the results are far superior and we no longer need to maintain the whitelist.

e.g

```
>>> familyname_with_spaces("DMMono")
'DM Mono'

>>> familyname_with_spaces("VT323")
'VT323'

>>> family_name_with_spaces("SpectralSC")
'Spectral SC'

>>> family_name_with_spaces("DMSerif")
'DM Serif'
```