### PR TITLE
Ensure fsSelection bit 7 is enabled for VFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - All rationale text needs to have 8 indentation spaces (because this indentation on the source should not show up on the user-interface when rationale text is printed on the text terminal)
   - Remove PriorityLevel class as it makes classifying checks by priority more complicated then necessary! (issue #2981)
   - Use the http://fonts.google.com/metadata/fonts endpoint to determine if a font is listed in Google Fonts. (issue #2991)
+  - Style condition will now work on variable fonts. Since the style name cannot be inferred from the filename for a variable font, we have to use the Typographic Subfamily name or Subfamily name instead.
 
 ### New Checks
   - **[com.google.fonts/check/varfont_duplicate_instance_names]**: Avoid duplicate instance names in variable fonts (issue #2986)
@@ -17,6 +18,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/font_version]**: fixed tolerance for warnings (PR #3009)
   - **[com.google.fonts/check/fontbakery_version]**: use pip_api module and PyPI JSON API instead of invoking command-line pip/pip3 via subprocess (#2966)
+  - **[com.google.fonts/check/fsselection]**: Ensure fsSelection bit 7 (USE_TYPO_METRICS) is enabled for variable fonts.
 
 ### Bugfixes
   - Fix ERROR in com.google.fonts/check/STAT_strings (issue #2992)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2843,6 +2843,14 @@ def com_google_fonts_check_fsselection(ttFont, style):
                           bitmask=FsSelection.BOLD,
                           bitname="BOLD")
 
+    # Checking fsSelection bit 7 is enabled for variable fonts:
+    if is_variable_font(ttFont):
+        yield check_bit_entry(ttFont, "OS/2", "fsSelection",
+                              True,
+                              bitmask=FsSelection.USETYPOMETRICS,
+                              bitname="USE_TYPO_METRICS")
+
+
 
 @check(
     id = 'com.google.fonts/check/italic_angle',

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1473,7 +1473,7 @@ def test_check_metadata_nameid_font_name():
     family_directory = os.path.dirname(font)
     family_meta = family_metadata(family_directory)
     font_meta = font_metadata(family_meta, font)
-    font_style = style(font)
+    font_style = style(ttFont)
     assert_PASS(check(ttFont, font_style, font_meta),
                 'with a good font...')
 
@@ -1590,7 +1590,7 @@ def test_check_metadata_valid_name_values():
     # Our reference Montserrat family is a good 18-styles family:
     for fontfile in MONTSERRAT_RIBBI:
         ttFont = TTFont(fontfile)
-        font_style = style(fontfile)
+        font_style = style(ttFont)
         family_directory = os.path.dirname(fontfile)
         family_meta = family_metadata(family_directory)
         font_meta = font_metadata(family_meta, fontfile)
@@ -1610,7 +1610,7 @@ def test_check_metadata_valid_name_values():
     #we do the same for NON-RIBBI styles:
     for fontfile in MONTSERRAT_NON_RIBBI:
         ttFont = TTFont(fontfile)
-        font_style = style(fontfile)
+        font_style = style(ttFont)
         family_directory = os.path.dirname(fontfile)
         family_meta = family_metadata(family_directory)
         font_meta = font_metadata(family_meta, fontfile)
@@ -1644,7 +1644,7 @@ def test_check_metadata_valid_full_name_values():
     # Our reference Montserrat family is a good 18-styles family:
     for fontfile in MONTSERRAT_RIBBI:
         ttFont = TTFont(fontfile)
-        font_style = style(fontfile)
+        font_style = style(ttFont)
         family_directory = os.path.dirname(fontfile)
         family_meta = family_metadata(family_directory)
         font_meta = font_metadata(family_meta, fontfile)
@@ -1664,7 +1664,7 @@ def test_check_metadata_valid_full_name_values():
     #we do the same for NON-RIBBI styles:
     for fontfile in MONTSERRAT_NON_RIBBI:
         ttFont = TTFont(fontfile)
-        font_style = style(fontfile)
+        font_style = style(ttFont)
         family_directory = os.path.dirname(fontfile)
         family_meta = family_metadata(family_directory)
         font_meta = font_metadata(family_meta, fontfile)
@@ -2363,7 +2363,7 @@ def DISABLED_test_check_production_encoded_glyphs(cabin_ttFonts):
     if remote:
         for font in cabin_fonts:
             ttFont = TTFont(font)
-            gfont = api_gfonts_ttFont(style(font), remote)
+            gfont = api_gfonts_ttFont(style(ttFont), remote)
 
             # Cabin font hosted on fonts.google.com contains
             # all the glyphs for the font in data/test/cabin
@@ -2542,11 +2542,11 @@ def test_check_name_familyname():
             if name.nameID == NameID.FONT_FAMILY_NAME:
                 ttFont['name'].names[i].string = value.encode(name.getEncoding())
         assert_results_contain(check(ttFont,
-                                     style(filename),
+                                     style(ttFont),
                                      familyname_with_spaces(familyname(filename))),
                                      expected, keyword,
                                      f'with filename="{filename}",'
-                                     f' value="{value}", style="{style(filename)}"...')
+                                     f' value="{value}", style="{style(ttFont)}"...')
 
 
 def test_check_name_subfamilyname():
@@ -2690,14 +2690,14 @@ def test_check_name_typographicfamilyname():
     font = TEST_FILE("montserrat/Montserrat-BoldItalic.ttf")
     ttFont = TTFont(font)
     assert_PASS(check(ttFont,
-                      style(font),
+                      style(ttFont),
                       familyname_with_spaces(familyname(font))),
                 f"with a RIBBI without nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
 
     # so we add one and make sure is emits a FAIL:
     ttFont['name'].names[5].nameID = NameID.TYPOGRAPHIC_FAMILY_NAME # 5 is arbitrary here
     assert_results_contain(check(ttFont,
-                                 style(font),
+                                 style(ttFont),
                                  familyname_with_spaces(familyname(font))),
                            FAIL, 'ribbi',
                            f'with a RIBBI that has got a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...')
@@ -2706,7 +2706,7 @@ def test_check_name_typographicfamilyname():
     font = TEST_FILE("montserrat/Montserrat-ExtraLight.ttf")
     ttFont = TTFont(font)
     assert_PASS(check(ttFont,
-                style(font),
+                style(ttFont),
                 familyname_with_spaces(familyname(font))),
                 f"with a non-RIBBI containing a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...")
 
@@ -2716,7 +2716,7 @@ def test_check_name_typographicfamilyname():
             ttFont['name'].names[i].string = "foo".encode(name.getEncoding())
 
     assert_results_contain(check(ttFont,
-                                 style(font),
+                                 style(ttFont),
                                  familyname_with_spaces(familyname(font))),
                            FAIL, 'non-ribbi-bad-value',
                            'with a non-RIBBI with bad nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entries...')
@@ -2728,7 +2728,7 @@ def test_check_name_typographicfamilyname():
             ttFont['name'].names[i].nameID = 255 # blah! :-)
 
     assert_results_contain(check(ttFont,
-                                 style(font),
+                                 style(ttFont),
                                  familyname_with_spaces(familyname(font))),
                            FAIL, 'non-ribbi-lacks-entry',
                            f'with a non-RIBBI lacking a nameid={NameID.TYPOGRAPHIC_FAMILY_NAME} entry...')


### PR DESCRIPTION
We recently pushed Merriweather Sans VF and it didn't have this bit enabled. This caused the following issue, https://github.com/google/fonts/issues/2631

According to the MS Spec it should be enabled for variable fonts anyway:

> In variable fonts, default line metrics should always be set using the sTypoAscender, sTypoDescender and sTypoLineGap values, and the USE_TYPO_METRICS flag in the fsSelection field should be set. 

https://docs.microsoft.com/en-us/typography/opentype/spec/os2#os2-table-and-opentype-font-variations


I've also updated the style condition so it will work on variable fonts and also added the missing unit test for the fsselection check.


@felipesanches once this is merged, I'll also update the vertical metrics regression check. I'll take another look at this pr later. I want to start submitting better PRs so you don't end up wasting your time correcting my lint errors errors etc.
