### PR TITLE
new check com.google.fonts/check/metadata/category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### New Checks
   - **[universal: com.google.fonts/check/rupee]**: Ensure indic fonts have the Indian Rupee Sign glyph (issue #2967)
+  - **[googlefonts: com.google.fonts/check/metadata/category]**: Ensure category field is valid in METADATA.pb file (issue #2972)
 
 ### Changes to existing checks
   - **[com.google.fonts/check/varfont_instance_names]**: Check will now only allow 18 named instances (Thin-Black + Italics). This was decided in a Friday team meeting on the 2020/06/26. Changes also reflect the updated spec, https://github.com/googlefonts/gf-docs/tree/master/Spec#fvar-instances.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -58,7 +58,8 @@ METADATA_CHECKS = [
   'com.google.fonts/check/metadata/os2_weightclass',
   'com.google.fonts/check/metadata/canonical_style_names',
   'com.google.fonts/check/metadata/broken_links',
-  'com.google.fonts/check/metadata/undeclared_fonts'
+  'com.google.fonts/check/metadata/undeclared_fonts',
+  'com.google.fonts/check/metadata/category'
 ]
 
 DESCRIPTION_CHECKS = [
@@ -618,6 +619,37 @@ def com_google_fonts_check_metadata_undeclared_fonts(family_metadata, family_dir
   if passed:
     yield PASS, "OK"
 
+
+@check(
+  id = 'com.google.fonts/check/metadata/category',
+  conditions = ['family_metadata'],
+  rationale = """
+    There are only five acceptable values for the category field in a METADATA.pb file:
+    - MONOSPACE
+    - SANS_SERIF
+    - SERIF
+    - DISPLAY
+    - HANDWRITING
+
+    This check is meant to avoid typos in this field.
+  """,
+  misc_metadata = {
+    'request': "https://github.com/googlefonts/fontbakery/issues/2972"
+  }
+)
+def com_google_fonts_check_metadata_category(family_metadata):
+  """Ensure METADATA.pb category field is valid."""
+  if family_metadata.category not in ["MONOSPACE",
+                                      "SANS_SERIF",
+                                      "SERIF",
+                                      "DISPLAY",
+                                      "HANDWRITING"]:
+    yield FAIL,\
+          Message('bad-value',
+                  f'The field category has "{family_metadata.category}"'
+                  f' which is not valid.')
+  else:
+    yield PASS, "OK!"
 
 
 @disable # TODO: re-enable after addressing issue #1998

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2361,7 +2361,7 @@ def DISABLED_test_check_production_encoded_glyphs(cabin_ttFonts):
 
 def test_check_metadata_nameid_copyright():
   """ Copyright field for this font on METADATA.pb matches
-      all copyright notice entries on the name table ? """
+      all copyright notice entries on the name table? """
   from fontbakery.utils import get_name_entry_strings
   from fontbakery.profiles.googlefonts import (
     com_google_fonts_check_metadata_nameid_copyright as check,
@@ -2385,6 +2385,41 @@ def test_check_metadata_nameid_copyright():
   assert_results_contain(check(ttFont, font_meta),
                          FAIL, 'mismatch',
                          'with a bad METADATA.pb (with a copyright string not matching this font)...')
+
+
+def test_check_metadata_category():
+  """ Category field for this font on METADATA.pb is valid? """
+  from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_category as check,
+                                               family_metadata)
+  # Our reference Cabin family...
+  fontfile = TEST_FILE("cabin/Cabin-Regular.ttf")
+  family_directory = os.path.dirname(fontfile)
+  metadata = family_metadata(family_directory)
+  assert metadata.category == "SANS_SERIF" # ...is known to be good ;-)
+
+  # So it must PASS the check:
+  assert_PASS(check(metadata),
+              "with a good METADATA.pb...")
+
+  # Then we report a problem with this sample of bad values:
+  for bad_value in ["SAN_SERIF",
+                    "MONO_SPACE",
+                    "sans_serif",
+                    "monospace"]:
+    metadata.category = bad_value
+    assert_results_contain(check(metadata),
+                           FAIL, 'bad-value',
+                           f'with a bad category "{bad_value}"...')
+
+  # And we accept the good ones:
+  for good_value in ["MONOSPACE",
+                     "SANS_SERIF",
+                     "SERIF",
+                     "DISPLAY",
+                     "HANDWRITING"]:
+    metadata.category = good_value
+    assert_PASS(check(metadata),
+                f'with "{good_value}"...')
 
 
 def test_check_name_mandatory_entries():


### PR DESCRIPTION
on googlefonts profile:
"Ensure category field is valid in METADATA.pb file"
(issue #2972)