### PR TITLE
Add a `--succinct` mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.8.0 (2020-Jun-??)
+### Note-worthy code changes
+  - Add a `--succinct` mode. This is a slightly more compact and succint output layout for the text terminal. As requested by @m4rc1e (issue #2915)
+
 ### New checks
   - **[com.google.fonts/check/repo/fb_report]**: WARN when upstream repo has fb report files (issue #2888)
   - **[com.google.fonts/check/repo/zip_files]**: FAIL when upstream repo has ZIP files (issue #2903)

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -96,6 +96,11 @@ def ArgumentParser(profile, profile_arg=True):
                             '(default: LOGLEVEL)'
                             ).format(', '.join(log_levels.keys())))
 
+  argument_parser.add_argument('--succinct',
+                               action='store_true',
+                               help=('This is a slightly more compact and succint'
+                                     ' output layout for the text terminal.'))
+
   if sys.platform != "win32":
     argument_parser.add_argument(
         '-n',
@@ -289,6 +294,7 @@ def main(profile=None, values=None):
   loglevel = min(args.loglevels) if args.loglevels else DEFAULT_LOG_LEVEL
   tr = TerminalReporter(runner=runner, is_async=False
                        , print_progress=not args.no_progress
+                       , succinct=args.succinct
                        , check_threshold=loglevel
                        , log_threshold=args.loglevel_messages or loglevel
                        , theme=theme

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -108,6 +108,7 @@ Here's the output of `fontbakery check-googlefonts -h`:
                             Messages are all status lines within a check.
                             One of: DEBUG, PASS, INFO, SKIP, WARN, FAIL, ERROR.
                             (default: LOGLEVEL)
+      --succinct            This is a slightly more compact and succint output layout for the text terminal.
       -n, --no-progress     In a tty as stdout, don't render the progress indicators.
       -C, --no-colors       No colors for tty output
       --dark-theme          Use a color theme with dark colors.


### PR DESCRIPTION
This is a slightly more compact and succint output layout for the text terminal.
As requested by @m4rc1e
(issue #2915)