### PR TITLE
New check: com.google.fonts/check/varfont/consistent_axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## 0.7.23 (2020-Apr-??)
-  - ...
+## 0.7.23 (2020-Apr-03)
+### New Checks
+  - **[com.google.fonts/check/varfont/consistent_axes]**: Ensure that all variable font files have the same set of axes and axis ranges. (issue #2810)
 
 
 ## 0.7.22 (2020-Mar-27)

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -201,6 +201,11 @@ def vmetrics(ttFonts):
 def is_variable_font(ttFont):
   return "fvar" in ttFont.keys()
 
+@condition
+def VFs(ttFonts):
+  """Returns a list of font files which are recognized as variable fonts"""
+  return [ttFont for ttFont in ttFonts
+          if is_variable_font(ttFont)]
 
 @condition
 def slnt_axis(ttFont):


### PR DESCRIPTION
Ensure that all variable font files have the same set of axes and axis ranges.
(issue #2810)