### PR TITLE
fix version tolerance in com.google.fonts/check/font_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2986)
   - **[com.google.fonts/check/metadata/includes_production_subsets]**: ensure METADATA.pb files include production subsets. (issue #2989)
 
+### Changes to existing checks
+  - **[com.google.fonts/check/font_version]**: fixed tolerance for warnings (PR #3009)
+
 ### Bugfixes
   - Fix ERROR in com.google.fonts/check/STAT_strings (issue #2992)
 

--- a/Lib/fontbakery/profiles/head.py
+++ b/Lib/fontbakery/profiles/head.py
@@ -110,9 +110,9 @@ def com_google_fonts_check_font_version(ttFont):
     # Get font version from the head table as an exact Fraction.
     head_version = fractions.Fraction(ttFont["head"].fontRevision)
 
-    # 0.5/0x10000 is the best achievable when converting a decimal
+    # 1/0x10000 is the best achievable when converting a decimal
     # to 16.16 Fixed point.
-    warn_tolerance = 0.5/0x10000
+    warn_tolerance = 1/0x10000
     # Some tools aren't that accurate and only care to do a
     # conversion to 3 decimal places.
     # 1/2000 is the tolerance for accepting equality to 3 decimal places.

--- a/tests/profiles/head_test.py
+++ b/tests/profiles/head_test.py
@@ -122,7 +122,7 @@ def test_check_font_version():
     # See more detailed discussion at:
     # https://github.com/googlefonts/fontbakery/issues/2006
     test_font = TTFont(test_font_path)
-    test_font["head"].fontRevision = 1.00099
+    test_font["head"].fontRevision = 1.00098
     test_font["name"].setName("Version 1.001", 5, 1, 0, 0x0)
     test_font["name"].setName("Version 1.001", 5, 3, 1, 0x409)
 


### PR DESCRIPTION
Change `warn_tolerance` to `1/0x10000`.

Here's an example of why the old tolerance of `0.5/0x10000` is incorrect:

```
>>> x = 3.505
>>> y = int(x * 0x10000)
>>> z = y/0x10000
>>> (x-z) * 0x10000
0.6799999999930151
```

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for checks to pass (except `github/pages`, which is stuck)
- [x] request a review

