### PR TITLE
new check: com.google.fonts/check/STAT/axis_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Now Travis is configured to use pinned versions of dependencies as described on requirements.txt (issue #3058)
 
 ### New checks
+  - **[com.google.fonts/check/STAT/axis_order]:** INFO-level check to gather stats on usage of the STAT table AxisOrdering field. May be updated in the future to enforce some ordering scheme yet to be defined. (issue #3049)
   - **[com.google.fonts/check/metadata/consistent_axis_enumeration]:** Validate VF axes on the 'fvar' table match the ones declared on METADATA.pb (issue #3051)
   - **[com.google.fonts/check/metadata/gf-axisregistry_valid_tags]:** VF axis tags are registered on GF Axis Registry (issue #3010)
   - **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** VF axes have ranges compliant to the bounds specified on the GF Axis Registry (issue #3022)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3449,3 +3449,23 @@ def test_check_metadata_consistent_axis_enumeration():
     md.axes[1].tag = "ouch" # and this is an unwanted extra axis
     assert_results_contain(check(ttFont, {"family_metadata": md}),
                            FAIL, "extra-axes")
+
+
+def test_check_STAT_axis_order():
+    """Check axis ordering on the STAT table."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/STAT/axis_order")
+
+    fonts = [TEST_FILE("cabinvf/Cabin[wdth,wght].ttf")]
+    assert_results_contain(check(fonts),
+                           INFO, "summary")
+
+    fonts = [TEST_FILE("merriweather/Merriweather-Regular.ttf")]
+    assert_results_contain(check(fonts),
+                           SKIP, "missing-STAT")
+
+    # A real-world case here would be a corrupted TTF file.
+    # This clearly is not a TTF, but is good enough for testing:
+    fonts = [TEST_FILE("merriweather/METADATA.pb")]
+    assert_results_contain(check(fonts),
+                           ERROR, "bad-font")


### PR DESCRIPTION
INFO-level check to gather stats on usage of the STAT table AxisOrdering field.
May be updated in the future to enforce some ordering scheme yet to be defined.
(issue #3049)