### PR TITLE
Accept HTTP Status 429 on "broken_links" checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[googlefonts: com.google.fonts/check/metadata/category]**: Ensure category field is valid in METADATA.pb file (issue #2972)
 
 ### Changes to existing checks
-  - **[com.google.fonts/check/metadata/broken_links]**: request URLs only once (issue #2974)
-  - **[com.google.fonts/check/description/broken_links]**: request URLs only once (issue #2974)
+  - **[com.google.fonts/check/metadata/broken_links]**: request URLs only once and accept status 429 - "too many requests" (issue #2974)
+  - **[com.google.fonts/check/description/broken_links]**: request URLs only once and accept status 429 - "too many requests" (issue #2974)
   - **[com.google.fonts/check/varfont_instance_names]**: Check will now only allow 18 named instances (Thin-Black + Italics). This was decided in a Friday team meeting on the 2020/06/26. Changes also reflect the updated spec, https://github.com/googlefonts/gf-docs/tree/master/Spec#fvar-instances.
 
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -277,7 +277,11 @@ def com_google_fonts_check_description_broken_links(description_html):
     try:
       response = requests.head(link, allow_redirects=True, timeout=10)
       code = response.status_code
-      if code != requests.codes.ok:
+      # Status 429: "Too Many Requests" is acceptable
+      # because it means the website is probably ok and
+      # we're just perhaps being too agressive in probing the server!
+      if code not in [requests.codes.ok,
+                      requests.codes.too_many_requests]:
         broken_links.append(f"{link} (status code: {code})")
     except requests.exceptions.Timeout:
       yield WARN,\
@@ -562,7 +566,11 @@ def com_google_fonts_check_metadata_broken_links(family_metadata):
       try:
         response = requests.head(link, allow_redirects=True, timeout=10)
         code = response.status_code
-        if code != requests.codes.ok:
+        # Status 429: "Too Many Requests" is acceptable
+        # because it means the website is probably ok and
+        # we're just perhaps being too agressive in probing the server!
+        if code not in [requests.codes.ok,
+                        requests.codes.too_many_requests]:
           broken_links.append(("{} (status code: {})").format(link, code))
       except requests.exceptions.Timeout:
         yield WARN,\


### PR DESCRIPTION
Probably fine. We're just being too aggressive on probing the webserver when we get those 429 responses...

com.google.fonts/check/metadata/broken_links
com.google.fonts/check/description/broken_links
(issue #2974)