### PR TITLE
new check: com.google.fonts/check/repo/zip_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.0 (2020-Jun-??)
 ### New checks
   - **[com.google.fonts/check/repo/fb_report]**: WARN when upstream repo has fb report files (issue #2888)
+  - **[com.google.fonts/check/repo/zip_files]**: FAIL when upstream repo has ZIP files (issue #2903)
 
 ### Changes to existing checks
   - **[com.google.fonts/check/metadata/os2_weightclass]**: Check will now work correctly for variable fonts (issue #2683)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -91,6 +91,7 @@ REPO_CHECKS = [
   'com.google.fonts/check/repo/dirname_matches_nameid_1',
   'com.google.fonts/check/repo/vf_has_static_fonts',
   'com.google.fonts/check/repo/fb_report',
+  'com.google.fonts/check/repo/zip_files',
   'com.google.fonts/check/license/OFL_copyright'
 ]
 
@@ -4221,6 +4222,42 @@ def com_google_fonts_check_repo_fb_report(family_directory):
                   "There's no need to keep a copy of Font Bakery reports in the repository,"
                   " since they are ephemeral; FB has a 'github markdown' output mode"
                   " to make it easy to file reports as issues.")
+
+
+@check(
+  id = 'com.google.fonts/check/repo/zip_files',
+  conditions = ['family_directory'],
+  rationale="""
+    Sometimes people check in ZIPs into their font project repositories. While we accept the practice of checking in binaries, we believe that a ZIP is a step too far ;)
+
+    Note: a source purist position is that only source files and build scripts should be checked in. 
+  """,
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2903'
+  }
+)
+def com_google_fonts_check_repo_zip_files(family_directory):
+  """A font repository should not include ZIP files"""
+  from fontbakery.utils import (filenames_ending_in,
+                                pretty_print_list)
+
+  COMMON_ZIP_EXTENSIONS = [".zip", ".7z", ".rar"]
+  zip_files = []
+  for ext in COMMON_ZIP_EXTENSIONS:
+    zip_files.extend(filenames_ending_in(ext, family_directory))
+
+  if not zip_files:
+    yield PASS, 'OK'
+  else:
+    files_list = pretty_print_list(zip_files,
+                                   shorten=None,
+                                   sep='\n\t* ')
+    yield FAIL, \
+          Message("zip-files",
+                  f"Please do not host ZIP files on the project repository."
+                  f" These files were detected:\n"
+                  f"\t* {files_list}")
+
 
 @check(
   id = 'com.google.fonts/check/vertical_metrics_regressions',

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3325,6 +3325,35 @@ def test_check_repo_fb_report():
     assert status == WARN and message.code == "fb-report"
 
 
+def test_check_repo_zip_files():
+  """ A font repository should not include ZIP files """
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_repo_zip_files as check
+  import tempfile
+  import shutil
+  with tempfile.TemporaryDirectory() as tmp_dir:
+    family_dir = portable_path(tmp_dir)
+    src_family = portable_path("data/test/varfont")
+    shutil.copytree(src_family, family_dir)
+
+    print("Test PASS for a repo without ZIP files.")
+    status, message = list(check(family_dir))[-1]
+    assert status == PASS
+
+    for ext in ["zip", "rar", "7z"]:
+      print(f"Test FAIL when a {ext} file is found.")
+      # ZIP files must be detected even if placed on subdirectories:
+      filepath = os.path.join(family_dir,
+                              f"jura",
+                              f"static",
+                              f"fonts-release.{ext}")
+      #create an empty file. The check won't care about the contents:
+      open(filepath, "w+")
+      status, message = list(check(family_dir))[-1]
+      assert status == FAIL and message.code == "zip-files"
+      # remove the file before testing the next one ;-)
+      os.remove(filepath)
+
+
 def test_check_vertical_metrics_regressions(cabin_ttFonts):
   from fontbakery.profiles.shared_conditions import family_directory
   from fontbakery.profiles.googlefonts import (


### PR DESCRIPTION
FAIL when upstream repo has ZIP files
(issue #2903)