### PR TITLE
new check com.google.fonts/check/metadata/includes_production_subsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### New Checks
   - **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2986)
+  - **[com.google.fonts/check/metadata/includes_production_subsets]**: ensure METADATA.pb files include production subsets. (issue #2989)
+
 
 ## 0.7.29 (2020-Jul-17)
 ### Note-worthy code changes

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -28,6 +28,7 @@ METADATA_CHECKS = [
   'com.google.fonts/check/metadata/license',
   'com.google.fonts/check/metadata/menu_and_latin',
   'com.google.fonts/check/metadata/subsets_order',
+  'com.google.fonts/check/metadata/includes_production_subsets',
   'com.google.fonts/check/metadata/copyright',
   'com.google.fonts/check/metadata/familyname',
   'com.google.fonts/check/metadata/has_regular',
@@ -1808,6 +1809,35 @@ def com_google_fonts_check_metadata_subsets_order(family_metadata):
                               "', '".join(expected)))
   else:
     yield PASS, "METADATA.pb subsets are sorted in alphabetical order."
+
+
+@check(
+  id = 'com.google.fonts/check/metadata/includes_production_subsets',
+  conditions = ['family_metadata',
+                'production_metadata',
+                'listed_on_gfonts_api'],
+  rationale = """
+    Check METADATA.pb file includes the same subsets as the family in production.
+  """,
+  misc_metadata = {
+    'request': 'https://github.com/googlefonts/fontbakery/issues/2989'
+  }
+)
+def com_google_fonts_check_metadata_includes_production_subsets(family_metadata, production_metadata):
+  """Check METADATA.pb includes production subsets."""
+  prod_families_metadata = {i['family']: i for i in production_metadata["familyMetadataList"]}
+  prod_family_metadata = prod_families_metadata[family_metadata.name]
+
+  prod_subsets = set(prod_family_metadata["subsets"])
+  local_subsets = set(family_metadata.subsets)
+  missing_subsets = prod_subsets - local_subsets
+  if len(missing_subsets) > 0:
+    yield FAIL, Message(
+      "missing-subsets",
+      f"The following subsets are missing [{', '.join(missing_subsets)}]"
+    )
+  else:
+    yield PASS, "No missing subsets"
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -540,3 +540,13 @@ def gfonts_repo_structure(fonts):
   #        about the expected structure.
   abspath = get_absolute_path(fonts[0])
   return abspath.split(os.path.sep)[-3] in ["ufl", "ofl", "apache"]
+
+
+@condition
+def production_metadata():
+  """Get the Google Fonts production metadata"""
+  import json
+  import requests
+  meta_url = "http://fonts.google.com/metadata/fonts"
+  # can't do requests.get("url").json() since request text starts with ")]}'"
+  return json.loads(requests.get(meta_url).text[5:])

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1239,6 +1239,29 @@ def test_check_metadata_subsets_order():
                            f'with subsets = {bad}')
 
 
+def test_check_metadata_includes_production_subsets():
+  """Check METADATA.pb has production subsets."""
+  from fontbakery.profiles.googlefonts import (
+    com_google_fonts_check_metadata_includes_production_subsets as check,
+  )
+  from fontbakery.profiles.googlefonts_conditions import production_metadata, family_metadata
+  from fontbakery.profiles.shared_conditions import family_directory
+
+  # We need to use a family that is already in production
+  # Our reference Cabin is known to be good
+  family_meta = family_metadata(family_directory(cabin_fonts[0]))
+
+  # So it must PASS the check:
+  assert_PASS(check(family_meta, production_metadata()),
+              "with a good METADATA.pb for this family...")
+
+  # Then we FAIL the check by removing a subset:
+  family_meta.subsets.pop()
+  assert_results_contain(check(family_meta, production_metadata()),
+                         FAIL, 'missing-subsets',
+                         'with a bad METADATA.pb (last subset has been removed)...')
+
+
 def test_check_metadata_copyright():
   """ METADATA.pb: Copyright notice is the same in all fonts? """
   from fontbakery.profiles.googlefonts import (com_google_fonts_check_metadata_copyright as check,


### PR DESCRIPTION
Ensure METADATA.pb files include production subsets.

Fixes #2989