### PR TITLE
com.google.fonts/check/description/broken_links: Skip when html does not parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.8.0 (2020-Jul-??)
-  - ...
+
+### Bugfixes
+  - **com.google.fonts/check/description/broken_links**: Skip when html does not parse. (issue #2664)
 
 
 ## 0.7.28 (2020-Jul-09)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -245,16 +245,16 @@ def com_google_fonts_check_canonical_filename(font):
 
 @check(
   id = 'com.google.fonts/check/description/broken_links',
-  conditions = ['description'],
+  conditions = ['description_html'],
   rationale = """
-    The snippet of HTML in the DESCRIPTION.en_us.html file is added to the font family webpage on the Google Fonts website. For that reason, all hyperlinks in it must be properly working. 
+    The snippet of HTML in the DESCRIPTION.en_us.html file is added to the font family webpage on the Google Fonts website. For that reason, all hyperlinks in it must be properly working.
   """
 )
-def com_google_fonts_check_description_broken_links(description):
+def com_google_fonts_check_description_broken_links(description_html):
   """Does DESCRIPTION file contain broken links?"""
   import requests
   from lxml import etree
-  doc = etree.fromstring("<html>" + description + "</html>")
+  doc = description_html
   broken_links = []
   for a_href in doc.iterfind('.//a[@href]'):
     link = a_href.get("href")

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -220,27 +220,28 @@ def test_check_description_broken_links():
   from fontbakery.profiles.googlefonts import (
     com_google_fonts_check_description_broken_links as check,
     description,
+    description_html,
     descfile)
 
   good_desc = description(descfile(TEST_FILE("cabin/Cabin-Regular.ttf")))
-  assert_PASS(check(good_desc),
+  assert_PASS(check(description_html(good_desc)),
               'with description file that has no links...')
 
   good_desc += ("<a href='http://example.com'>Good Link</a>"
                 "<a href='http://fonts.google.com'>Another Good One</a>")
-  assert_PASS(check(good_desc),
+  assert_PASS(check(description_html(good_desc)),
               'with description file that has good links...')
 
   good_desc += "<a href='mailto:juca@members.fsf.org'>An example mailto link</a>"
-  assert_results_contain(check(good_desc),
+  assert_results_contain(check(description_html(good_desc)),
                          INFO, "email",
                          'with a description file containing "mailto" links...')
 
-  assert_PASS(check(good_desc),
+  assert_PASS(check(description_html(good_desc)),
               'with a description file containing "mailto" links...')
 
   bad_desc = good_desc + "<a href='http://thisisanexampleofabrokenurl.com/'>This is a Bad Link</a>"
-  assert_results_contain(check(bad_desc),
+  assert_results_contain(check(description_html(bad_desc)),
                          FAIL, 'broken-links',
                          'with a description file containing a known-bad URL...')
 


### PR DESCRIPTION

## Description
com.google.fonts/check/description/broken_links was still suffering under parser errors from DESCRIPTION.en_us.html

This is a follow up of https://github.com/googlefonts/fontbakery/commit/f2ace463ee447251ba5bf7513424d7ed7ed78b90 and fixes one more check related to #2664


## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

