### PR TITLE
Reimplement check font version using floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.8.0 (2020-Jun-??)
   - ...
+### Changes to existing checks
+  - **[com.google.fonts/check/font_version]**: Check now allows more than 3 decimal places to be matched (issue #2928)
 
 
 ## 0.7.27 (2020-Jun-10)

--- a/Lib/fontbakery/profiles/head.py
+++ b/Lib/fontbakery/profiles/head.py
@@ -133,7 +133,7 @@ def com_google_fonts_check_font_version(ttFont):
           failed = True
           yield FAIL,\
                 Message("mismatch",
-                        f'head version is "{head_version}"'
+                        f'head version is "{float(head_version):.5f}"'
                         f' while name version string (for'
                         f' platform {record.platformID},'
                         f' encoding {record.platEncID}) is'
@@ -141,7 +141,7 @@ def com_google_fonts_check_font_version(ttFont):
         elif abs(name_version - head_version) > warn_tolerance:
           yield WARN,\
                 Message("near-mismatch",
-                        f'head version is "{head_version}"'
+                        f'head version is "{float(head_version):.5f}"'
                         f' while name version string (for'
                         f' platform {record.platformID},'
                         f' encoding {record.platEncID}) is'

--- a/tests/profiles/head_test.py
+++ b/tests/profiles/head_test.py
@@ -84,16 +84,17 @@ def test_check_unitsperem():
 def test_parse_version_string():
   """ Checking font version fields. """
   from fontbakery.profiles.head import parse_version_string
+  import fractions
 
-  version_tests_good = {"Version 01.234": ("1", "234"),
-    "1.234": ("1", "234"),
-    "01.234; afjidfkdf 5.678": ("1", "234"),
-    "1.3": ("1", "300"),
-    "1.003": ("1", "003"),
-    "1.0": ("1", "000"),
-    "1.000": ("1", "000"),
-    "3.000;NeWT;Nunito-Regular": ("3", "000"),
-    "Something Regular Italic Version 1.234": ("1", "234")}
+  version_tests_good = {"Version 01.234": fractions.Fraction("1.234"),
+    "1.234": fractions.Fraction("1.234"),
+    "01.234; afjidfkdf 5.678": fractions.Fraction("1.234"),
+    "1.3": fractions.Fraction("1.300"),
+    "1.003": fractions.Fraction("1.003"),
+    "1.0": fractions.Fraction(1),
+    "1.000": fractions.Fraction(1),
+    "3.000;NeWT;Nunito-Regular": fractions.Fraction("3"),
+    "Something Regular Italic Version 1.234": fractions.Fraction("1.234")}
 
   version_tests_bad = ["Version 0x.234", "x", "212122;asdf 01.234"]
 

--- a/tests/profiles/head_test.py
+++ b/tests/profiles/head_test.py
@@ -122,6 +122,21 @@ def test_check_font_version():
   test_font["head"].fontRevision = 1.00099
   test_font["name"].setName("Version 1.001", 5, 1, 0, 0x0)
   test_font["name"].setName("Version 1.001", 5, 3, 1, 0x409)
+  check_results = list(check(test_font))
+  # There should be at least one WARN...
+  assert WARN in [r[0] for r in check_results]
+  # But final result is a PASS.
+  final_status, message = check_results[-1]
+  assert final_status == PASS
+
+  # Test that having more than 3 decimal places in the version
+  # in the Name table is acceptable.
+  # See https://github.com/googlefonts/fontbakery/issues/2928
+  test_font = TTFont(test_font_path)
+  # This is the nearest multiple of 1/65536 to 2020.0613
+  test_font["head"].fontRevision = 2020.061294555664
+  test_font["name"].setName("Version 2020.0613", 5, 1, 0, 0x0)
+  test_font["name"].setName("Version 2020.0613", 5, 3, 1, 0x409)
   status, message = list(check(test_font))[-1]
   assert status == PASS
 


### PR DESCRIPTION
## Description
[This PR is Good To Go as far as I'm concerned, let me know if you need anything else in it]

This pull request addresses is a proposal for the font version problems described in #2928

The check issues a FAIL if any version string in the `name` table is > 0.0005 away from the exact value in the `head` table. The check issues a WARN if a version string in the `name` table is not exact, but is closer than 0.0005.

You can see an example of the new WARN on FamilySans-Regular.ttf

```
$ fontbakery check-universal -c com.google.fonts/check/font_version ./data/test/familysans/FamilySans-Regular.ttf
Start ... running 1 individual check executions.
 >> com.google.fonts/check/font_version
    Checking font version fields (head and name table).
    with ./data/test/familysans/FamilySans-Regular.ttf

    * WARN: head version is "1.00499" while name version string (for platform 1, encoding 0) is "Version 1.005". This matches to 3 decimal places, but is not as accurate as possible. [code: near-mismatch]
    * WARN: head version is "1.00499" while name version string (for platform 3, encoding 1) is "Version 1.005". This matches to 3 decimal places, but is not as accurate as possible. [code: near-mismatch]


    Result: WARN
```

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

