### PR TITLE
Checking for subtable format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.8.0 (2020-Jul-??)
+  - Checks if GSUB lookup format is 1 for ligature collection in `profiles/shared_conditions.py`; format 1 is the only significant one for `ligatures()` and `ligature_glyphs()`)
   - ...
 
 

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -117,11 +117,12 @@ def ligatures(ttFont):
           for index in record.Feature.LookupListIndex:
             lookup = ttFont["GSUB"].table.LookupList.Lookup[index]
             for subtable in lookup.SubTable:
-              for firstGlyph in subtable.ligatures.keys():
-                all_ligatures[firstGlyph] = []
-                for lig in subtable.ligatures[firstGlyph]:
-                  if lig.Component not in all_ligatures[firstGlyph]:
-                    all_ligatures[firstGlyph].append(lig.Component)
+              if subtable.Format == 1:
+                for firstGlyph in subtable.ligatures.keys():
+                  all_ligatures[firstGlyph] = []
+                  for lig in subtable.ligatures[firstGlyph]:
+                    if lig.Component not in all_ligatures[firstGlyph]:
+                      all_ligatures[firstGlyph].append(lig.Component)
     return all_ligatures
   except:
     return -1 # Indicate fontTools-related crash...
@@ -137,10 +138,11 @@ def ligature_glyphs(ttFont):
           for index in record.Feature.LookupListIndex:
             lookup = ttFont["GSUB"].table.LookupList.Lookup[index]
             for subtable in lookup.SubTable:
-              for firstGlyph in subtable.ligatures.keys():
-                for lig in subtable.ligatures[firstGlyph]:
-                  if lig.LigGlyph not in all_ligature_glyphs:
-                    all_ligature_glyphs.append(lig.LigGlyph)
+              if subtable.Format == 1:
+                for firstGlyph in subtable.ligatures.keys():
+                  for lig in subtable.ligatures[firstGlyph]:
+                    if lig.LigGlyph not in all_ligature_glyphs:
+                      all_ligature_glyphs.append(lig.LigGlyph)
     return all_ligature_glyphs
   except:
     return -1  # Indicate fontTools-related crash...


### PR DESCRIPTION
Formats other than 1 don’t have .ligatures attribute (like contextual substitutions), so it throws an error here and returns -1, which leads to a FAIL.
Only Format 1 seems to be wanted here, so checking for it.