### PR TITLE
Add "metadata_file" as a condition for the escaped_strings check in order to avoid an ERROR whenever the file is not available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## 0.7.32 (2020-Dec-??)
+## 0.7.34 (2020-Dec-??)
   - ...
+
+
+## 0.7.33 (2020-Nov-24)
+### Release note
+  - This is a quick single bug-fix release because the problem below was disrupting the continuous integration setup of several users.
+
+### changes to checks
+  - **[com.google.fonts/check/metadata/escaped_strings]:** Add "metadata_file" as a condition for the check in order to avoid an ERROR whenever the file is not available (issue #3095)
 
 
 ## 0.7.32 (2020-Nov-19)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4901,6 +4901,7 @@ def com_google_fonts_check_STAT_axis_order(fonts):
         In some cases we've seen designer names and other fields with escaped strings in METADATA files.
         Nowadays the strings can be full unicode strings and do not need escaping.
     """,
+    conditions = ["metadata_file"],
     misc_metadata = {
         'request': 'https://github.com/googlefonts/fontbakery/issues/2932'
     }


### PR DESCRIPTION
(issue #3095)