### PR TITLE
profiles.googlefonts_conditions.familyname now works on variable fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New Checks
   - **[com.google.fonts/check/varfont/consistent_axes]**: Ensure that all variable font files have the same set of axes and axis ranges. (issue #2810)
 
+### bugfixes
+  - profiles.googlefonts_conditions.familyname now works on variable fonts.
 
 ## 0.7.22 (2020-Mar-27)
 ### Note-worthy changes

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -262,6 +262,9 @@ def familyname(font):
   filename_base = os.path.splitext(filename)[0]
   if '-' in filename_base:
     return filename_base.split('-')[0]
+  # Handle VFs e.g Inconsolata[wdth,wght] --> Inconsolata
+  if "[" in filename_base:
+    return filename_base.split("[")[0]
 
 
 @condition


### PR DESCRIPTION
The `familyname` function can now parse variable fonts correctly. Atm, this function returns a NoneType for vfs which then produces errors for the regression checks because the `remote_styles` function expects a familyname, not a NoneType. 

I still don't like this function because it still has the possibility to return a NoneType. We should definitely improve it in the future.