### PR TITLE
Refactored ttfautohint_stats to hinting_stats and return hinting impact info also for CFF/CFF2 fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### documentation
   - clarify that Xcode version can be 9 or later (issue #2784)
 
+### Changes to existing checks
+  - **[[com.google.fonts/check/hinting_impact]]**: Add support for CFF hints (#2802)
+
 
 ## 0.7.21 (2020-Mar-06)
 ### Note-worthy changes

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1136,16 +1136,15 @@ def com_google_fonts_check_name_description_max_length(ttFont):
 
 @check(
   id = 'com.google.fonts/check/hinting_impact',
-  conditions = ['is_ttf',
-                'ttfautohint_stats'],
+  conditions = ['hinting_stats'],
   rationale = """
-    This check is merely informative, displaying and useful comparison of filesizes after ttfautohint usage versus unhinted font files.
+    This check is merely informative, displaying and useful comparison of filesizes of hinted versus unhinted font files.
   """
 )
-def com_google_fonts_check_hinting_impact(font, ttfautohint_stats):
+def com_google_fonts_check_hinting_impact(font, hinting_stats):
   """Show hinting filesize impact."""
-  hinted = ttfautohint_stats["hinted_size"]
-  dehinted = ttfautohint_stats["dehinted_size"]
+  hinted = hinting_stats["hinted_size"]
+  dehinted = hinting_stats["dehinted_size"]
   increase = hinted - dehinted
   change = (float(hinted)/dehinted - 1) * 100
 
@@ -1165,12 +1164,12 @@ def com_google_fonts_check_hinting_impact(font, ttfautohint_stats):
         Message("size-impact",
                 f"Hinting filesize impact:\n"
                 f"\n"
-                f"|  | {font} |\n"
-                f"|:--- | ---:|\n"
-                f"| Dehinted Size | {dehinted_size} |\n"
-                f"| Hinted Size | {hinted_size} |\n"
-                f"| Increase | {increase} |\n"
-                f"| Change   | {change:.1f} % |\n")
+                f"\t|  | {font} |\n"
+                f"\t|:--- | ---:|\n"
+                f"\t| Dehinted Size | {dehinted_size} |\n"
+                f"\t| Hinted Size | {hinted_size} |\n"
+                f"\t| Increase | {increase} |\n"
+                f"\t| Change   | {change:.1f} % |\n")
 
 
 @check(
@@ -1252,7 +1251,7 @@ def com_google_fonts_check_has_ttfautohint_params(ttFont):
     This check finds which version of ttfautohint was used, by inspecting name table entries and then finds which version of ttfautohint is currently installed in the system.
   """
 )
-def com_google_fonts_check_old_ttfautohint(ttFont, ttfautohint_stats):
+def com_google_fonts_check_old_ttfautohint(ttFont, hinting_stats):
   """Font has old ttfautohint applied?"""
   from fontbakery.utils import get_name_entry_strings
 
@@ -1268,7 +1267,7 @@ def com_google_fonts_check_old_ttfautohint(ttFont, ttfautohint_stats):
     used = list(map(int, used.split(".")))
     return installed > used
 
-  if not ttfautohint_stats:
+  if not hinting_stats:
     yield ERROR,\
           Message("not-available",
                   "ttfautohint is not available.")

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -265,24 +265,58 @@ def familyname(font):
 
 
 @condition
-def ttfautohint_stats(font):
+def hinting_stats(font):
+  """
+  Return file size differences for a hinted font compared to an dehinted version of same file
+  """
   from ttfautohint import ttfautohint, libttfautohint
   from io import BytesIO
   from fontTools.ttLib import TTFont
-  from fontbakery.profiles.shared_conditions import is_ttf
+  from fontTools.subset import main as pyftsubset
+  from fontbakery.profiles.shared_conditions import (is_ttf,
+                                                     is_cff,
+                                                     is_cff2)
 
-  if not is_ttf(TTFont(font)):
+  if is_ttf(TTFont(font)):
+    original_buffer = BytesIO()
+    TTFont(font).save(original_buffer)
+    dehinted_buffer = ttfautohint(in_buffer=original_buffer.getvalue(),
+                                  dehint=True)
+    dehinted_size = len(dehinted_buffer)
+    version = libttfautohint.version_string
+
+  elif is_cff(TTFont(font)) or is_cff2(TTFont(font)):
+    ext = os.path.splitext(font)[1]
+    tmp = font.replace(ext, "-tmp-dehinted%s" % ext)
+    args = [font,
+            "--no-hinting",
+            "--glyphs=*",
+            "--ignore-missing-glyphs",
+            "--no-notdef-glyph",
+            "--no-recommended-glyphs",
+            "--no-layout-closure",
+            "--layout-features=*",
+            "--no-desubroutinize",
+            "--name-languages=*",
+            "--glyph-names",
+            "--no-prune-unicode-ranges",
+            "--output-file=%s" % tmp]
+    pyftsubset(args)
+
+    dehinted_size = os.stat(tmp).st_size
+    version = "" # TODO If there is a way, extract the psautohint version used?
+    os.remove(tmp)
+  
+  else:
     return None
 
-  original_buffer = BytesIO()
-  TTFont(font).save(original_buffer)
-  dehinted_buffer = ttfautohint(in_buffer=original_buffer.getvalue(),
-                                dehint=True)
   return {
-    "dehinted_size": len(dehinted_buffer),
+    "dehinted_size": dehinted_size,
     "hinted_size": os.stat(font).st_size,
-    "version": libttfautohint.version_string
+    "version": version
   }
+
+
 
 
 @condition

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -855,11 +855,13 @@ def test_check_name_description_max_length():
 def test_check_hinting_impact():
   """ Show hinting filesize impact. """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_hinting_impact as check,
-                                               ttfautohint_stats)
+                                               hinting_stats)
+  # TODO: test the CFF code-path
+
   font = TEST_FILE("mada/Mada-Regular.ttf")
 
   print('Test this check always emits an INFO result...')
-  status, message = list(check(TTFont(font), ttfautohint_stats(font)))[-1]
+  status, message = list(check(TTFont(font), hinting_stats(font)))[-1]
   assert status == INFO and message.code == "size-impact"
 
 


### PR DESCRIPTION
**com.google.fonts/check/hinting_impact**

Add support for CFF hints
(issue #2802 / followup to PR #2805)