### PR TITLE
Setup tox to install deps from requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.7.32 (2020-Oct-??)
 ### Note-worthy code changes
   - We now keep a local copy of the Google Fonts Axis Registry textproto files so that the checks do not need to keep always fetch them online at runtime. These files should not change too often, but we should be careful to check for updates on our FontBakery releases. (issue #3022)
+  - Now Travis is configured to use pinned versions of dependencies as described on requirements.txt (issue #3058)
 
 ### New checks
   - **[com.google.fonts/check/metadata/gf-axisregistry_valid_tags]:** VF axis tags are registered on GF Axis Registry (issue #3010)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     coverage
     ufo2ft
+    -rrequirements.txt
 commands = coverage run -m pytest {posargs}
 passenv = LD_LIBRARY_PATH LD_PRELOAD
 


### PR DESCRIPTION
This commit declares an older version of opentype-sanitizer so that it will fail Travis on purpose. Then I'll fix it and it will pass :-)
(issue #3058)