### PR TITLE
Avoid duplicate instance names in variable fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.0 (2020-Jul-??)
 ### Note-worthy code changes
   - remove PriorityLevel class as it makes classifying checks by priority more complicated then necessary! (issue #2981)
-  - Added **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts
+  - Added **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2988)
   - ...
 
 ## 0.7.29 (2020-Jul-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.0 (2020-Jul-??)
 ### Note-worthy code changes
   - remove PriorityLevel class as it makes classifying checks by priority more complicated then necessary! (issue #2981)
-  - Added **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2988)
+  - Added **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2986)
   - ...
 
 ## 0.7.29 (2020-Jul-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.0 (2020-Jul-??)
 ### Note-worthy code changes
   - remove PriorityLevel class as it makes classifying checks by priority more complicated then necessary! (issue #2981)
-
+  - Added **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts
+  - ...
 
 ## 0.7.29 (2020-Jul-17)
 ### Note-worthy code changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.0 (2020-Jul-??)
 ### Note-worthy code changes
   - remove PriorityLevel class as it makes classifying checks by priority more complicated then necessary! (issue #2981)
-  - Added **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2986)
-  - ...
+
+### New Checks
+  - **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2986)
 
 ## 0.7.29 (2020-Jul-17)
 ### Note-worthy code changes

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4635,11 +4635,10 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
 @check(
   id = 'com.google.fonts/check/varfont_duplicate_instance_names',
   rationale = """
-    According to Google Font’s specs (as of 2020-06-26), only weight and italic tokens are allowed in instance names (= "ExtraBold Italic").
+    Repeating instance names may be the result of instances for several VF axes defined in `fvar`, but since 
+    currently only weight+italic tokens are allowed in instance names as per GF specs, they ended up repeating.
 
-    This variable font contains duplicate instance names, suggesting that instances are defined for more then one axis.
-
-    Instead, only a base set of fonts for the most general representation of the family can be defined through instances in the `fvar` table,
+    Instead, only a base set of fonts for the most default representation of the family can be defined through instances in the `fvar` table,
     all other instances will have to be left to access through the `STAT` table.
   """,
   conditions = ['is_variable_font'],

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4646,11 +4646,6 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
 )
 def com_google_fonts_check_varfont_duplicate_instance_names(ttFont):
   """Check variable font instances don't have duplicate names"""
-  # This check and the fontbakery.parse module used to be more complicated.
-  # On 2020-06-26, we decided to only allow Thin-Black + Italic instances.
-  # If we decide to add more particles to instance names, It's worthwhile
-  # revisiting our previous implementation which can be found in commits
-  # earlier than or equal to ca71d787eb2b8b5a9b111884080dde5d45f5579f
   from fontbakery.constants import SHOW_GF_DOCS_MSG
 
   seen = []

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4635,6 +4635,8 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
 @check(
   id = 'com.google.fonts/check/varfont_duplicate_instance_names',
   rationale = """
+    This check's purpose is to detect duplicate named instance names in a given variable font.
+
     Repeating instance names may be the result of instances for several VF axes defined in `fvar`, but since 
     currently only weight+italic tokens are allowed in instance names as per GF specs, they ended up repeating.
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4635,7 +4635,7 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
 @check(
   id = 'com.google.fonts/check/varfont_duplicate_instance_names',
   rationale = """
-    This check's purpose is to detect duplicate named instance names in a given variable font.
+    This check's purpose is to detect duplicate named instances names in a given variable font.
 
     Repeating instance names may be the result of instances for several VF axes defined in `fvar`, but since 
     currently only weight+italic tokens are allowed in instance names as per GF specs, they ended up repeating.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -144,6 +144,7 @@ FONT_FILE_CHECKS = [
   'com.google.fonts/check/cjk_vertical_metrics',
   'com.google.fonts/check/varfont_instance_coordinates',
   'com.google.fonts/check/varfont_instance_names',
+  'com.google.fonts/check/varfont_duplicate_instance_names',
   'com.google.fonts/check/varfont/consistent_axes',
   'com.google.fonts/check/varfont/unsupported_axes'
 ]
@@ -4625,6 +4626,56 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
     yield FAIL,\
           Message('bad-instance-names',
                   f'Following instances are not supported: {failed_instances}\n'
+                  f'\n'
+                  f'{SHOW_GF_DOCS_MSG}#fvar-instances')
+  else:
+    yield PASS, "Instance names are correct"
+
+
+@check(
+  id = 'com.google.fonts/check/varfont_duplicate_instance_names',
+  rationale = f"""
+    According to Google Font’s specs (as of 2020-06-26), only weight and italic tokens are allowed in instance names (= "ExtraBold Italic").
+
+    This variable font contains duplicate instance names, suggesting that instances are defined for more then one axis.
+
+    Instead, only a base set of fonts for the most general representation of the family can be defined through instances in the `fvar` table,
+    all other instances will have to be left to access through the `STAT` table.
+  """,
+  conditions = ['is_variable_font'],
+)
+def com_google_fonts_check_varfont_duplicate_instance_names(ttFont):
+  """Check variable font instances don't have duplicate names"""
+  # This check and the fontbakery.parse module used to be more complicated.
+  # On 2020-06-26, we decided to only allow Thin-Black + Italic instances.
+  # If we decide to add more particles to instance names, It's worthwhile
+  # revisiting our previous implementation which can be found in commits
+  # earlier than or equal to ca71d787eb2b8b5a9b111884080dde5d45f5579f
+  from fontbakery.parse import instance_parse
+  from fontbakery.constants import SHOW_GF_DOCS_MSG
+
+  seen = []
+  duplicate = []
+
+  for instance in ttFont['fvar'].instances:
+    name = ttFont['name'].getName(
+      instance.subfamilyNameID,
+      PlatformID.WINDOWS,
+      WindowsEncodingID.UNICODE_BMP,
+      WindowsLanguageID.ENGLISH_USA
+    ).toUnicode()
+    
+    if name in seen:
+      duplicate.append(name)
+
+    if not name in seen:
+      seen.append(name)
+
+  if duplicate:
+    duplicate_instances = "\n\t- ".join([""] + duplicate)
+    yield FAIL,\
+          Message('duplicate-instance-names',
+                  f'Following instances names are duplicate: {duplicate_instances}\n'
                   f'\n'
                   f'{SHOW_GF_DOCS_MSG}#fvar-instances')
   else:

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4651,7 +4651,6 @@ def com_google_fonts_check_varfont_duplicate_instance_names(ttFont):
   # If we decide to add more particles to instance names, It's worthwhile
   # revisiting our previous implementation which can be found in commits
   # earlier than or equal to ca71d787eb2b8b5a9b111884080dde5d45f5579f
-  from fontbakery.parse import instance_parse
   from fontbakery.constants import SHOW_GF_DOCS_MSG
 
   seen = []

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4669,11 +4669,9 @@ def com_google_fonts_check_varfont_duplicate_instance_names(ttFont):
     duplicate_instances = "\n\t- ".join([""] + duplicate)
     yield FAIL,\
           Message('duplicate-instance-names',
-                  f'Following instances names are duplicate: {duplicate_instances}\n'
-                  f'\n'
-                  f'{SHOW_GF_DOCS_MSG}#fvar-instances')
+                  f'Following instances names are duplicate: {duplicate_instances}\n')
   else:
-    yield PASS, "Instance names are correct"
+    yield PASS, "Instance names are unique"
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4634,7 +4634,7 @@ def com_google_fonts_check_varfont_instance_names(ttFont):
 
 @check(
   id = 'com.google.fonts/check/varfont_duplicate_instance_names',
-  rationale = f"""
+  rationale = """
     According to Google Font’s specs (as of 2020-06-26), only weight and italic tokens are allowed in instance names (= "ExtraBold Italic").
 
     This variable font contains duplicate instance names, suggesting that instances are defined for more then one axis.

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3469,7 +3469,6 @@ def test_check_varfont_instance_names(vf_ttFont):
 
 def test_check_varfont_duplicate_instance_names(vf_ttFont):
   from fontbakery.profiles.googlefonts import com_google_fonts_check_varfont_duplicate_instance_names as check
-  from fontbakery.parse import instance_parse
   from copy import copy
 
   assert_PASS(check(vf_ttFont),

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3472,7 +3472,7 @@ def test_check_varfont_duplicate_instance_names(vf_ttFont):
   from copy import copy
 
   assert_PASS(check(vf_ttFont),
-              'with a variable font which has correct instance names.')
+              'with a variable font which has unique instance names.')
 
   vf_ttFont2 = copy(vf_ttFont)
   duplicate_instance_name = vf_ttFont2['name'].getName(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3467,6 +3467,30 @@ def test_check_varfont_instance_names(vf_ttFont):
                          'with a variable font which does not have correct instance names.')
 
 
+def test_check_varfont_duplicate_instance_names(vf_ttFont):
+  from fontbakery.profiles.googlefonts import com_google_fonts_check_varfont_duplicate_instance_names as check
+  from fontbakery.parse import instance_parse
+  from copy import copy
+
+  assert_PASS(check(vf_ttFont),
+              'with a variable font which has correct instance names.')
+
+  vf_ttFont2 = copy(vf_ttFont)
+  duplicate_instance_name = vf_ttFont2['name'].getName(
+      vf_ttFont2['fvar'].instances[0].subfamilyNameID,
+      PlatformID.WINDOWS,
+      WindowsEncodingID.UNICODE_BMP,
+      WindowsLanguageID.ENGLISH_USA
+  ).toUnicode()
+  vf_ttFont2['name'].setName(string=duplicate_instance_name, 
+                            nameID=vf_ttFont2['fvar'].instances[1].subfamilyNameID,
+                            platformID=PlatformID.WINDOWS,
+                            platEncID=WindowsEncodingID.UNICODE_BMP,
+                            langID=WindowsLanguageID.ENGLISH_USA)
+  assert_results_contain(check(vf_ttFont2),
+                         FAIL, 'duplicate-instance-names')
+
+
 def test_check_varfont_unsupported_axes():
   """Ensure VFs do not contain opsz or ital axes."""
   from fontbakery.profiles.googlefonts import com_google_fonts_check_varfont_unsupported_axes as check


### PR DESCRIPTION
## Description
Added check to avoid duplicate instance names in variable fonts

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

