### PR TITLE
Update com.google.fonts/check/varfont/unsupported_axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.8.0 (2020-Jun-??)
-  - ...
+### Changes to existing checks
+  - **[com.google.fonts/check/varfont/unsupported_axes]**: Removed opsz axis and added slnt axis
 
 
 ## 0.7.27 (2020-Jun-10)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4606,16 +4606,16 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
   }
 )
 def com_google_fonts_check_varfont_unsupported_axes(ttFont):
-  """ Ensure VFs do not contain opsz or ital axes. """
-  from fontbakery.profiles.shared_conditions import opsz_axis, ital_axis
+  """ Ensure VFs do not contain slnt or ital axes. """
+  from fontbakery.profiles.shared_conditions import slnt_axis, ital_axis
   if ital_axis(ttFont):
     yield FAIL,\
           Message("unsupported-ital",
                   'The "ital" axis is not yet well supported on Google Chrome.')
-  elif opsz_axis(ttFont):
+  elif slnt_axis(ttFont):
     yield FAIL,\
-          Message("unsupported-opsz",
-                  'The "opsz" axis is not yet well supported on Google Chrome.')
+          Message("unsupported-slnt",
+                  'The "slnt" axis is not yet well supported on Google Chrome.')
   else:
     yield PASS, "Looks good!"
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3546,7 +3546,7 @@ def test_check_varfont_unsupported_axes():
   from fontbakery.profiles.shared_conditions import slnt_axis, ital_axis
   from fontTools.ttLib.tables._f_v_a_r import Axis
 
-  # Our reference varfont, CabinVFBeta.ttf, lacks 'ital' and 'opsz' variation axes.
+  # Our reference varfont, CabinVFBeta.ttf, lacks 'ital' and 'slnt' variation axes.
   # So, should pass the check:
   ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
   status, message = list(check(ttFont))[-1]
@@ -3563,8 +3563,8 @@ def test_check_varfont_unsupported_axes():
   # so it must also FAIL:
   ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
   new_axis = Axis()
-  new_axis.axisTag = "opsz"
+  new_axis.axisTag = "slnt"
   ttFont["fvar"].axes.append(new_axis)
   status, message = list(check(ttFont))[-1]
-  assert status == FAIL and message.code == "unsupported-opsz"
+  assert status == FAIL and message.code == "unsupported-slnt"
 


### PR DESCRIPTION
Remove opsz axis since our api now supports it properly.

Add slnt axis since it still has issues in Google Chrome.

This change should close #2866