### PR TITLE
New check: com.google.fonts/check/cjk_vertical_metrics (followup to PR #2797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.google.fonts/check/repo/fb_report]**: WARN when upstream repo has fb report files (issue #2888)
   - **[com.google.fonts/check/repo/zip_files]**: FAIL when upstream repo has ZIP files (issue #2903)
+  - **[[com_google_fonts_check_cjk_vertical_metrics]]**: Check cjk fonts follow our cjk metric schema
 
 ### Changes to existing checks
   - **[com.google.fonts/check/metadata/os2_weightclass]**: Check will now work correctly for variable fonts (issue #2683)

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -340,3 +340,8 @@ def is_cjk_font(ttFont):
 
   # default, return False if the above checks did not identify a CJK font
   return False
+
+
+@condition
+def typo_metrics_enabled(ttFont):
+  return ttFont['OS/2'].fsSelection & 0b10000000 > 0

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -396,10 +396,15 @@ def assert_results_contain(check_results, expected_status, expected_msgcode=None
   order among other log messages.
   """
   found = False
-  for status, message in list(check_results):
+  check_results = list(check_results)
+  for status, message in check_results:
     if status == expected_status and message.code == expected_msgcode:
       found = True
       break
+  if not found:
+    print(f"Expected to find {expected_status}, [code: {expected_msgcode}]\n"
+          f"But did not find it in:\n"
+          f"{check_results}")
   assert(found)
 
 


### PR DESCRIPTION
Ensure that new CJK families follow our cjk vertical metrics schema.

 (followup to PR #2797)