### PR TITLE
Don’t redirect ftxvalidator stderr to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bugfixes
   - Corrections to UNICODERANGE_DATA constant. Contributed by Bob Hallissy @bobh0303 (PR #2901)
   - Fix implementation of GDEF mark/nonmark checks (issues #2904 and #2877)
+  - Ftxvalidator check now treats stderr separately and emits it as a WARN to avoid corrupting plist data and thus breaking its parsing. (issue #2801)
 
 
 ## 0.7.26 (2020-May-29)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -227,7 +227,16 @@ def com_google_fonts_check_ftxvalidator(font, ftxvalidator_cmd):
         "all",  # execute all checks
         font
     ]
-    ftx_output = subprocess.check_output(ftx_cmd, stderr=subprocess.STDOUT)
+    # here we capture stdout and stderr separately to avoid
+    # corrupting the plist data to be parsed a bit later:
+    pipes = subprocess.Popen(ftx_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    ftx_output, ftx_err = pipes.communicate()
+
+    if len(ftx_err):
+      yield WARN, \
+            Message('stderr',
+                    f"stderr output from ftxvalidator:\n{ftx_err}")
+
     ftx_data = plistlib.loads(ftx_output)
     # we accept kATSFontTestSeverityInformation
     # and kATSFontTestSeverityMinorError
@@ -243,6 +252,7 @@ def com_google_fonts_check_ftxvalidator(font, ftxvalidator_cmd):
           "all",  # execute all checks
           font
       ]
+      # Here, stdout and stderr are mixed:
       ftx_output = subprocess.check_output(ftx_cmd, stderr=subprocess.STDOUT)
       yield FAIL, f"ftxvalidator output follows:\n\n{ftx_output}\n"
 


### PR DESCRIPTION
On Khaled's system (macOS 10.15.4), this warning is written to stderr:

   dyld: warning, LC_RPATH @executable_path/../Frameworks in /Library/Frameworks/FontToolbox.framework/Versions/A/FontToolbox being ignored in restricted program because of @executable_path (Codesign main executable with Library Validation to allow @ paths)

Which breaks parsing of the plist file.

Now stderr is treated separately and emitted as a WARN.

(issue #2801 / follow up to pull request #2907)