### PR TITLE
Do not WARN for upem=2048 on com.google.fonts/check/unitsperem_strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[com.google.fonts/check/valid_glyphnames]**: Increase glyphname max-length to 63 chars. (issue #2832)
+  - **[com.google.fonts/check/unitsperem_strict]:** Do not WARN for upem=2048 (issue #2827)
 
 ### Bugfixes
   - profiles.googlefonts_conditions.familyname now works on variable fonts.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2496,7 +2496,7 @@ def com_google_fonts_check_unitsperem_strict(ttFont):
                   f" Variable Fonts)."
                   f" The acceptable values for unitsPerEm,"
                   f" though, are: {ACCEPTABLE}.")
-  elif upm_height != 2000:
+  elif upm_height < 2000:
     yield WARN,\
           Message("legacy-value",
                   f"Even though unitsPerEm ({upm_height}) in"
@@ -2506,7 +2506,7 @@ def com_google_fonts_check_unitsperem_strict(ttFont):
                   f" Variable Fonts by avoiding excessive"
                   f" rounding of coordinates on interpolations.")
   else:
-    yield PASS, "Font em size is good (unitsPerEm = 2000)."
+    yield PASS, f"Font em size is good (unitsPerEm = {upm_height})."
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2146,9 +2146,7 @@ def test_check_unitsperem_strict():
   fontfile = TEST_FILE("cabin/Cabin-Regular.ttf")
   ttFont = TTFont(fontfile)
 
-  PASS_VALUES = [2000] # The potential "New Standard" for Variable Fonts!
-
-  WARN_VALUES = [16, 32, 64, 128, 256, 512, 1024, 2048] # Good for better performance on legacy renderers
+  WARN_VALUES = [16, 32, 64, 128, 256, 512, 1024] # Good for better performance on legacy renderers
   WARN_VALUES.extend([500, 1000]) # or common typical values
 
   # and finally the bad ones, including:
@@ -2156,6 +2154,9 @@ def test_check_unitsperem_strict():
   FAIL_VALUES.extend([100, 2500]) # suboptimal (uncommon and not power of two)
   FAIL_VALUES.extend([4096, 8192, 16384]) # and valid ones suggested by the opentype spec,
                                           # but too large, causing undesireable filesize bloat.
+
+  PASS_VALUES = [2000, # The potential "New Standard" for Variable Fonts!
+                 2048] # A power of two but higher than 2000, so no need to warn about excessive rounding.
 
   for pass_value in PASS_VALUES:
     print (f"Test PASS with unitsPerEm = {pass_value}...")


### PR DESCRIPTION
(issue #2827)