### PR TITLE
Address a corner case when the most common advance value is zero.

### DIFF
--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -165,7 +165,8 @@ def glyph_metrics_stats(ttFont):
     seems_monospaced = ascii_most_common_width >= len(ascii_widths) * 0.8
 
     width_max = max([adv for k, (adv, lsb) in glyph_metrics.items()])
-    most_common_width = Counter(glyph_metrics.values()).most_common(1)[0][0][0]
+    most_common_width = Counter([g for g in glyph_metrics.values()
+                                 if g[0] != 0]).most_common(1)[0][0][0]
     return {
         "seems_monospaced": seems_monospaced,
         "width_max": width_max,


### PR DESCRIPTION
Then we should ignore it and get the second most common value.
In other words, what we want here is the most common nonzero value.

I think it is extremely unlikely to happen, but this ensures it will also be properly handled if it ever happens.
(issue #3053)
