### PR TITLE
Don’t redirect ftxvalidator stderr to stdout

### DIFF
--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -227,7 +227,7 @@ def com_google_fonts_check_ftxvalidator(font, ftxvalidator_cmd):
         "all",  # execute all checks
         font
     ]
-    ftx_output = subprocess.check_output(ftx_cmd, stderr=subprocess.STDOUT)
+    ftx_output = subprocess.check_output(ftx_cmd)
     ftx_data = plistlib.loads(ftx_output)
     # we accept kATSFontTestSeverityInformation
     # and kATSFontTestSeverityMinorError


### PR DESCRIPTION
## Description
On my system (macOS 10.15.4), this warning is written to stderr:

   dyld: warning, LC_RPATH @executable_path/../Frameworks in /Library/Frameworks/FontToolbox.framework/Versions/A/FontToolbox being ignored in restricted program because of @executable_path (Codesign main executable with Library Validation to allow @ paths)

Which breaks parsing of the plist file. I don’t see any reason for the
current redirect.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

