### PR TITLE
New check: com.google.fonts/check/description/eof_linebreak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.google.fonts/check/varfont/unsupported_axes]**: Ensure VFs do not contain opsz or ital axes. (issue #2866)
   - **[com.google.fonts/check/STAT_strings]**: Check correctness of name table strings referenced by STAT table. (issue #2863)
+  - **[com.google.fonts/check/description/eof_linebreak]**: DESCRIPTION.en_us.html should end in a linebreak. (issue #2879)
 
 ### Added rationale metadata to these checks
   - **com.google.fonts/check/vendor_id**

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -67,7 +67,8 @@ DESCRIPTION_CHECKS = [
   'com.google.fonts/check/description/min_length',
   'com.google.fonts/check/description/max_length',
   'com.google.fonts/check/description/git_url',
-  'com.google.fonts/check/description/variable_font'
+  'com.google.fonts/check/description/variable_font',
+  'com.google.fonts/check/description/eof_linebreak'
 ]
 
 FAMILY_CHECKS = [
@@ -391,6 +392,29 @@ def com_google_fonts_check_description_max_length(description):
                   " have size smaller than 1000 bytes.")
   else:
     yield PASS, "DESCRIPTION.en_us.html is smaller than 1000 bytes."
+
+
+@check(
+  id = 'com.google.fonts/check/description/eof_linebreak',
+  conditions = ['description'],
+  rationale = """
+    Some older text-handling tools sometimes misbehave if the last line of data in a text file is not terminated with a newline character (also known as '\\n').
+
+    We know that this is a very small detail, but for the sake of keeping all DESCRIPTION.en_us.html files uniformly formatted throughout the GFonts collection, we chose to adopt the practice of placing this final linebreak char on them.
+""",
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2879'
+  }
+)
+def com_google_fonts_check_description_eof_linebreak(description):
+  """DESCRIPTION.en_us.html should end in a linebreak."""
+  if description[-1] != '\n':
+    yield WARN,\
+          Message("missing-eof-linebreak",
+                  "The last characther on DESCRIPTION.en_us.html"
+                  " is not a line-break. Please add it.")
+  else:
+    yield PASS, ":-)"
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -352,6 +352,24 @@ def test_check_description_max_length():
   assert status == PASS
 
 
+def test_check_description_eof_linebreak():
+  """ DESCRIPTION.en_us.html should end in a linebreak. """
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_description_eof_linebreak as check
+
+  bad = ("We want to avoid description files\n"
+         "without an end-of-file linebreak\n"
+         "like this one.")
+  print('Test WARN when we lack an end-of-file linebreak...')
+  status, message = list(check(bad))[-1]
+  assert status == WARN and message.code == "missing-eof-linebreak"
+
+  good = ("On the other hand, this one\n"
+          "is good enough.\n")
+  print('Test PASS when we add one...')
+  status, message = list(check(good))[-1]
+  assert status == PASS
+
+
 def test_check_name_family_and_style_max_length(): 
   """ Combined length of family and style must not exceed 27 characters. """
   from fontbakery.profiles.googlefonts import ( 


### PR DESCRIPTION
DESCRIPTION.en_us.html should end in a linebreak.
(issue #2879)