### PR TITLE
A couple new checks for the GF Axis Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.7.32 (2020-Oct-??)
-  - ...
+### New checks
+  - **[com.google.fonts/check/metadata/gf-axisregistry_valid_tags]:** VF axis tags are registered on GF Axis Registry (issue #3010)
+  - **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** VF axes have ranges compliant to the bounds specified on the GF Axis Registry (issue #3022)
 
 
 ## 0.7.31 (2020-Sept-24)

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -547,3 +547,12 @@ def production_metadata():
     meta_url = "http://fonts.google.com/metadata/fonts"
     # can't do requests.get("url").json() since request text starts with ")]}'"
     return json.loads(requests.get(meta_url).text[5:])
+
+
+@condition
+def gfaxisregistry(production_metadata):
+  registry = {}
+  for entry in production_metadata['axisRegistry']:
+    registry[entry["tag"]] = entry
+  return registry
+

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ commands = pylint --disable={[testenv:pylint]wont_fix},{[testenv:pylint]maybe_so
 select = E,F,W
 
 exclude =
+# Exclude the entire build directory:
+    build
 # Exclude this auto-generated file that should not be hand-edited:
     Lib/fontbakery/fonts_public_pb2.py,
 # No need to traverse hidden directories such as .git, .tox


### PR DESCRIPTION
- **[com.google.fonts/check/metadata/gf-axisregistry_valid_tags]:** VF axis tags are registered on GF Axis Registry (issue #3010)
- **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** VF axes have ranges compliant to the bounds specified on the GF Axis Registry (issue #3022)