### PR TITLE
change readme logo link to "http"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis Build Status](https://travis-ci.org/googlefonts/fontbakery.svg)](https://travis-ci.org/googlefonts/fontbakery)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://github.com/googlefonts/fontbakery/blob/master/LICENSE.txt)
 
-# [![Font Bakery](data/logo.png)](https://fontbakery.com)
+# [![Font Bakery](data/logo.png)](http://fontbakery.com)
 
 Font Bakery is a command-line tool for checking the quality of font projects.
 


### PR DESCRIPTION
The logo link is currently `https`, but the site has no SSL certificate, so Chrome warns me "Your connection is not private" when I click it. This edit changes it to just `http`, so it should (I think) avoid the warning page.

## Description

![image](https://user-images.githubusercontent.com/45946693/79234723-ae8d8500-7e38-11ea-812d-aef990cab311.png)

## Alternative

We could add an SSL cert to fontbakery.com to make it `https`.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

