### PR TITLE
Jh adobefonts space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.7.25 (2020-May-??)
 ### Changes to existing checks
   - **[com.google.fonts/check/unitsperem_strict]**: update requirements on upm values; 2000 is a minimum for VF because lower than that creates less smooth interpolation; and larger than 2048 causes a filesize increase. (issue #2827)
+  - **[com.google.fonts/check/whitespace_glyphs]**: yield one unique message (and `message.code`) per missing whitespace case to enable selective overrides based on individual message codes
+  - update adobefonts overridden whitespace_glyphs check to WARN on missing 0x00A0 (fail on 0x0020)
 
 ### Bug Fixes
   - Family names with more than a single word were not being properly detected when querying GFonts API (issue #2848)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -122,9 +122,11 @@ com_google_fonts_check_dsig_adobefonts = profile.check_log_override(
     ,)
 )
 
-com_google_fonts_check_whitespace_glyphs_adobefonts = profile.check_log_override(
-    'com.google.fonts/check/whitespace_glyphs'
-  , overrides = (('missing-whitespace-glyphs', WARN, None),)
+com_google_fonts_check_whitespace_glyph_nbsp = profile.check_log_override(
+    'com.google.fonts/check/whitespace_glyphs',
+    reason='For Adobe, this is not as severe '\
+           + 'as assessed in the original check for 0x00A0.',
+    overrides = (('missing-whitespace-glyph-0x00A0', WARN, None),)
 )
 
 com_google_fonts_check_valid_glyphnames_adobefonts = profile.check_log_override(

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -371,12 +371,13 @@ def com_google_fonts_check_mandatory_glyphs(ttFont):
 )
 def com_google_fonts_check_whitespace_glyphs(ttFont, missing_whitespace_chars):
   """Font contains glyphs for whitespace characters?"""
-  if missing_whitespace_chars != []:
-    yield FAIL, Message("missing-whitespace-glyphs",
-                    ("Whitespace glyphs missing for"
-                     " the following codepoints:"
-                     " {}.").format(", ".join(missing_whitespace_chars)))
-  else:
+  failed = False
+  for wsc in missing_whitespace_chars:
+    failed = True
+    yield FAIL, Message(f"missing-whitespace-glyph-{wsc}",
+                        (f"Whitespace glyph missing for codepoint {wsc}."))
+
+  if not failed:
     yield PASS, "Font contains glyphs for whitespace characters."
 
 

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -379,7 +379,7 @@ def test_check_whitespace_glyphs():
 
   missing = missing_whitespace_chars(ttFont)
   status, message = list(check(ttFont, missing))[-1]
-  assert status == FAIL and message.code == "missing-whitespace-glyphs"
+  assert status == FAIL and message.code == "missing-whitespace-glyph-0x00A0"
 
   # restore original Mada Regular font:
   ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
@@ -387,12 +387,12 @@ def test_check_whitespace_glyphs():
   # And finally remove the space character (0x0020) to get another FAIL:
   print ("Test FAIL with a font lacking a space (0x0020)...")
   for table in ttFont['cmap'].tables:
-    if 0x00A0 in table.cmap:
-      del table.cmap[0x00A0]
+    if 0x0020 in table.cmap:
+      del table.cmap[0x0020]
 
   missing = missing_whitespace_chars(ttFont)
   status, message = list(check(ttFont, missing))[-1]
-  assert status == FAIL and message.code == "missing-whitespace-glyphs"
+  assert status == FAIL and message.code == "missing-whitespace-glyph-0x0020"
 
 
 def test_check_whitespace_glyphnames():


### PR DESCRIPTION
## Description
This pull request updates `com.google.fonts/check/whitespace_glyphs` to yield one unique message (and message.code) per missing whitespace case to enable selective overrides of individual missing whitespace cases. The `adobefonts` profile has also been updated to override the `0x00A0` missing whitespace case, to WARN instead of FAIL. Test code has been updated as well

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

