### PR TITLE
Output string rendering in com_google_fonts_check_STAT_gf_axisregistry_names

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4845,7 +4845,7 @@ def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont, GFAxisRegistry):
                 yield FAIL, \
                       Message("bad-coordinate",
                               (f"Axis Value for '{axis.AxisTag}':'{name_entry.toUnicode()}' is"
-                               f" expected to be 'fallbacks[name_entry.toUnicode()]'"
+                               f" expected to be '{fallbacks[name_entry.toUnicode()]}'"
                                f" but this font has '{name_entry.toUnicode()}'='{axis_value.Value}'."))
 
     if passed:


### PR DESCRIPTION
## Description
String renders as literal `'fallbacks[name_entry.toUnicode()]'` because not embraced `{}`

## To Do
- [x] update `CHANGELOG.md` (not changing anything here because check is unpublished)
- [ ] wait for checks to pass (except `github/pages`, which is stuck)
- [ ] request a review

