### PR TITLE
Add caveat about ligature caret support in ufo2ft to check rationale

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3987,6 +3987,8 @@ def com_google_fonts_check_integer_ppem_if_hinted(ttFont):
         All ligatures in a font must have corresponding caret (text cursor) positions defined in the GDEF table, otherwhise, users may experience issues with caret rendering.
 
         If using GlyphsApp, ligature carets can be set directly on canvas by accessing the `Glyph -> Set Anchors` menu option or by pressing the `Cmd+U` keyboard shortcut.
+
+        If designing with UFOs, (as of Oct 2020) ligature carets are not yet compiled by ufo2ft, and therefore will not build via FontMake. See googlefonts/ufo2ft/issues/329
     """,
     misc_metadata = {
         'request': 'https://github.com/googlefonts/fontbakery/issues/1225'


### PR DESCRIPTION
## Description

In both Fraunces and Recursive, a current FontBakery `WARN` is this:

</details>
<details>
<summary>⚠ <b>WARN:</b> Are there caret positions declared for every ligature?</summary>

* [com.google.fonts/check/ligature_carets](https://font-bakery.readthedocs.io/en/latest/fontbakery/profiles/googlefonts.html#com.google.fonts/check/ligature_carets)
<pre>--- Rationale ---

All ligatures in a font must have corresponding caret (text cursor) positions
defined in the GDEF table, otherwhise, users may experience issues with caret
rendering.

If using GlyphsApp, ligature carets can be set directly on canvas by accessing
the `Glyph -&gt; Set Anchors` menu option or by pressing the `Cmd+U` keyboard
shortcut.


</pre>

* ⚠ **WARN** This font lacks caret position values for ligature glyphs on its GDEF table. [code: lacks-caret-pos]

</details>

Unfortunately, this makes no mention of the fact that ligature carets currently aren’t supported in the FontMake UFO build process by ufo2ft. So, I just spent quite awhile adding ligature carets to Fraunces, for no (immediate) purpose. 

It feels like something which might be worth calling out in the rationale, so that future UFO-based projects can either ignore this `WARN` for now, or approach adding these in a post-process instead of directly to UFOs.

So, this simply adds the following to the rationale:

> If designing with UFOs, (as of Oct 2020) ligature carets are not yet compiled by ufo2ft, and therefore will not build via FontMake. See googlefonts/ufo2ft/issues/329

## To Do

This PR is somewhat more for discussion than an immediate suggestion ... do we add this kind of information to rationales, when it has an unknown "expiration date"? Have I written it clearly enough, or should I approach it differently?

If it does seem worth merging, I could later work on these to-do items. Thanks!

- [x] request a pre-review
- [ ] update `CHANGELOG.md`
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

