### PR TITLE
Improve com_google_fonts_check_whitespace_glyphnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/description/valid_html]**: Verify that html snippets parse correctly (issue #2664)
   - **[com.google.fonts/check/metadata/os2_weightclass]**: Check now allows Thin to have 100, 250 and ExtraLight to have 200, 275 (issue #2947)
   - **[com.google.fonts/check/whitespace_glyphnames]**: Report names that are not Adobe Glyph List compliant (issue #2624)
+  - **[com.google.fonts/check/whitespace_glyphnames]**: Reviewed and updated keywords so that they more precisely indicate which specific FAIL or WARN causes a check failure.
   - **[com.google.fonts/check/whitespace_ink]**: Removed OGHAM SPACE MARK U+1680 as it is a whitespace that should have a drawing. (PR #2297 contributed by @drj11)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/varfont/unsupported_axes]**: Removed opsz axis and added slnt axis (issue #2866)
   - **[com.google.fonts/check/description/valid_html]**: Verify that html snippets parse correctly (issue #2664)
   - **[com.google.fonts/check/metadata/os2_weightclass]**: Check now allows Thin to have 100, 250 and ExtraLight to have 200, 275 (issue #2947)
+  - **[com.google.fonts/check/whitespace_glyphnames]**: Report names that are not Adobe Glyph List compliant (issue #2624)
 
 ### Bugfixes
   - **[com.google.fonts/check/valid_glyphnames]**: Improve broken text in the FAIL message (PR #2939)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -479,9 +479,10 @@ def com_google_fonts_check_whitespace_glyphnames(ttFont):
 )
 def com_google_fonts_check_whitespace_ink(ttFont):
   """Whitespace glyphs have ink?"""
-  from fontbakery.utils import get_glyph_name, glyph_has_ink
+  from fontbakery.utils import (get_glyph_name,
+                                glyph_has_ink)
 
-  # This tests that certain glyphs are empty.
+  # This checks that certain glyphs are empty.
   # Some, but not all, are Unicode whitespace.
 
   # code-points for all Unicode whitespace chars
@@ -503,15 +504,16 @@ def com_google_fonts_check_whitespace_ink(ttFont):
   # a whitespace that should have a drawing.
   NON_DRAWING = WHITESPACE_CHARACTERS | EXTRA_NON_DRAWING - {0x1680}
 
-  failed = False
+  passed = True
   for codepoint in sorted(NON_DRAWING):
     g = get_glyph_name(ttFont, codepoint)
     if g is not None and glyph_has_ink(ttFont, g):
-      failed = True
-      yield FAIL, ("Glyph \"{}\" has ink."
-                   " It needs to be replaced by"
-                   " an empty glyph.").format(g)
-  if not failed:
+      passed = False
+      yield FAIL,\
+            Message('has-ink',
+                    f'Glyph "{g}" has ink.'
+                    f' It needs to be replaced by an empty glyph.')
+  if passed:
     yield PASS, "There is no whitespace glyph with ink."
 
 

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -441,20 +441,19 @@ def test_check_whitespace_glyphnames():
   ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
 
   # See https://github.com/googlefonts/fontbakery/issues/2624
-  print("Test FAIL for naming 0x00A0 nbsp (it's not AGL-complient) ...")
+  # nbsp is not Adobe Glyph List compliant.
   editCmap(ttFont, 0x00A0, "nbsp")
-  status, message = list(check(ttFont))[-1]
-  assert status == FAIL and message.code == "badA0"
+  assert_results_contain(check(ttFont), FAIL, 'badA0',
+                         'with bad glyph name for char 0x00A0 ...')
 
-  print("Test WARN for naming 0x00A0 nbspace ...")
   editCmap(ttFont, 0x00A0, "nbspace")
-  status, message = list(check(ttFont))[-1]
-  assert status == WARN and message.code == "badA0"
+  assert_results_contain(check(ttFont), WARN, 'badA0',
+                         "for naming 0x00A0 nbspace ...")
 
-  print("Test PASS for naming 0x00A0 uni00A0 ...")
   editCmap(ttFont, 0x00A0, "uni00A0")
-  status, message = list(check(ttFont))[-1]
-  assert status == PASS
+  assert_PASS(check(ttFont),
+              "for naming 0x00A0 uni00A0 ...")
+
 
 def test_check_whitespace_ink():
   """ Whitespace glyphs have ink? """

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -426,16 +426,16 @@ def test_check_whitespace_glyphnames():
 
   deleteGlyphEncodings(ttFont, 0x0020)
   assert_results_contain(check(ttFont),
-                         FAIL, 'bad20',
-                         'with bad glyph name for char 0x0020 ...')
+                         FAIL, 'missing-0020',
+                         'with missing glyph name for char 0x0020 ...')
 
   # restore the original font object in preparation for the next test-case:
   ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
 
   deleteGlyphEncodings(ttFont, 0x00A0)
   assert_results_contain(check(ttFont),
-                         FAIL, 'badA0',
-                         'with bad glyph name for char 0x00A0 ...')
+                         FAIL, 'missing-00a0',
+                         'with missing glyph name for char 0x00A0 ...')
 
   # restore the original font object in preparation for the next test-case:
   ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
@@ -443,16 +443,24 @@ def test_check_whitespace_glyphnames():
   # See https://github.com/googlefonts/fontbakery/issues/2624
   # nbsp is not Adobe Glyph List compliant.
   editCmap(ttFont, 0x00A0, "nbsp")
-  assert_results_contain(check(ttFont), FAIL, 'badA0',
-                         'with bad glyph name for char 0x00A0 ...')
+  assert_results_contain(check(ttFont), FAIL, 'non-compliant-00a0',
+                         'with not AGL-compliant glyph name "nbsp" for char 0x00A0...')
 
   editCmap(ttFont, 0x00A0, "nbspace")
-  assert_results_contain(check(ttFont), WARN, 'badA0',
-                         "for naming 0x00A0 nbspace ...")
+  assert_results_contain(check(ttFont), WARN, 'not-recommended-00a0',
+                         'for naming 0x00A0 "nbspace"...')
 
+  editCmap(ttFont, 0x0020, "foo")
+  assert_results_contain(check(ttFont), FAIL, 'non-compliant-0020',
+                         'with not AGL-compliant glyph name "foo" for char 0x0020...')
+
+  editCmap(ttFont, 0x0020, "uni0020")
+  assert_results_contain(check(ttFont), WARN, 'not-recommended-0020',
+                         'for naming 0x0020 "uni0020"...')
+
+  editCmap(ttFont, 0x0020, "space")
   editCmap(ttFont, 0x00A0, "uni00A0")
-  assert_PASS(check(ttFont),
-              "for naming 0x00A0 uni00A0 ...")
+  assert_PASS(check(ttFont))
 
 
 def test_check_whitespace_ink():

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -464,12 +464,12 @@ def test_check_whitespace_ink():
 
   test_font["cmap"].tables[0].cmap[0x0020] = "uni1E17"
   assert_results_contain(check(test_font),
-                         FAIL, None, # FIXME: This needs a message keyword
+                         FAIL, 'has-ink',
                          'for whitespace character having composites (with ink).')
 
   test_font["cmap"].tables[0].cmap[0x0020] = "scedilla"
   assert_results_contain(check(test_font),
-                         FAIL, None, # FIXME: This needs a message keyword
+                         FAIL, 'has-ink',
                          'for whitespace character having outlines (with ink).')
 
   import fontTools.pens.ttGlyphPen
@@ -477,7 +477,7 @@ def test_check_whitespace_ink():
   pen.addComponent("space", (1, 0, 0, 1, 0, 0))
   test_font["glyf"].glyphs["uni200B"] = pen.glyph()
   assert_results_contain(check(test_font),
-                         FAIL, None, # FIXME: This needs a message keyword
+                         FAIL, 'has-ink', # should we give is a separate keyword? This looks wrong.
                          'for whitespace character having composites (without ink).')
 
 


### PR DESCRIPTION
Only PASS names approved by Adobe Glyph List For New Fonts;
WARN for names that work with AGL but are not recommended;
FAIL for everything else.

In particular, FAIL for nbsp (per https://github.com/googlefonts/fontbakery/issues/2624) which is not Adobe Glyph List compliant.

## Description
This pull request addresses the problems described at issue #2624 -

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review
- [x] Is u00A0 a valid, but not recommended, name for U+00A0 (and similarly for the others)

I would appreciate someone with more familiarity with the Adobe Glyph List specs than I have casting an eye over this and expressing an opinion on the u00A0 names.

