### PR TITLE
Improve handling of PANOSE values for monospaced fonts

### DIFF
--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -199,6 +199,14 @@ class MacStyle(enum.IntEnum):
   BOLD   = (1 << 0)
   ITALIC = (1 << 1)
 
+class PANOSE_FamilyKind(enum.IntEnum):
+  ANY = 0
+  NO_FIT = 1
+  LATIN_TEXT = 2
+  LATIN_HAND_WRITTEN = 3
+  LATIN_DECORATIVE = 4
+  LATIN_SYMBOL = 5
+
 class PANOSE_Proportion(enum.IntEnum):
   ANY = 0
   NO_FIT = 1

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -97,6 +97,7 @@ def com_google_fonts_check_name_no_copyright_on_description(ttFont):
 def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
   """Checking correctness of monospaced metadata."""
   from fontbakery.constants import (IsFixedWidth,
+                                    PANOSE_FamilyKind,
                                     PANOSE_Proportion)
   failed = False
   # Note: These values are read from the dict here only to
@@ -122,7 +123,8 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
                     f" (meaning 'fixed width monospaced'),"
                     f" but got {ttFont['post'].isFixedPitch} instead.")
 
-    if ttFont['OS/2'].panose.bProportion != PANOSE_Proportion.MONOSPACED:
+    if ttFont['OS/2'].panose.bFamilyType == PANOSE_FamilyKind.LATIN_TEXT and \
+       ttFont['OS/2'].panose.bProportion != PANOSE_Proportion.MONOSPACED:
       failed = True
       yield FAIL,\
             Message("mono-bad-panose-proportion",


### PR DESCRIPTION
This pull request addresses the problems described at issue #2857

This is still work in progress.
