### PR TITLE
com.google.fonts/check/varfont/unsupported_axes: Update rationale that was confusing and outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[com.google.fonts/check/repo/vf_has_static_fonts]:** Downgrade it to WARN-level. (issue #3099)
+  - **[com.google.fonts/check/varfont/unsupported_axes]**: Update rationale that was confusing and outdated (issues #3108 and #2866)
 
 ### Bugfixes
   - **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** Add "family_metadata" as a condition to avoid an ERROR (issue #3104)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4664,11 +4664,11 @@ def com_google_fonts_check_varfont_duplicate_instance_names(ttFont):
 @check(
     id = 'com.google.fonts/check/varfont/unsupported_axes',
     rationale = """
-        The 'ital' axis is not supported yet in Google Chrome. The 'opsz' axis also has patchy support.
+        The 'ital' and 'slnt' axes are not supported yet in Google Chrome.
 
         For the time being, we need to ensure that VFs do not contain either of these axes. Once browser support is better, we can deprecate this check.
 
-        For more info regarding ital and opsz browser support, see:
+        For more info regarding browser support, see:
         https://arrowtype.github.io/vf-slnt-test/
     """,
     conditions = ['is_variable_font'],


### PR DESCRIPTION
(issues #3108 and #2866)