### PR TITLE
Refactor listed_on_gfonts_api condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.8.0 (2020-Jul-??)
 ### Note-worthy code changes
-  - remove PriorityLevel class as it makes classifying checks by priority more complicated then necessary! (issue #2981)
+  - Remove PriorityLevel class as it makes classifying checks by priority more complicated then necessary! (issue #2981)
+  - Use the http://fonts.google.com/metadata/fonts endpoint to determine if a font is listed in Google Fonts. (issue #2991)
 
 ### New Checks
   - **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2986)

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -324,24 +324,21 @@ def hinting_stats(font):
 
 @condition
 def listed_on_gfonts_api(familyname):
-  from fontbakery.utils import split_camel_case
   if not familyname:
     return False
 
-  def query_gfonts(fname):
-    import requests
-    queryname = fname.replace(' ', '+')
-    url = ('http://fonts.googleapis.com'
-         '/css?family={}').format(queryname)
-    r = requests.get(url)
-    return r.status_code == 200
+  from fontbakery.utils import split_camel_case
+  # Some families such as "Libre Calson Text" have camelcased filenames
+  # ("LibreCalsonText-Regular.ttf") and require us to split in order
+  # to find it in the GFonts metadata:
+  from_camelcased_name = split_camel_case(familyname)
 
-  if query_gfonts(familyname): return True
+  for item in production_metadata()["familyMetadataList"]:
+    if item["family"] == familyname or \
+       item["family"] == from_camelcased_name:
+      return True
 
-  # else...
-  # Some families such as "Libre Calson Text" have camelcased filenames ("LibreCalsonText-Regular.ttf")
-  # and require us to split in order to properly form a good query URL:
-  return query_gfonts(split_camel_case(familyname))
+  return False
 
 
 @condition

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1083,7 +1083,7 @@ def test_check_metadata_listed_on_gfonts():
   # This is to ensure the code handles well camel-cased familynames.
   listed = listed_on_gfonts_api(familyname(filename))
   assert_PASS(check(listed),
-              f'with "{filename}", listeed and with a camel-cased name...')
+              f'with "{filename}", listed and with a camel-cased name...')
 
   filename = "librecaslontext/LibreCaslonText[wght].ttf"
   # And the check should also properly handle space-separated multi-word familynames.


### PR DESCRIPTION
Use the http://fonts.google.com/metadata/fonts endpoint to determine if a font is listed in Google Fonts.
(issue #2991)