### PR TITLE
Update metadata weight checks for VFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.0 (2020-Jun-??)
   - ...
 
+### Modified checks
+- **[com.google.fonts/check/metadata/os2_weightclass]**: Check will now work correctly for variable fonts (issue #2683)
+- **[com.google.fonts/check/metadata/match_weight_postscript]**: Disabled for variable fonts
+
 
 ## 0.7.26 (2020-May-29)
 ### Noteworthy code-changes

--- a/data/test/varfont/jura/METADATA.pb
+++ b/data/test/varfont/jura/METADATA.pb
@@ -6,7 +6,7 @@ date_added: "2011-05-18"
 fonts {
   name: "Jura"
   style: "normal"
-  weight: 300
+  weight: 400
   filename: "Jura[wght].ttf"
   post_script_name: "Jura-Light"
   full_name: "Jura Light"

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2118,6 +2118,28 @@ def test_check_metadata_os2_weightclass():
     family_metadata,
     font_metadata)
 
+  # VF
+  # Our reference Jura is known to be good
+  fontfile = portable_path("data/test/varfont/jura/Jura[wght].ttf")
+  ttFont = TTFont(fontfile)
+  family_directory = os.path.dirname(fontfile)
+  family_meta = family_metadata(family_directory)
+  font_meta = font_metadata(family_meta, fontfile)
+
+  # So it must PASS the check:
+  print (f"Test PASS with a good font ({fontfile})...")
+  status, message = list(check(ttFont, font_meta))[-1]
+  assert status == PASS
+
+  # And fail if it finds a bad weight value:
+  good_value = font_meta.weight
+  bad_value = good_value + 100
+  font_meta.weight = bad_value
+  print (f"Test FAIL with a bad font ({fontfile})...")
+  status, message = list(check(ttFont, font_meta))[-1]
+  assert status == FAIL and message.code == "mismatch"
+
+  # Static
   # Our reference Montserrat family is a good 18-styles family:
   for fontfile in MONTSERRAT_RIBBI + MONTSERRAT_NON_RIBBI:
     ttFont = TTFont(fontfile)


### PR DESCRIPTION
**com_google_fonts_check_metadata_os2_weightclass**
I've updated the check so variable font families now follow what I proposed in https://github.com/googlefonts/fontbakery/issues/2683#issuecomment-631544957

**com_google_fonts_check_metadata_match_weight_postscript**
Since the metadata weight values for variable font families are no longer related to the OS/2.usWeightClass, this check is disabled for VFs only.

Fixes https://github.com/googlefonts/fontbakery/issues/2683, https://github.com/googlefonts/fontbakery/issues/2873, 
