### PR TITLE
fix ERROR on com.google.fonts/check/metadata/consistent_axis_enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/varfont/unsupported_axes]:** Update rationale that was confusing and outdated (issues #3108 and #2866)
 
 ### Bugfixes
+  - **[com.google.fonts/check/metadata/consistent_axis_enumeration]:** Add "family_metadata" as a condition to avoid an ERROR (issue #3122)
   - **[com.google.fonts/check/metadata/gf-axisregistry_bounds]:** Add "family_metadata" as a condition to avoid an ERROR (issue #3104)
   - **[com.google.fonts/check/metadata/gf-axisregistry_valid_tags]:** Add "family_metadata" as a condition to avoid an ERROR (issue #3105)
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4819,7 +4819,8 @@ def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont, GFAxisRegistry):
     rationale = """
         All font variation axes present in the font files must be properly declared on METADATA.pb so that they can be served by the GFonts API.
     """,
-    conditions = ['is_variable_font'],
+    conditions = ['is_variable_font',
+                  'family_metadata'],
     misc_metadata = {
         'request': 'https://github.com/googlefonts/fontbakery/issues/3051'
     }


### PR DESCRIPTION
By adding "family_metadata" as a condition.
(issue #3122)