### PR TITLE
Update com_google_fonts_check_metadata_os2_weightclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/font_version]**: Check now allows more than 3 decimal places to be matched (issue #2928)
   - **[com.google.fonts/check/varfont/unsupported_axes]**: Removed opsz axis and added slnt axis (issue #2866)
   - **[com.google.fonts/check/description/valid_html]**: Verify that html snippets parse correctly (issue #2664)
+  - **[com.google.fonts/check/metadata/os2_weightclass]**: Check now allows Thin to have 100, 250 and ExtraLight to have 200, 275 (issue #2947)
 
 ### Bugfixes
   - **[com.google.fonts/check/valid_glyphnames]**: Improve broken text in the FAIL message (PR #2939)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2462,8 +2462,10 @@ def com_google_fonts_check_metadata_os2_weightclass(ttFont,
   """Check METADATA.pb font weights are correct."""
   from .shared_conditions import is_variable_font
   # Weight name to value mapping:
-  GF_API_WEIGHT_NAMES = {250: "Thin",
-                         275: "ExtraLight",
+  GF_API_WEIGHT_NAMES = {100: "Thin",
+                         200: "ExtraLight",
+                         250: "Thin", # Legacy. Pre-vf epoch
+                         275: "ExtraLight", # Legacy. Pre-vf epoch
                          300: "Light",
                          400: "Regular",
                          500: "Medium",

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2182,6 +2182,29 @@ def test_check_metadata_os2_weightclass():
     status, message = list(check(ttFont, font_meta))[-1]
     assert status == FAIL and message.code == "mismatch"
 
+    # If font is Thin or ExtraLight, ensure that this check can
+    # accept both 100, 250 for Thin and 200, 275 for ExtraLight
+    font_meta.weight = good_value
+    font_meta = font_metadata(family_meta, fontfile)
+    if "Thin" in fontfile:
+        ttFont["OS/2"].usWeightClass = 100
+        print (f"Test PASS with a good font ({fontfile})...")
+        status, message = list(check(ttFont, font_meta))[-1]
+        assert status == PASS
+        ttFont["OS/2"].usWeightClass = 250
+        print (f"Test PASS with a good font ({fontfile})...")
+        status, message = list(check(ttFont, font_meta))[-1]
+        assert status == PASS
+
+    if "ExtraLight" in fontfile:
+        ttFont["OS/2"].usWeightClass = 200
+        print (f"Test PASS with a good font ({fontfile})...")
+        status, message = list(check(ttFont, font_meta))[-1]
+        assert status == PASS
+        ttFont["OS/2"].usWeightClass = 275
+        print (f"Test PASS with a good font ({fontfile})...")
+        status, message = list(check(ttFont, font_meta))[-1]
+        assert status == PASS
 
 def NOT_IMPLEMENTED_test_check_metadata_match_weight_postscript():
   """ METADATA.pb: Metadata weight matches postScriptName. """


### PR DESCRIPTION
Check now accepts 100, 250 for Thin and 200, 275 for ExtraLight.

Fixes #2947 