### PR TITLE
Ignore zero advance-width glyphs at com.google.fonts/check/monospace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** VF axes have ranges compliant to the bounds specified on the GF Axis Registry (issue #3022)
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Check that particle names and values on STAT table match the fallback names in each axis registry at the Google Fonts Axis Registry (issue #3022)
 
+### Changes to existing checks
+  - **[com.google.fonts/check/monospace]**: Ignore zero advance-width glyphs (issue #3053)
+
 
 ## 0.7.31 (2020-Sept-24)
 ### Note-worthy code changes

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -159,7 +159,7 @@ def glyph_metrics_stats(ttFont):
     ascii_glyph_names = [ttFont.getBestCmap()[c] for c in range(32, 128)
                          if c in ttFont.getBestCmap()]
     ascii_widths = [adv for name, (adv, lsb) in glyph_metrics.items()
-                    if name in ascii_glyph_names]
+                    if name in ascii_glyph_names and adv != 0]
     ascii_width_count = Counter(ascii_widths)
     ascii_most_common_width = ascii_width_count.most_common(1)[0][1]
     seems_monospaced = ascii_most_common_width >= len(ascii_widths) * 0.8


### PR DESCRIPTION
(issue #3053)