### PR TITLE
Refactor com_google_fonts_check_whitespace_ink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/varfont/unsupported_axes]**: Removed opsz axis and added slnt axis (issue #2866)
   - **[com.google.fonts/check/description/valid_html]**: Verify that html snippets parse correctly (issue #2664)
   - **[com.google.fonts/check/metadata/os2_weightclass]**: Check now allows Thin to have 100, 250 and ExtraLight to have 200, 275 (issue #2947)
+  - **[com.google.fonts/check/whitespace_ink]**: Removed OGHAM SPACE MARK U+1680 as it is a whitespace that should have a drawing. (PR #2297 contributed by @drj11)
 
 ### Bugfixes
   - **[com.google.fonts/check/valid_glyphnames]**: Improve broken text in the FAIL message (PR #2939)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -469,15 +469,30 @@ def com_google_fonts_check_whitespace_ink(ttFont):
   """Whitespace glyphs have ink?"""
   from fontbakery.utils import get_glyph_name, glyph_has_ink
 
-  # code-points for all "whitespace" chars:
-  WHITESPACE_CHARACTERS = [
+  # This tests that certain glyphs are empty.
+  # Some, but not all, are Unicode whitespace.
+
+  # code-points for all Unicode whitespace chars
+  # (according to Unicode 11.0 property list):
+  WHITESPACE_CHARACTERS = {
     0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x0020, 0x0085, 0x00A0, 0x1680,
     0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008,
-    0x2009, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000, 0x180E, 0x200B,
-    0x2060, 0xFEFF
-  ]
+    0x2009, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000
+  }
+
+  # Code-points that do not have whitespace property, but
+  # should not have a drawing.
+  EXTRA_NON_DRAWING = {
+    0x180E, 0x200B, 0x2060, 0xFEFF
+  }
+
+  # Make the set of non drawing characters.
+  # OGHAM SPACE MARK U+1680 is removed as it is
+  # a whitespace that should have a drawing.
+  NON_DRAWING = WHITESPACE_CHARACTERS | EXTRA_NON_DRAWING - {0x1680}
+
   failed = False
-  for codepoint in WHITESPACE_CHARACTERS:
+  for codepoint in sorted(NON_DRAWING):
     g = get_glyph_name(ttFont, codepoint)
     if g is not None and glyph_has_ink(ttFont, g):
       failed = True


### PR DESCRIPTION
Make it clear which characters are whitespace and which are not.

## Description

This pull request addresses the problems described at issue #1903. Sort of.

I think the hard-coded list of whitespace characters is fine. All I've done in this PR is separate the 3 sets of characters so that it's clearer to anyone who is investigating later.

## To Do
- [x] update `CHANGELOG.md` (required!)
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

