### PR TITLE
updating units per em criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[googlefonts: com.google.fonts/check/metadata/category]**: Ensure category field is valid in METADATA.pb file (issue #2972)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/ligature_carets]**: updating units per em criteria because the assumptions behind our previous "upm=2000 for VFs" suggestion were not really correct. (issue #2791)
   - **[com.google.fonts/check/ligature_carets]**: Add GlyphsApp instructions for fixing ligature caret WARNs (issue #2955)
   - **[com.google.fonts/check/metadata/broken_links]**: request URLs only once and accept status 429 - "too many requests" (issue #2974)
   - **[com.google.fonts/check/description/broken_links]**: request URLs only once and accept status 429 - "too many requests" (issue #2974)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2671,13 +2671,9 @@ def com_google_fonts_check_metadata_canonical_style_names(ttFont, font_metadata)
 
     The spec suggests usage of powers of two in order to get some performance improvements on legacy renderers, so those values are acceptable.
 
-    But value of 500 or 1000 are also acceptable, with the added benefit that it makes upm math easier for designers, while the performance hit of not using a power of two is most likely negligible nowadays.
+    But values of 500 or 1000 are also acceptable, with the added benefit that it makes upm math easier for designers, while the performance hit of not using a power of two is most likely negligible nowadays.
 
-    Another acceptable value is 2000. Since TT outlines are all integers (no floats), then instances in a VF suffer rounding compromises, and therefore a 1000 UPM is too small because it forces too many such compromises.
-   
-    Therefore 2000 is a good 'new VF standard', because 2000 is a simple 2x conversion from existing fonts drawn on a 1000 UPM, and anyone who knows what 10 units can do for 1000 UPM will know what 20 units does too.
-
-    Additionally, values above 2048 would result in filesize increases with not much added benefit.
+    Additionally, values above 2048 would likely result in unreasonable filesize increases.
   """
 )
 def com_google_fonts_check_unitsperem_strict(ttFont):
@@ -2696,20 +2692,9 @@ def com_google_fonts_check_unitsperem_strict(ttFont):
     yield FAIL,\
           Message("bad-value",
                   f"Font em size (unitsPerEm) is {upm_height}."
-                  f" If possible, please consider using 1000"
-                  f" or even 2000 (which is ideal for"
-                  f" Variable Fonts)."
+                  f" If possible, please consider using 1000."
                   f" Good values for unitsPerEm,"
                   f" though, are typically these: {ACCEPTABLE}.")
-  elif upm_height < 2000:
-    yield WARN,\
-          Message("legacy-value",
-                  f"Even though unitsPerEm ({upm_height}) in"
-                  f" this font is reasonable. It is strongly"
-                  f" advised to consider changing it to 2000,"
-                  f" since it will likely improve the quality of"
-                  f" Variable Fonts by avoiding excessive"
-                  f" rounding of coordinates on interpolations.")
   else:
     yield PASS, f"Font em size is good (unitsPerEm = {upm_height})."
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2168,8 +2168,9 @@ def test_check_unitsperem_strict():
   fontfile = TEST_FILE("cabin/Cabin-Regular.ttf")
   ttFont = TTFont(fontfile)
 
-  WARN_LEGACY_VALUES = [16, 32, 64, 128, 256, 512, 1024] # Good for better performance on legacy renderers
-  WARN_LEGACY_VALUES.extend([500, 1000]) # or common typical values
+  PASS_VALUES = [16, 32, 64, 128, 256, 512, 1024] # Good for better performance on legacy renderers
+  PASS_VALUES.extend([500, 1000]) # or common typical values
+  PASS_VALUES.extend([2000, 2048]) # not so common, but still ok
 
   WARN_LARGE_VALUES = [2500, 4000, 4096] # uncommon and large,
                                          # but we've seen legitimate cases such as the
@@ -2182,19 +2183,11 @@ def test_check_unitsperem_strict():
                                     # but too large, causing undesireable filesize bloat.
 
 
-  PASS_VALUES = [2000, # The potential "New Standard" for Variable Fonts!
-                 2048] # A power of two but higher than 2000, so no need to warn about excessive rounding.
-
   for pass_value in PASS_VALUES:
     ttFont["head"].unitsPerEm = pass_value
     assert_PASS(check(ttFont),
                 f'with unitsPerEm = {pass_value}...')
 
-  for warn_value in WARN_LEGACY_VALUES:
-    ttFont["head"].unitsPerEm = warn_value
-    assert_results_contain(check(ttFont),
-                           WARN, 'legacy-value',
-                           f'with unitsPerEm = {warn_value}...')
 
   for warn_value in WARN_LARGE_VALUES:
     ttFont["head"].unitsPerEm = warn_value


### PR DESCRIPTION
because the assumptions behind our previous "upm=2000 for VFs" suggestion were not really correct.
(issue #2791)