### PR TITLE
Check that particle names on STAT table match the fallback names...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
   - **[com.google.fonts/check/metadata/gf-axisregistry_valid_tags]:** VF axis tags are registered on GF Axis Registry (issue #3010)
   - **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** VF axes have ranges compliant to the bounds specified on the GF Axis Registry (issue #3022)
+  - **[com.google.fonts/check/STAT/gf-axisregistry]:** Check that particle names and values on STAT table match the fallback names in each axis registry at the Google Fonts Axis Registry (issue #3022)
 
 
 ## 0.7.31 (2020-Sept-24)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4839,8 +4839,9 @@ def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont, GFAxisRegistry):
                 passed = False
                 yield FAIL, \
                       Message("bad-coordinate",
-                              (f"Axis Value for '{axis.AxisTag}':'{fb.name}' is expected to be 'fb.value'"
-                               f" but this font has '{fb.name}'='{axis_value.Value}'."))
+                              (f"Axis Value for '{axis.AxisTag}':'{name_entry.toUnicode()}' is"
+                               f" expected to be 'fallbacks[name_entry.toUnicode()]'"
+                               f" but this font has '{name_entry.toUnicode()}'='{axis_value.Value}'."))
 
     if passed:
         yield PASS, "OK"

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -555,10 +555,16 @@ def GFAxisRegistry():
     from fontbakery.utils import get_Protobuf_Message
     from pkg_resources import resource_filename
 
+    def normalize_name(name):
+        return ''.join(name.split(' '))
+
     registry = {}
     def append_AxisMessage(path):
-        message = get_Protobuf_Message(AxisProto, path)
-        registry[message.tag] = message
+        axis_dict = {"message": get_Protobuf_Message(AxisProto, path),
+                     "fallbacks": {}}
+        for fb in axis_dict["message"].fallback:
+            axis_dict["fallbacks"][normalize_name(fb.name)] = fb.value
+        registry[axis_dict["message"].tag] = axis_dict
 
     for axis in ["casual.textproto",
                  "cursive.textproto",

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3408,3 +3408,25 @@ def test_check_gf_axisregistry_valid_tags():
     assert_results_contain(check(ttFont, {"family_metadata": md}),
                            FAIL, "bad-axis-tag")
 
+
+def test_check_STAT_gf_axisregistry():
+    """Validate STAT particle names and values match the fallback names in GFAxisRegistry."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/STAT/gf-axisregistry")
+    # Our reference varfont, CabinVF,
+    # has "Regular", instead of "Roman" in its 'ital' axis on the STAT table:
+    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
+    assert_results_contain(check(ttFont),
+                           FAIL, "invalid-name")
+
+    # LibreCaslonText is good though:
+    ttFont = TTFont(TEST_FILE("librecaslontext/LibreCaslonText[wght].ttf"))
+    assert_PASS(check(ttFont))
+
+    # Finally, we'll break it by setting an invalid coordinate for "Bold":
+    assert ttFont['STAT'].table.AxisValueArray.AxisValue[3].ValueNameID == ttFont['name'].names[4].nameID
+    assert ttFont['name'].names[4].toUnicode() == "Bold"
+    ttFont['STAT'].table.AxisValueArray.AxisValue[3].Value = 800 # instead of the expected 700
+    # Note: I know it is AxisValue[3] and names[4] because I inspected the font using ttx.
+    assert_results_contain(check(ttFont),
+                           FAIL, "bad-coordinate")


### PR DESCRIPTION
...in each axis registry at the Google Fonts Axis Registry
(issue #3022)

This pull request is marked as a **DRAFT** because it still lacks code-tests. I want to get feedback from @m4rc1e regarding whether this implementation correctly encodes the checking procedures he had in mind for the STAT table when he requested it at #3022. If Marc agrees that this is indeed what we should be checking for, then I'll put the effort to write a few test-case examples in a code-test for this check.
