### PR TITLE
new check: com.google.fonts/check/repo/fb_report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.8.0 (2020-Jun-??)
-  - ...
+### New checks
+  - **[com.google.fonts/check/repo/fb_report]**: WARN when upstream repo has fb report files (issue #2888)
 
-### Modified checks
-- **[com.google.fonts/check/metadata/os2_weightclass]**: Check will now work correctly for variable fonts (issue #2683)
-- **[com.google.fonts/check/metadata/match_weight_postscript]**: Disabled for variable fonts
+### Changes to existing checks
+  - **[com.google.fonts/check/metadata/os2_weightclass]**: Check will now work correctly for variable fonts (issue #2683)
+  - **[com.google.fonts/check/metadata/match_weight_postscript]**: Disabled for variable fonts
+
+### Bugfixes
+  - Corrections to UNICODERANGE_DATA constant. Contributed by Bob Hallissy @bobh0303 (PR #2901)
 
 
 ## 0.7.26 (2020-May-29)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -90,6 +90,7 @@ NAME_TABLE_CHECKS = [
 REPO_CHECKS = [
   'com.google.fonts/check/repo/dirname_matches_nameid_1',
   'com.google.fonts/check/repo/vf_has_static_fonts',
+  'com.google.fonts/check/repo/fb_report',
   'com.google.fonts/check/license/OFL_copyright'
 ]
 
@@ -4195,6 +4196,31 @@ def com_google_fonts_check_repo_vf_has_static_fonts(family_directory):
                   'Please create a subdirectory called "static/"'
                   ' and include in it static font files.')
 
+
+@check(
+  id = 'com.google.fonts/check/repo/fb_report',
+  conditions = ['family_directory'],
+  rationale="""
+    A FontBakery report is ephemeral and so should be used for posting issues on a bug-tracker instead of being hosted in the font project repository.
+  """,
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2888'
+  }
+)
+def com_google_fonts_check_repo_fb_report(family_directory):
+  """A font repository should not include fontbakery report files"""
+  from fontbakery.utils import filenames_ending_in
+
+  has_report_files = any([f for f in filenames_ending_in(".json", family_directory)
+                          if '"result"' in open(f).read()])
+  if not has_report_files:
+    yield PASS, 'OK'
+  else:
+    yield WARN, \
+          Message("fb-report",
+                  "There's no need to keep a copy of Font Bakery reports in the repository,"
+                  " since they are ephemeral; FB has a 'github markdown' output mode"
+                  " to make it easy to file reports as issues.")
 
 @check(
   id = 'com.google.fonts/check/vertical_metrics_regressions',

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -401,3 +401,18 @@ def assert_results_contain(check_results, expected_status, expected_msgcode=None
       found = True
       break
   assert(found)
+
+
+def filenames_ending_in(suffix, root):
+  '''
+  Returns a list of the filenames of all files in a given directory subtree
+  that have the given filename suffix. Example: List all ".json" files.
+  '''
+  filenames = []
+  for f in os.listdir(root):
+    fullpath = os.path.join(root, f)
+    if f.endswith(suffix):
+      filenames.append(fullpath)
+    if os.path.isdir(fullpath):
+      filenames.extend(filenames_ending_in(suffix, fullpath))
+  return filenames


### PR DESCRIPTION
WARN when upstream repo has font bakery report files.
Users should use `--ghmarkdown` to get reports useful for posting issues on a bug tracker.
(issue #2888)