### PR TITLE
com.google.fonts/check/cjk_vertical_metrics: added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.google.fonts/check/repo/fb_report]**: WARN when upstream repo has fb report files (issue #2888)
   - **[com.google.fonts/check/repo/zip_files]**: FAIL when upstream repo has ZIP files (issue #2903)
+  - **[[com_google_fonts_check_cjk_vertical_metrics]]**: Check cjk fonts follow our cjk metric schema
 
 ### Changes to existing checks
   - **[com.google.fonts/check/metadata/os2_weightclass]**: Check will now work correctly for variable fonts (issue #2683)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -141,6 +141,7 @@ FONT_FILE_CHECKS = [
   'com.google.fonts/check/unitsperem_strict',
   'com.google.fonts/check/contour_count',
   'com.google.fonts/check/vertical_metrics_regressions',
+  'com.google.fonts/check/cjk_vertical_metrics',
   'com.google.fonts/check/varfont_instance_coordinates',
   'com.google.fonts/check/varfont_instance_names',
   'com.google.fonts/check/varfont/consistent_axes',
@@ -4287,10 +4288,9 @@ def com_google_fonts_check_vertical_metrics_regressions(ttFonts, remote_styles):
   family hosted on Google Fonts."""
   import math
   from .shared_conditions import (is_variable_font,
-                                  get_instance_axis_value)
+                                  get_instance_axis_value,
+                                  typo_metrics_enabled)
 
-  def typo_metrics_enabled(ttFont):
-    return ttFont['OS/2'].fsSelection & 0b10000000 > 0
 
   failed = False
   ttFonts = list(ttFonts)
@@ -4358,6 +4358,82 @@ def com_google_fonts_check_vertical_metrics_regressions(ttFonts, remote_styles):
                     f" when it should be {expected_descender}")
   if not failed:
     yield PASS, "Vertical metrics have not regressed."
+
+
+@check(
+  id = 'com.google.fonts/check/cjk_vertical_metrics',
+  conditions = ['is_cjk_font', 'not remote_styles'],
+  rationale="""
+    CJK fonts have different vertical metrics when compared to Latin fonts. We follow the schema developed by dr Ken Lunde for Source Han Sans and the Noto CJK fonts.
+
+    Our documentation includes further information: https://github.com/googlefonts/gf-docs/tree/master/Spec#cjk-vertical-metrics
+  """
+)
+def com_google_fonts_check_cjk_vertical_metrics(ttFont):
+  """Check font follows the Google Fonts CJK vertical metric schema"""
+  from .shared_conditions import is_cjk_font, typo_metrics_enabled
+  font_upm = ttFont['head'].unitsPerEm
+
+  font_metrics = {
+    'OS/2.sTypoAscender': ttFont['OS/2'].sTypoAscender,
+    'OS/2.sTypoDescender': ttFont['OS/2'].sTypoDescender,
+    'OS/2.sTypoLineGap': ttFont['OS/2'].sTypoLineGap,
+    'hhea.ascender': ttFont['hhea'].ascent,
+    'hhea.descender': ttFont['hhea'].descent,
+    'hhea.lineGap': ttFont['hhea'].lineGap,
+    'OS/2.usWinAscent': ttFont['OS/2'].usWinAscent,
+    'OS/2.usWinDescent': ttFont['OS/2'].usWinDescent
+  }
+
+  expected_metrics = {
+    'OS/2.sTypoAscender': font_upm * 0.88,
+    'OS/2.sTypoDescender': font_upm * -0.12,
+    'OS/2.sTypoLineGap': 0,
+    'hhea.lineGap': 0,
+  }
+
+  failed, warn = False, False
+  # Check fsSelection bit 7 is not enabled
+  if typo_metrics_enabled(ttFont):
+    failed = True
+    yield FAIL, Message(
+      "bit-7",
+      "OS/2 fsSelection bit 7 must be disabled"
+    )
+  # Check typo metrics and hhea lineGap match our expected values
+  for k in expected_metrics:
+    if font_metrics[k] != expected_metrics[k]:
+      failed = True
+      yield FAIL, Message(
+        "bad-value",
+        f'{k} is "{font_metrics[k]}" it should be {expected_metrics[k]}'
+      )
+  # Check hhea and win values match
+  if font_metrics['hhea.ascender'] != font_metrics['OS/2.usWinAscent']:
+      failed = True
+      yield FAIL, Message(
+        "hhea-win-mismatch",
+        'hhea.ascender must match OS/2.usWinAscent'
+      )
+  if abs(font_metrics['hhea.descender']) != font_metrics['OS/2.usWinDescent']:
+      failed = True
+      yield FAIL, Message(
+        "hhea-win-mismatch",
+        'hhea.descender must match absolute value of OS/2.usWinDescent'
+      )
+  # Check the sum of the hhea metrics is between 1.1-1.5x of the font's upm
+  hhea_sum = sum([font_metrics['hhea.ascender'],
+                  abs(font_metrics['hhea.descender']),
+                  font_metrics['hhea.lineGap']]) / font_upm
+  if not failed and not 1.1 < hhea_sum <= 1.5:
+    warn = True
+    yield WARN, Message(
+      "bad-hhea-range",
+      (f"We recommend the absolute sum of the hhea metrics should be "
+       f"between 1.1-1.4x of the font's upm. This font has {hhea_sum}x")
+    )
+  if not failed and not warn:
+    yield PASS, "Vertical metrics are good"
 
 
 @check(

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -340,3 +340,8 @@ def is_cjk_font(ttFont):
 
   # default, return False if the above checks did not identify a CJK font
   return False
+
+
+@condition
+def typo_metrics_enabled(ttFont):
+  return ttFont['OS/2'].fsSelection & 0b10000000 > 0


### PR DESCRIPTION
After doing some research and talking to Ken Lunde, it makes sense to use the same vertical metrics schema as Source Han Sans and the Noto Sans CJK families. I've updated our wip spec which has more [info](https://gist.github.com/m4rc1e/8f4c4498519e8a36cd54e16a004275cb#cjk-vertical-metrics)

We've released some CJK fonts in the past so I've decided that this check should only run on new families which are not on Google Fonts. If a family being checked is CJK and it exists on Google Fonts, our regular vertical metrics regression check will be used instead.

I haven't touched @chrissimpkins is_cjk_font function in this pr. I may improve it at a later date once I've done further research. For more info see #2796

@felipesanches I may be a little slow make improvements on this pr this week. I'll try my best.

