### PR TITLE
WIP: new feature multiprocessing

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -536,7 +536,7 @@ class CheckRunner:
       else:
         try:
           _len = len(val)
-          bool_val = False if _len == 0 else True
+          bool_val = not _len == 0
         except TypeError:
           # TypeError: object of type 'bool' has no len()
           bool_val = bool(val)

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -1733,19 +1733,19 @@ class Profile:
     )
     return '{{"section":{},"check":{},"iterargs":{}}}'.format(*values)
 
+  def deserialize_identity(self, key):
+    item = json.loads(key)
+    section = self._get_section(item['section'])
+    check, _ = self.get_check(item['check'])
+    # tuple of tuples instead list of lists
+    iterargs = tuple(tuple(item) for item in item['iterargs'])
+    return section, check, iterargs
+
   def serialize_order(self, order):
     return map(self.serialize_identity, order)
 
   def deserialize_order(self, serialized_order):
-    result = []
-    for item in serialized_order:
-      item = json.loads(item)
-      section = self._get_section(item['section'])
-      check, _ = self.get_check(item['check'])
-      # tuple of tuples instead list of lists
-      iterargs = tuple(tuple(item) for item in item['iterargs'])
-      result.append((section, check, iterargs))
-    return tuple(result)
+    return tuple(self.deserialize_identity(item) for item in serialized_order)
 
   def setup_argparse(self, argument_parser):
     """

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -525,7 +525,23 @@ class CheckRunner:
       if err:
         status = (ERROR, err)
         return (status, None)
-      if not val:
+
+      # An annoying FutureWarning here (Python 3.8.3) on stderr:
+      #     "FutureWarning: The behavior of this method will change in future
+      #      versions. Use specific 'len(elem)' or 'elem is not None' test instead."
+      # Actually not shure how to tackle this, since val is very unspecific
+      # here intentionally. Where is the documentation for the change?
+      if val is None:
+        bool_val = False
+      else:
+        try:
+          _len = len(val)
+          bool_val = False if _len == 0 else True
+        except TypeError:
+          # TypeError: object of type 'bool' has no len()
+          bool_val = bool(val)
+
+      if not bool_val:
         unfulfilled_conditions.append(condition)
     if unfulfilled_conditions:
       # This will make the check neither pass nor fail

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -185,7 +185,7 @@ def ArgumentParser(profile, profile_arg=True):
                       help=f'Use multi-processing to run the checks. The argument is the \n'
                       f'number of worker processes. Use -1 to specify the number returned \n'
                       f'by os.cpu_count()( = {os.cpu_count()}). Use 0 to run in single-processing mode \n'
-                      '(default %(default)s) .'
+                      '(default %(default)s).'
                       )
   return argument_parser, values_keys
 

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -178,11 +178,18 @@ def ArgumentParser(profile, profile_arg=True):
                       ''.format(', '.join(iterargs))
                       )
 
-  argument_parser.add_argument('-M','--multiprocessing', default=0, type=int,
-                      help=f'Use multi-processing to run the checks. The argument is the \n'
-                      f'number of worker processes. Use -1 to specify the number returned \n'
-                      f'by os.cpu_count()( = {os.cpu_count()}). Use 0 to run in single-processing mode \n'
-                      '(default %(default)s).'
+  def positive_int(value):
+    int_value = int(value)
+    if int_value < 0:
+        raise argparse.ArgumentTypeError(f'Invalid value "{value}" '
+                            'must be zero or a positive integer value.')
+    return int_value
+  argument_parser.add_argument('-j','--jobs', default=0, const=os.cpu_count(), type=positive_int,
+                      nargs='?', metavar='JOBS', dest='multiprocessing',
+                      help='Use multi-processing to run the checks. The argument is the\n'
+                      'number of worker processes. Without argument, cpu count auto\n'
+                      'detection is used( = %(const)s). Use 0 to run in single-processing \n'
+                      'mode (default %(default)s).'
                       )
   return argument_parser, values_keys
 

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -20,8 +20,7 @@ from fontbakery.checkrunner import (
             , SKIP
             , PASS
             , FAIL
-            , STARTSECTION
-            , ENDSECTION
+            , SECTIONSUMMARY
             , START
             , END
             , ENDCHECK
@@ -120,8 +119,7 @@ def ArgumentParser(profile, profile_arg=True):
         help='No colors for tty output.')
 
   argument_parser.add_argument('-S', '--show-sections', default=False, action='store_true',
-                      help='Show section start and end info plus summary.')
-
+                      help='Show section summaries.')
 
   argument_parser.add_argument('-L', '--list-checks', default=False, action='store_true',
                       help='List the checks available in the selected profile.')
@@ -321,7 +319,7 @@ def main(profile=None, values=None):
                        , theme=theme
                        , collect_results_by=args.gather_by
                        , skip_status_report=None if args.show_sections\
-                                                      else (STARTSECTION, ENDSECTION)
+                                                      else (SECTIONSUMMARY, )
 
                        )
   reporters = [tr.receive]

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -273,6 +273,10 @@ def multiprocessing_runner(multiprocessing, runner, runner_kwds):
   for check in joblist:
     jobs.put(check)
 
+  # NOTE: it is VERY interesting how this actually replicates the
+  # check runner protocol, makes me think that it should perhaps not
+  # actually be an inherent part of CheckRunner at all.
+
   yield START, runner.order, (None, None, None)
   try:
     for _ in range(process_count):
@@ -318,8 +322,8 @@ def multiprocessing_runner(multiprocessing, runner, runner_kwds):
   # events. The issue comes from the async nature of multiprocessing.
   checkrun_summary = Counter()
   for _, (section_order, section_summary, section) in sections.items():
-    yield STARTSECTION, section_order, (section, None, None)
-    yield ENDSECTION, section_summary, (section, None, None)
+    yield STARTSECTION, section_order, (section, None, None) # should be removed
+    yield ENDSECTION, section_summary, (section, None, None) # should be SECTIONSUMMARY
     checkrun_summary.update(section_summary)
   yield END, checkrun_summary, (None, None, None)
 

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -182,11 +182,10 @@ def ArgumentParser(profile, profile_arg=True):
                       )
 
   argument_parser.add_argument('-M','--multiprocessing', default=0, type=int,
-                      help=f'Use multi-processing to run the checks. The argument '
-                           'is the number of worker processes. Use -1  to specify'
-                           f'{os.cpu_count()} (the number returned '
-                           'by os.cpu_count()). Use 0 (default) to run in '
-                           'single-processing mode.'
+                      help=f'Use multi-processing to run the checks. The argument is the \n'
+                      f'number of worker processes. Use -1 to specify the number returned \n'
+                      f'by os.cpu_count()( = {os.cpu_count()}). Use 0 to run in single-processing mode \n'
+                      '(default %(default)s) .'
                       )
   return argument_parser, values_keys
 

--- a/Lib/fontbakery/multiprocessing.py
+++ b/Lib/fontbakery/multiprocessing.py
@@ -213,10 +213,9 @@ def _multiprocessing_checkrunner(jobs, process_count, *args):
       p.terminate()
       p.join()
 
-def multiprocessing_runner(multiprocessing, runner, runner_kwds):
-  # multiprocessing is an int, never 0 at this point
-  assert multiprocessing != 0
-  process_count = os.cpu_count() if multiprocessing < 0 else multiprocessing
+def multiprocessing_runner(process_count, runner, runner_kwds):
+  # process_count is a positive int, never 0 at this point
+  assert process_count > 0
   profile = runner.profile
   joblist = list(profile.serialize_order(runner.order))
 

--- a/Lib/fontbakery/multiprocessing.py
+++ b/Lib/fontbakery/multiprocessing.py
@@ -8,7 +8,6 @@ Domain specific knowledge should be encoded only in the Profile (Checks,
 Conditions) and MAYBE in *customized* reporters e.g. subclasses.
 
 """
-import os
 from collections import OrderedDict
 from contextlib import contextmanager
 from functools import partial
@@ -20,17 +19,13 @@ from fontbakery.checkrunner import (  # NOQA
               INFO
             , WARN
             , ERROR
-#            , STARTSECTION
             , STARTCHECK
             , SKIP
             , PASS
             , FAIL
             , ENDCHECK
-#            , ENDSECTION
-#            , START
             , END
             , DEBUG
-#            , Status
             , CheckRunner
             , session_protocol_generator
             , drive_session_protocol

--- a/Lib/fontbakery/reporters/__init__.py
+++ b/Lib/fontbakery/reporters/__init__.py
@@ -14,13 +14,12 @@ from fontbakery.checkrunner import (
             , INFO
             , WARN
             , ERROR
-            , STARTSECTION
             , STARTCHECK
             , SKIP
             , PASS
             , FAIL
             , ENDCHECK
-            , ENDSECTION
+            , SECTIONSUMMARY
             , START
             , END
             , ProtocolViolationError

--- a/Lib/fontbakery/reporters/multiprocessing.py
+++ b/Lib/fontbakery/reporters/multiprocessing.py
@@ -1,0 +1,134 @@
+"""
+Separation of Concerns Disclaimer:
+While created specifically for checking fonts and font-families this
+module has no domain knowledge about fonts. It can be used for any kind
+of (document) checking. Please keep it so. It will be valuable for other
+domains as well.
+Domain specific knowledge should be encoded only in the Profile (Checks,
+Conditions) and MAYBE in *customized* reporters e.g. subclasses.
+
+"""
+from collections import OrderedDict
+from fontbakery.reporters import FontbakeryReporter
+from fontbakery.checkrunner import (  # NOQA
+              INFO
+            , WARN
+            , ERROR
+#            , STARTSECTION
+            , STARTCHECK
+            , SKIP
+            , PASS
+            , FAIL
+            , ENDCHECK
+#            , ENDSECTION
+#            , START
+            , END
+            , DEBUG
+#            , Status
+            )
+from fontbakery.message import Message
+
+name2status = {status.name:status for status in (
+                            DEBUG, PASS, SKIP, INFO, WARN, FAIL, ERROR)}
+
+# somehowsimilar to DashbordWorkerReporter of Font Bakery Dashboard
+class WorkerToQueueReporter(FontbakeryReporter):
+  def __init__(self, queue, profile, ticks_to_flush = None, **kwd):
+    super().__init__(**kwd)
+    self._queue = queue
+    self._profile = profile;
+    self.ticks_to_flush = ticks_to_flush or 1
+
+    self._current = None
+    self._collectedChecks = None
+
+  def _register(self, event):
+    super()._register(event)
+    status, message, identity = event
+    _section, check, _iterargs = identity
+    if status == END:
+      self.flush()
+      return
+
+    if not check:
+      return
+
+    key = self._profile.serialize_identity(identity)
+
+    if status == STARTCHECK:
+        self._current = {
+            'statuses': []
+        }
+
+    if status == ENDCHECK:
+        # Do more? Anything more would make access easier but also be a
+        # derivative of the actual data, i.e. not SSOT. Calculating (and
+        # thus interpreting) results for the checks is probably not too
+        # expensive to do it on the fly.
+        self._current['result'] = message.name
+        self._save_result(key, self._current)
+        self._current = None
+
+    if status >= DEBUG:
+      # message can be a lot here, currently we know about:
+      #    string, an Exception, a Message. Probably we should leave it
+      #    like this. Message should be the ultimate answer if it's not
+      #    an Exception or a string.
+      # turn everything in a fontbakery/Message like object
+      # `code` may be used for overwriting special failing statuses
+      # otherwise, code must be none
+      #
+      # Optional keys are:
+      #  "code": used to explicitly overwrite specific (FAIL) statuses
+      #  "traceback": only provided if message is an Excepion and likely
+      #               if status is "ERROR"
+      log = {'status': status.name}
+
+      if hasattr(message, 'traceback'):
+        # message is likely a FontbakeryError if this is not None
+        log['traceback'] = message.traceback
+      if isinstance(message, Message):
+        # Ducktyping could be a valid option here.
+        # in that case, a FontbakeryError could also provide a `code` attribute
+        # which would allow to skip that error explicitly. However
+        # ERROR statuses should never be skiped explicitly, the cause
+        # of the error must be repaired!
+        log.update(message.getData())
+      else:
+        log['message'] = f'{message}'
+      self._current['statuses'].append(log)
+
+  def _save_result(self, key, check_result):
+    """ send check_result to the queue"""
+    if self._collectedChecks is None:
+      # order is not really relevant in multiprocessing, however, we keep
+      # it as long as possible, could be good for debugging.
+      self._collectedChecks = OrderedDict()
+    self._collectedChecks[key] = check_result
+    if len(self._collectedChecks) >= self.ticks_to_flush:
+      self.flush()
+
+  def flush(self):
+    if self._collectedChecks:
+      self._queue.put(tuple(self._collectedChecks.items()))
+    self._collectedChecks = None
+
+
+def deserialize_queue_check(profile, key, check_data):
+  identity = profile.deserialize_identity(key)
+  yield STARTCHECK, None, identity  ## = event
+
+  for log in check_data['statuses']:
+    status = name2status[log['status']]
+    if 'code' in log:
+      message = Message(log['code'], log['message'])
+    elif 'traceback' in log:
+      # not to happy with this generic exception, let's se how it plays out
+      message = Exception(log['message'])
+      setattr(message, 'traceback', log['traceback'])
+    else:
+      message = log['message']
+    yield status, message, identity ### = event
+
+  status = name2status[check_data['result']]
+  yield ENDCHECK, status, identity ## = event

--- a/Lib/fontbakery/reporters/multiprocessing.py
+++ b/Lib/fontbakery/reporters/multiprocessing.py
@@ -31,7 +31,7 @@ from fontbakery.message import Message
 name2status = {status.name:status for status in (
                             DEBUG, PASS, SKIP, INFO, WARN, FAIL, ERROR)}
 
-# somehowsimilar to DashbordWorkerReporter of Font Bakery Dashboard
+# Similar to DashbordWorkerReporter of Font Bakery Dashboard.
 class WorkerToQueueReporter(FontbakeryReporter):
   def __init__(self, queue, profile, ticks_to_flush = None, **kwd):
     super().__init__(**kwd)
@@ -114,6 +114,7 @@ class WorkerToQueueReporter(FontbakeryReporter):
     self._collectedChecks = None
 
 
+# Putting this in here, because it's the inverse of the above serialization
 def deserialize_queue_check(profile, key, check_data):
   identity = profile.deserialize_identity(key)
   yield STARTCHECK, None, identity  ## = event

--- a/Lib/fontbakery/reporters/multiprocessing.py
+++ b/Lib/fontbakery/reporters/multiprocessing.py
@@ -36,7 +36,7 @@ class WorkerToQueueReporter(FontbakeryReporter):
   def __init__(self, queue, profile, ticks_to_flush = None, **kwd):
     super().__init__(**kwd)
     self._queue = queue
-    self._profile = profile;
+    self._profile = profile
     self.ticks_to_flush = ticks_to_flush or 1
 
     self._current = None

--- a/Lib/fontbakery/reporters/serialize.py
+++ b/Lib/fontbakery/reporters/serialize.py
@@ -12,8 +12,7 @@ Conditions) and MAYBE in *customized* reporters e.g. subclasses.
 """
 from fontbakery.checkrunner import (
               DEBUG
-            , STARTSECTION
-            , ENDSECTION
+            , SECTIONSUMMARY
             , ENDCHECK
             , START
             , END
@@ -66,7 +65,7 @@ class SerializeReporter(FontbakeryReporter):
           # give the consumer a clue that/how the sections
           # are structured differently.
           item['clusteredBy'] = self._results_by
-      if status in (STARTSECTION, ENDSECTION):
+      if status == SECTIONSUMMARY:
         item.update(dict(key=key, result=None, checks=[]))
       if check:
         item.update(dict(key=key, result=None, logs=[]))
@@ -103,8 +102,10 @@ class SerializeReporter(FontbakeryReporter):
       if item["key"][2] != ():
         item['filename'] = self.runner.get_iterarg(*item["key"][2][0])
 
-    if status in (END, ENDSECTION):
+    if status == END:
       item['result'] = message # is a Counter
+    if status == SECTIONSUMMARY:
+      _, item['result'] = message # message[1] is a Counter
     if status == ENDCHECK:
       item['result'] = message.name # is a Status
     if status >= DEBUG:
@@ -122,7 +123,6 @@ class SerializeReporter(FontbakeryReporter):
       return self._doc
     doc = self._items[self._get_key((None, None, None))]
     seen = set()
-    sectionorder = []
     # this puts all in the original order
     for identity in self._order:
       key = self._get_key(identity)


### PR DESCRIPTION
**CAUTION** this is experimental, although working so far.

Please feel free to try it out!

## Description

This adds a command line argument:

```
  -M MULTIPROCESSING, --multiprocessing MULTIPROCESSING
                        Use multi-processing to run the checks. The argument is the 
                        number of worker processes. Use -1 to specify the number returned 
                        by os.cpu_count()( = 8). Use 0 to run in single-processing mode 
                        (default 0).
```

and to run e.g.:

```
$ fontbakery check-googlefonts -M -1  ~/Desktop/*.ttf 
```

Using the time command i get:

```

$ time fontbakery check-googlefonts -M -1  ~/Desktop/*.ttf
[…]
real	0m17.935s
user	1m8.124s
sys	0m2.629s

$ time fontbakery check-googlefonts ~/Desktop/*.ttf
[…]
real    0m56.971s
user    0m33.152s
sys     0m4.130s
```

Which is *39 seconds* quicker.



## To Do
- [x] better code organization?
- [x] I'm not very happy how STARTSECTION/ENDSECTION are handled, but the solution may be to replace these statuses by something else (SECTIONSUMMARY?). However, this could break stuff external to this project, we don't know.
- [x] There's some room to implement this more elegantly, but would e.g. involve touching `CheckRunner` or try to avoid pickling the module etc. I'll have a look myself after a few days.
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review
