### PR TITLE
New check: com.google.fonts/check/varfont/unsupported_axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.25 (2020-May-??)
+### New checks
+  - **[com.google.fonts/check/varfont/unsupported_axes]**: Ensure VFs do not contain opsz or ital axes. (issue #2866)
+
 ### Added rationale metadata to these checks
   - **com.google.fonts/check/vendor_id**
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -141,7 +141,8 @@ FONT_FILE_CHECKS = [
   'com.google.fonts/check/vertical_metrics_regressions',
   'com.google.fonts/check/varfont_instance_coordinates',
   'com.google.fonts/check/varfont_instance_names',
-  'com.google.fonts/check/varfont/consistent_axes'
+  'com.google.fonts/check/varfont/consistent_axes',
+  'com.google.fonts/check/varfont/unsupported_axes'
 ]
 
 GOOGLEFONTS_PROFILE_CHECKS = \
@@ -4356,6 +4357,36 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
     yield WARN, SHOW_GF_DOCS_MSG
   else:
     yield PASS, "Instance names are correct"
+
+
+@check(
+  id = 'com.google.fonts/check/varfont/unsupported_axes',
+  rationale = """
+    The 'ital' axis is not supported yet in Google Chrome. The 'opsz' axis also has patchy support.
+
+    For the time being, we need to ensure that VFs do not contain either of these axes. Once browser support is better, we can deprecate this check.
+
+    For more info regarding ital and opsz browser support, see:
+    https://arrowtype.github.io/vf-slnt-test/
+  """,
+  conditions = ['is_variable_font'],
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2866'
+  }
+)
+def com_google_fonts_check_varfont_unsupported_axes(ttFont):
+  """ Ensure VFs do not contain opsz or ital axes. """
+  from fontbakery.profiles.shared_conditions import opsz_axis, ital_axis
+  if ital_axis(ttFont):
+    yield FAIL,\
+          Message("unsupported-ital",
+                  'The "ital" axis is not yet well supported on Google Chrome.')
+  elif opsz_axis(ttFont):
+    yield FAIL,\
+          Message("unsupported-opsz",
+                  'The "opsz" axis is not yet well supported on Google Chrome.')
+  else:
+    yield PASS, "Looks good!"
 
 
 ###############################################################################

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -214,6 +214,20 @@ def slnt_axis(ttFont):
       if axis.axisTag == "slnt":
         return axis
 
+@condition
+def opsz_axis(ttFont):
+  if "fvar" in ttFont:
+    for axis in ttFont["fvar"].axes:
+      if axis.axisTag == "opsz":
+        return axis
+
+@condition
+def ital_axis(ttFont):
+  if "fvar" in ttFont:
+    for axis in ttFont["fvar"].axes:
+      if axis.axisTag == "ital":
+        return axis
+
 
 def get_instance_axis_value(ttFont, instance_name, axis_tag):
   if not is_variable_font(ttFont):

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3376,3 +3376,32 @@ def test_check_varfont_instance_names(vf_ttFont):
   status, message = list(check(vf_ttFont3))[-1]
   assert status == WARN
 
+
+def test_check_varfont_unsupported_axes():
+  """Ensure VFs do not contain opsz or ital axes."""
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_varfont_unsupported_axes as check
+  from fontbakery.profiles.shared_conditions import slnt_axis, ital_axis
+  from fontTools.ttLib.tables._f_v_a_r import Axis
+
+  # Our reference varfont, CabinVFBeta.ttf, lacks 'ital' and 'opsz' variation axes.
+  # So, should pass the check:
+  ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
+  status, message = list(check(ttFont))[-1]
+  assert status == PASS
+  
+  # If we add 'ital' it must FAIL:
+  new_axis = Axis()
+  new_axis.axisTag = "ital"
+  ttFont["fvar"].axes.append(new_axis)
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL and message.code == "unsupported-ital"
+
+  # Then we reload the font and add 'opsz'
+  # so it must also FAIL:
+  ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
+  new_axis = Axis()
+  new_axis.axisTag = "opsz"
+  ttFont["fvar"].axes.append(new_axis)
+  status, message = list(check(ttFont))[-1]
+  assert status == FAIL and message.code == "unsupported-opsz"
+


### PR DESCRIPTION
Ensure VFs do not contain opsz or ital axes.
(issue #2866)