### PR TITLE
Deprecate com.google.fonts/check/description/variable_font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,27 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## 0.7.27 (2020-Jun-??)
+## 0.8.0 (2020-Jun-??)
   - ...
 
 
-## 0.7.26 (2020-May-26)
+## 0.7.26 (2020-May-29)
 ### Noteworthy code-changes
   - update gfonts protobuf schema, in sync with GFTools (https://github.com/googlefonts/gftools/issues/202) (#issue #2886)
 
 ### Bugfixes
   - fix ERROR on com.google.fonts/check/STAT_strings (issue #2889)
 
+### Deprecated checks
+  - **[com.google.fonts/check/description/variable_font]**: Not needed anymore since Google Fonts now displays the information in its UI, so no need to also mention it on the description. (issue #2885)
+
 ### New checks
   - **[com.google.fonts/check/gdef_spacing_marks]**: warn when glyphs in the GDEF mark glyph class should be non-spacing (issue #2877).
   - **[com.google.fonts/check/gdef_non_mark_chars]**: fails when glyphs mapped to non-mark characters are in the GDEF mark glyph class (issue #2877)
   - **[com.google.fonts/check/gdef_mark_chars]**: warns when glyphs mapped to mark characters are not in the GDEF mark glyph class. (issue #2877)
+
+### Modified checks
+- **[com.google.fonts/check/metadata/valid_copyright]**: Accept year range in copyright strings. (issue #2393)
 
 
 ## 0.7.25 (2020-May-15)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -67,7 +67,6 @@ DESCRIPTION_CHECKS = [
   'com.google.fonts/check/description/min_length',
   'com.google.fonts/check/description/max_length',
   'com.google.fonts/check/description/git_url',
-  'com.google.fonts/check/description/variable_font',
   'com.google.fonts/check/description/eof_linebreak'
 ]
 
@@ -320,29 +319,6 @@ def com_google_fonts_check_description_git_url(description):
                   "Please host your font project on a public Git repo"
                   " (such as GitHub or GitLab) and place a link"
                   " in the DESCRIPTION.en_us.html file.")
-
-
-@check(
-  id = 'com.google.fonts/check/description/variable_font',
-  conditions = ['is_variable_font',
-                'description'],
-  rationale = """
-    Families with variable fonts do not always mention that in their descriptions. Therefore, this check ensures that a standard boilerplate sentence is present in the DESCRIPTION.en_us.html files for all those families which are available as variable fonts.
-  """
-)
-def com_google_fonts_check_description_variable_font(description):
-  """Does DESCRIPTION file mention when a family
-     is available as variable font?"""
-  if "variable font" not in description.lower():
-    yield FAIL,\
-          Message("should-mention-varfonts",
-                  "Please mention in the DESCRIPTION.en-us.html"
-                  " that the family is a variable font. This check"
-                  " expects the words 'variable font' to be present"
-                  " in the text e.g 'This font is now available as"
-                  " a variable font.'")
-  else:
-    yield PASS, "Looks good!"
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -273,25 +273,6 @@ def test_check_description_git_url():
   assert status == FAIL and message.code == "lacks-git-url"
 
 
-def test_check_description_variable_font():
-  """ Does DESCRIPTION file mention when a family
-      is available as variable font? """
-  from fontbakery.profiles.googlefonts import (
-    com_google_fonts_check_description_variable_font as check,
-    description,
-    descfile)
-
-  bad_desc = description(descfile(TEST_FILE("varfont/Oswald-VF.ttf")))
-  print('Test FAIL when "variable font" is not present in DESC file...')
-  status, message = list(check(bad_desc))[-1]
-  assert status == FAIL and message.code == "should-mention-varfonts"
-
-  good_desc = description(descfile(TEST_FILE("cabinvfbeta/Cabin-VF.ttf")))
-  print('Test PASS with description file containing "variable font"...')
-  status, message = list(check(good_desc))[-1]
-  assert status == PASS
-
-
 def test_check_description_valid_html():
   """ DESCRIPTION file is a propper HTML snippet ? """
   from fontbakery.profiles.googlefonts import (


### PR DESCRIPTION
Not needed anymore since Google Fonts now displays the information in its UI, so no need to also mention it on the description.
(issue #2885)