### PR TITLE
Add flake8 config

### DIFF
--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -547,7 +547,7 @@ def DISABLED_test_check_family_equal_numbers_of_glyphs(mada_ttFonts, cabin_ttFon
 
   # our reference Mada family is bad here with 407 glyphs on most font files
   # except the Black and the Medium, that both have 408 glyphs.
-  asser_results_contain(check(mada_ttFonts),
+  assert_results_contain(check(mada_ttFonts),
                         FAIL, 'glyph-count-diverges',
                         'with fonts that diverge on number of glyphs.')
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -548,8 +548,8 @@ def DISABLED_test_check_family_equal_numbers_of_glyphs(mada_ttFonts, cabin_ttFon
   # our reference Mada family is bad here with 407 glyphs on most font files
   # except the Black and the Medium, that both have 408 glyphs.
   assert_results_contain(check(mada_ttFonts),
-                        FAIL, 'glyph-count-diverges',
-                        'with fonts that diverge on number of glyphs.')
+                         FAIL, 'glyph-count-diverges',
+                         'with fonts that diverge on number of glyphs.')
 
 
 # TODO: re-enable after addressing issue #1998

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1,4 +1,5 @@
 import pytest
+import io
 import os
 from fontTools.ttLib import TTFont
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ ignore =
     E712, # comparison to True should be 'if cond is True:' or 'if cond:'
     E713, # test for membership should be 'not in'
     E722, # do not use bare 'except'
+    E741, # ambiguous variable name
     F401, # '<module>' imported but unused
     F403, # 'from <module> import *' used; unable to detect undefined names
     F405, # '<name>' may be undefined, or defined from star imports
@@ -98,6 +99,7 @@ ignore =
     E701, # multiple statements on one line (colon)
     E704, # multiple statements on one line (def)
     E731, # do not assign a lambda expression, use a def
+    F541, # f-string is missing placeholders
     W191, # indentation contains tabs
     W291, # trailing whitespace
     W293, # blank line contains whitespace

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,7 @@ deps =
     sphinx
     sphinx_rtd_theme
     recommonmark
-test_list = E901,E999,F821,F822,F823
-commands = flake8 --count --select={[testenv:flake8]test_list} --show-source --statistics Lib
+commands = flake8 --count --show-source --statistics
 
 # Same rationale as with flake8.
 [testenv:pylint]
@@ -38,3 +37,70 @@ deps =
 wont_fix = invalid-name,bad-indentation,inconsistent-return-statements,too-many-return-statements,too-many-public-methods
 maybe_someday = fixme,missing-docstring,too-many-locals,too-many-branches,too-many-statements,bad-continuation,unidiomatic-typecheck,logging-format-interpolation,too-many-nested-blocks,superfluous-parens,bare-except,undefined-loop-variable,too-many-instance-attributes,old-style-class,unnecessary-pass,unused-argument,consider-iterating-dictionary,attribute-defined-outside-init,too-many-boolean-expressions,too-many-arguments,wrong-import-order,bad-whitespace,pointless-string-statement,pointless-statement,redefined-builtin,global-statement,too-many-lines,global-variable-undefined,redefined-variable-type,multiple-statements,expression-not-assigned,too-many-format-args,deprecated-lambda,broad-except,no-self-use,no-name-in-module,abstract-method,no-member,line-too-long,trailing-newlines,duplicate-code,redefined-outer-name,trailing-whitespace,unused-variable,logging-not-lazy,undefined-variable,protected-access,anomalous-backslash-in-string,wrong-import-position,ungrouped-imports,singleton-comparison,misplaced-comparison-constant,consider-using-enumerate,used-before-assignment,too-few-public-methods,dangerous-default-value,unexpected-keyword-arg,len-as-condition,no-else-return,relative-import,not-callable,unsupported-membership-test,keyword-arg-before-vararg,consider-using-ternary,useless-return,chained-comparison,consider-using-in,useless-object-inheritance,no-else-raise,c-extension-no-member,import-outside-toplevel,unnecessary-comprehension,unused-import
 commands = pylint --disable={[testenv:pylint]wont_fix},{[testenv:pylint]maybe_someday} Lib/fontbakery
+
+[flake8]
+select = E,F,W
+# max-line-length=88  # un-comment when E501 is removed from ignore
+ignore = 
+    # ITEMS AT THE TOP OF THIS LIST SHOULD BE FIXED IN CODE SOON
+    # ONCE FIXED, REMOVE FROM IGNORE LIST
+    F841, # local variable '<name>' is assigned to but never used
+    W605, # invalid escape sequence
+
+    # ITEMS BELOW ARE MEDIUM PRIORITY TO FIX AND REMOVE FROM IGNORE LIST
+    E402, # module level import not at top of file
+    E711, # comparison to None should be 'if cond is None
+    E712, # comparison to True should be 'if cond is True:' or 'if cond:'
+    E713, # test for membership should be 'not in'
+    E722, # do not use bare 'except'
+    F401, # '<module>' imported but unused
+    F403, # 'from <module> import *' used; unable to detect undefined names
+    F405, # '<name>' may be undefined, or defined from star imports
+
+    # ITEMS BELOW ARE LOWER PRIORITY TO FIX AND REMOVE FROM IGNORE LIST
+    E101, # indentation contains mixed spaces and tabs
+    E111, # indentation is not a multiple of four
+    E114, # indentation is not a multiple of four (comment)
+    E116, # unexpected indentation (comment)
+    E117, # over-indented (comment)
+    E121, # continuation line under-indented for hanging indent
+    E122, # continuation line missing indentation or outdented
+    E123, # closing bracket does not match indentation of opening bracket's line
+    E124, # closing bracket does not match visual indentation
+    E125, # continuation line with same indent as next logical line
+    E126, # continuation line over-indented for hanging indent
+    E127, # continuation line over-indented for visual indent
+    E128, # continuation line under-indented for visual indent
+    E129, # visually indented line with same indent as next logical line
+    E131, # continuation line unaligned for hanging indent
+    E201, # whitespace after '{'
+    E202, # whitespace before ')'
+    E203, # whitespace before ','
+    E211, # whitespace before '('
+    E221, # multiple spaces before operator
+    E222, # multiple spaces after operator
+    E225, # missing whitespace around operator
+    E226, # missing whitespace around arithmetic operator
+    E231, # missing whitespace after ','
+    E241, # multiple spaces after ':'
+    E251, # unexpected spaces around keyword / parameter equals
+    E261, # at least two spaces before inline comment
+    E262, # inline comment should start with '# '
+    E265, # block comment should start with '# '
+    E266, # too many leading '#' for block comment
+    E272, # multiple spaces before keyword
+    E302, # expected <n> blank lines, found <m>
+    E303, # too many blank lines (<n>)
+    E305, # expected 2 blank lines after class or function definition, found <n>
+    E306, # expected 1 blank line before a nested definition, found <n>
+    E501, # line too long
+    E502, # the backslash is redundant between brackets
+    E701, # multiple statements on one line (colon)
+    E704, # multiple statements on one line (def)
+    E731, # do not assign a lambda expression, use a def
+    W191, # indentation contains tabs
+    W291, # trailing whitespace
+    W293, # blank line contains whitespace
+    W391, # blank line at end of file
+    W503, # line break before binary operator
+    W504, # line break after binary operator


### PR DESCRIPTION
## Description
This pull request adds a `[flake8]` configuration block to `tox.ini`, to enable flake8 to be used with a consistent configuration and to encourage developers to use it frequently during development ("live" linting is supported by many IDEs).

The configuration is currently set up to ignore quite a few checks. That is intentional so that we don't suddenly start blocking PRs based on failed flake8 checks. @cjchapman and I did some analysis of the current state of the fontbakery codebase and made a rough attempt to prioritize the ignored checks to guide developer efforts on updating the code and removing checks from the ignore list gradually (see #2996).

To demonstrate the benefit of using flake8, we ran with this new config locally across the entire codebase (including tests) and discovered two `F821` errors (undefined name) in 2 separate test files. These were fixed and are included in this PR. They were previously not caught because the flake8 check in CI was only run on the 'Lib' folder. Note that this PR also updates the `[testenv:flake8]` block to run on the entire codebase now.

Closes #2995.