### PR TITLE
Refactored ttfautohint_stats to hinting_stats and return hinting impa…

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1136,16 +1136,15 @@ def com_google_fonts_check_name_description_max_length(ttFont):
 
 @check(
   id = 'com.google.fonts/check/hinting_impact',
-  conditions = ['is_ttf',
-                'ttfautohint_stats'],
+  conditions = ['hinting_stats'],
   rationale = """
-    This check is merely informative, displaying and useful comparison of filesizes after ttfautohint usage versus unhinted font files.
+    This check is merely informative, displaying and useful comparison of filesizes of hinted versus unhinted font files.
   """
 )
-def com_google_fonts_check_hinting_impact(font, ttfautohint_stats):
+def com_google_fonts_check_hinting_impact(font, hinting_stats):
   """Show hinting filesize impact."""
-  hinted = ttfautohint_stats["hinted_size"]
-  dehinted = ttfautohint_stats["dehinted_size"]
+  hinted = hinting_stats["hinted_size"]
+  dehinted = hinting_stats["dehinted_size"]
   increase = hinted - dehinted
   change = (float(hinted)/dehinted - 1) * 100
 
@@ -1252,7 +1251,7 @@ def com_google_fonts_check_has_ttfautohint_params(ttFont):
     This check finds which version of ttfautohint was used, by inspecting name table entries and then finds which version of ttfautohint is currently installed in the system.
   """
 )
-def com_google_fonts_check_old_ttfautohint(ttFont, ttfautohint_stats):
+def com_google_fonts_check_old_ttfautohint(ttFont, hinting_stats):
   """Font has old ttfautohint applied?"""
   from fontbakery.utils import get_name_entry_strings
 
@@ -1268,7 +1267,7 @@ def com_google_fonts_check_old_ttfautohint(ttFont, ttfautohint_stats):
     used = list(map(int, used.split(".")))
     return installed > used
 
-  if not ttfautohint_stats:
+  if not hinting_stats:
     yield ERROR,\
           Message("not-available",
                   "ttfautohint is not available.")


### PR DESCRIPTION
…ct info also for CFF/CFF2 fonts

## Description
A first stab at #2802

A few things I am not 100% about:
- I use `pyftsubset` to make the dehinted file, and arguments I think will result in least/no impact in the font other than removing hinting; I am not super knowledgable about the inner workings of pyftsubset, so there could be things that should/should not be done if using this approach, OR use another approach other that pyftsubset? (I inquired about options to "dehint" a font with [psautohint here](https://github.com/adobe-type-tools/psautohint/issues/241), and `tx` seems to be an option to clean only (?) the CFF table from hinting info, but not sure if a) that is even desired — I think `pyftsubset --no-hinting` cleans up other tables as well, which I think is what we want — and b) getting to interact with the `tx` binary seemed more difficult to get into the fontbakery test suite
- I am not sure how the metrics are generated for ttf dehinted fonts, but due to the aforementioned fact the "dehinted" OTF are not binary hinted/dehinted. I tested with both a TTF and an OTF generated from GlyphsApp with "autohint" unchecked — both seems to report some file size change, so maybe that is not an issue
- Not sure if the `pyftsubset` dependency needs a update to requirements... when installing fontbakery with `pip install -U -e .` I get e.g. `pip list`:
```
fonttools          4.6.0
```
which fulfills the pyftsubset requirement, but the `requirements.txt` actually specs something different: `fontTools[ufo,lxml,unicode]==4.0.2` — or are this requirements.txt and the setup.py requirements different?
- I don't know if there is any psautohint version info somewhere in a hinted font, so it `version ""` for cff/cff2 fonts
- I added all imports for the cff and ttf at the top of the condition — should they import more granular inside the if/elif loop?

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

