### PR TITLE
Check both tables are present in os2_metrics_match_hhea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix implementation of GDEF mark/nonmark checks (issues #2904 and #2877)
   - Ftxvalidator check now treats stderr separately and emits it as a WARN to avoid corrupting plist data and thus breaking its parsing. (issue #2801)
   - Fix crash on **com.google.fonts/check/family/vertical_metrics**. Thanks for reporting, @drj11 (issue #2917)
+  - Fix crash on **com.google.fonts/check/family/os2_metrics_match_hhea** (issue #2921)
 
 
 ## 0.7.26 (2020-May-29)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -136,6 +136,23 @@ def com_google_fonts_check_os2_metrics_match_hhea(ttFont):
   Mac OS X uses the hhea values.
   Windows uses OS/2 or Win, depending on the OS or fsSelection bit value.
   """
+
+  filename = os.path.basename(ttFont.reader.file.name)
+
+  # Check both OS/2 and hhea are present.
+  missing_tables = False
+
+  required = ["OS/2", "hhea"]
+  for key in required:
+      if key not in ttFont:
+          missing_tables = True
+          yield FAIL,\
+                  Message(f'lacks-{key}',
+                          f"{filename} lacks a '{key}' table.")
+
+  if missing_tables:
+      return
+
   # OS/2 sTypoAscender and sTypoDescender match hhea ascent and descent
   if ttFont["OS/2"].sTypoAscender != ttFont["hhea"].ascent:
     yield FAIL,\


### PR DESCRIPTION
## Description

Fixed #2921, whereby a missing OS/2 table crashes os2_metrics_match_hhea

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

