### PR TITLE
new check: com.google.fonts/check/metadata/consistent_axis_enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Now Travis is configured to use pinned versions of dependencies as described on requirements.txt (issue #3058)
 
 ### New checks
+  - **[com.google.fonts/check/metadata/consistent_axis_enumeration]:** Validate VF axes on the 'fvar' table match the ones declared on METADATA.pb (issue #3051)
   - **[com.google.fonts/check/metadata/gf-axisregistry_valid_tags]:** VF axis tags are registered on GF Axis Registry (issue #3010)
   - **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** VF axes have ranges compliant to the bounds specified on the GF Axis Registry (issue #3022)
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Check that particle names and values on STAT table match the fallback names in each axis registry at the Google Fonts Axis Registry (issue #3022)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3430,3 +3430,22 @@ def test_check_STAT_gf_axisregistry():
     # Note: I know it is AxisValue[3] and names[4] because I inspected the font using ttx.
     assert_results_contain(check(ttFont),
                            FAIL, "bad-coordinate")
+
+
+def test_check_metadata_consistent_axis_enumeration():
+    """Validate VF axes match the ones declared on METADATA.pb."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/metadata/consistent_axis_enumeration")
+    # The axis tags of CabinVF,
+    # are properly declared on its METADATA.pb:
+    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
+    assert_PASS(check(ttFont))
+
+    md = check["family_metadata"]
+    md.axes[1].tag = "wdth" # this effectively removes the "wght" axis while not adding an extra one
+    assert_results_contain(check(ttFont, {"family_metadata": md}),
+                           FAIL, "missing-axes")
+
+    md.axes[1].tag = "ouch" # and this is an unwanted extra axis
+    assert_results_contain(check(ttFont, {"family_metadata": md}),
+                           FAIL, "extra-axes")


### PR DESCRIPTION
Validate VF axes on the fvar table match the ones declared on METADATA.pb (issue #3051)