### PR TITLE
Add GlyphsApp instructions for fixing ligature caret WARNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[googlefonts: com.google.fonts/check/metadata/category]**: Ensure category field is valid in METADATA.pb file (issue #2972)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/ligature_carets]**: Add GlyphsApp instructions for fixing ligature caret WARNs (issue #2955)
   - **[com.google.fonts/check/metadata/broken_links]**: request URLs only once and accept status 429 - "too many requests" (issue #2974)
   - **[com.google.fonts/check/description/broken_links]**: request URLs only once and accept status 429 - "too many requests" (issue #2974)
   - **[com.google.fonts/check/varfont_instance_names]**: Check will now only allow 18 named instances (Thin-Black + Italics). This was decided in a Friday team meeting on the 2020/06/26. Changes also reflect the updated spec, https://github.com/googlefonts/gf-docs/tree/master/Spec#fvar-instances.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3988,6 +3988,8 @@ def com_google_fonts_check_integer_ppem_if_hinted(ttFont):
   conditions = ['ligature_glyphs'],
   rationale = """
     All ligatures in a font must have corresponding caret (text cursor) positions defined in the GDEF table, otherwhise, users may experience issues with caret rendering.
+
+    If using GlyphsApp, ligature carets can be set directly on canvas by accessing the `Glyph -> Set Anchors` menu option or by pressing the `Cmd+U` keyboard shortcut.
   """,
   misc_metadata = {
     'request': 'https://github.com/googlefonts/fontbakery/issues/1225'


### PR DESCRIPTION
com.google.fonts/check/ligature_carets
(issue #2955) 