### PR TITLE
Ignore zero width glyphs in the monospace glyph warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.31 (2020-Oct-??)
-  - Updated `com.google.fonts/check/monospace` to not report zero width (mark) glyphs
+  - ...
 
 
 ## 0.7.30 (2020-Sept-24)
@@ -26,6 +26,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/varfont/stat_axis_record_for_each_axis]**: ensure the STAT table has an Axis Record for every axis in the font (PR #3017)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/monospace]**: Updated to not report zero width (mark) glyphs (issue #3036)
   - **[com.google.fonts/check/font_version]**: fixed tolerance for warnings (PR #3009)
   - **[com.google.fonts/check/fontbakery_version]**: use pip_api module and PyPI JSON API instead of invoking command-line pip/pip3 via subprocess (#2966)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.31 (2020-Oct-??)
-  - ...
+  - Updated `com.google.fonts/check/monospace` to not report zero width (mark) glyphs
 
 
 ## 0.7.30 (2020-Sept-24)

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -148,6 +148,7 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
         unusually_spaced_glyphs = [
             g for g in ttFont['glyf'].glyphs
             if g not in ['.notdef', '.null', 'NULL'] and
+            ttFont['hmtx'].metrics[g][0] != 0 and
             ttFont['hmtx'].metrics[g][0] != most_common_width
         ]
         outliers_ratio = float(len(unusually_spaced_glyphs)) / num_glyphs


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #3036

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

