### PR TITLE
familynames with more than a single word were not being properly detected when querying GFonts API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/unitsperem_strict]**: update requirements on upm values; 2000 is a minimum for VF because lower than that creates less smooth interpolation; and larger than 2048 causes a filesize increase. (issue #2827)
 
+### Bug Fixes
+  - Family names with more than a single word were not being properly detected when querying GFonts API (issue #2848)
+
 
 ## 0.7.24 (2020-Apr-21)
 ### Note-worthy changes

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -263,8 +263,10 @@ def familyname(font):
   if '-' in filename_base:
     return filename_base.split('-')[0]
   # Handle VFs e.g Inconsolata[wdth,wght] --> Inconsolata
-  if "[" in filename_base:
+  elif "[" in filename_base:
     return filename_base.split("[")[0]
+  else:
+    return filename_base
 
 
 @condition
@@ -320,18 +322,26 @@ def hinting_stats(font):
   }
 
 
-
-
 @condition
 def listed_on_gfonts_api(familyname):
+  from fontbakery.utils import split_camel_case
   if not familyname:
     return False
 
-  import requests
-  url = ('http://fonts.googleapis.com'
-         '/css?family={}').format(familyname.replace(' ', '+'))
-  r = requests.get(url)
-  return r.status_code == 200
+  def query_gfonts(fname):
+    import requests
+    queryname = fname.replace(' ', '+')
+    url = ('http://fonts.googleapis.com'
+         '/css?family={}').format(queryname)
+    r = requests.get(url)
+    return r.status_code == 200
+
+  if query_gfonts(familyname): return True
+
+  # else...
+  # Some families such as "Libre Calson Text" have camelcased filenames ("LibreCalsonText-Regular.ttf")
+  # and require us to split in order to properly form a good query URL:
+  return query_gfonts(split_camel_case(familyname))
 
 
 @condition

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -77,6 +77,22 @@ def unindent_rationale(rationale, checkid=None):
   return content
 
 
+def split_camel_case(camelcase):
+  result = []
+  word = ""
+  for char in camelcase:
+    if char.isupper():
+      if word != "":
+        result.append(word)
+      word = char
+    else:
+      word += char
+
+  if word != "":
+    result.append(word)
+  return " ".join(result)
+
+
 def suffix(font):
   filename = os.path.basename(font)
   basename = os.path.splitext(filename)[0]

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1049,24 +1049,47 @@ def test_check_name_ascii_only_entries():
   assert status == PASS
 
 
+def test_split_camel_case_condition():
+  from fontbakery.utils import split_camel_case
+  assert split_camel_case("Lobster") == "Lobster"
+  assert split_camel_case("LibreCaslonText") == "Libre Caslon Text"
+
+
 def test_check_metadata_listed_on_gfonts():
   """ METADATA.pb: Fontfamily is listed on Google Fonts API? """
-  from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_listed_on_gfonts as check,
-                                               listed_on_gfonts_api,
-                                               family_metadata)
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_metadata_listed_on_gfonts as check
+  from fontbakery.profiles.googlefonts_conditions import (familyname,
+                                                          listed_on_gfonts_api,
+                                                          family_metadata)
 
-  print ("Test WARN with a family that is not listed on Google Fonts...")
+  filename = "familysans/FamilySans-Regular.ttf"
+  print (f"Test WARN with '{filename}', a family that's not listed on GFonts...")
   # Our reference FamilySans family is a just a generic example
   # and thus is not really hosted (nor will ever be hosted) at Google Fonts servers:
-  listed = listed_on_gfonts_api("Family Sans")
+  listed = listed_on_gfonts_api(familyname(filename))
   # For that reason, we expect to get a WARN in this case:
   status, message = list(check(listed))[-1]
   assert status == WARN and message.code == "not-found"
 
-  print ("Test PASS with a family that is available...")
+  filename = "merryweather/Merriweather-Regular.ttf"
+  print (f"Test PASS with '{filename}', a family that is available...")
   # Our reference Merriweather family is available on the Google Fonts collection:
-  listed = listed_on_gfonts_api("Merriweather")
+  listed = listed_on_gfonts_api(familyname(filename))
   # So it must PASS:
+  status, message = list(check(listed))[-1]
+  assert status == PASS
+
+  filename = "abeezee/ABeeZee-Regular.ttf"
+  print (f"Test PASS with '{filename}', available and with a camel-cased name...")
+  # This is to ensure the code handles well camel-cased familynames.
+  listed = listed_on_gfonts_api(familyname(filename))
+  status, message = list(check(listed))[-1]
+  assert status == PASS
+
+  filename = "librecaslontext/LibreCaslonText[wght].ttf"
+  print (f"Test PASS with '{filename}', available and with a space-separated name...")
+  # And the check should also properly handle space-separated multi-word familynames.
+  listed = listed_on_gfonts_api(familyname(filename))
   status, message = list(check(listed))[-1]
   assert status == PASS
 
@@ -2794,7 +2817,7 @@ def test_check_name_copyright_length():
 def test_check_fontdata_namecheck():
   """ Familyname is unique according to namecheck.fontdata.com """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_fontdata_namecheck as check,
-                                                     familyname)
+                                               familyname)
 
   print('Test INFO with an already used name...')
   # We dont FAIL because this is meant as a merely informative check


### PR DESCRIPTION
(issue #2848)
