### PR TITLE
split mandatory_glyphs check into multiple WARNs so that reporting of problems is clearer to users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/mandatory_avar_table]:** Require variable fonts to include an avar table (issue #3100)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/mandatory_glyphs]:** split check into multiple WARNs so that reporting of problems is clearer to users (issue #3086)
   - **[com.google.fonts/check/monospace]:** fix formatting of percentage to only display up to 2 decimals (issue #3117)
   - **[com.google.fonts/check/repo/vf_has_static_fonts]:** Downgrade it to WARN-level. (issue #3099)
   - **[com.google.fonts/check/varfont/unsupported_axes]:** Update rationale that was confusing and outdated (issues #3108 and #2866)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -359,26 +359,39 @@ def com_google_fonts_check_fontbakery_version():
 @check(
     id = 'com.google.fonts/check/mandatory_glyphs',
     rationale = """
-        The OpenType specification v1.8.2 recommends that the first glyph is the .notdef glyph without a codepoint assigned and with a drawing.
+        The OpenType specification v1.8.2 recommends that the first glyph is the '.notdef' glyph without a codepoint assigned and with a drawing.
 
         https://docs.microsoft.com/en-us/typography/opentype/spec/recom#glyph-0-the-notdef-glyph
 
-        Pre-v1.8, it was recommended that a font should also contain a .null, CR and space glyph. This might have been relevant for applications on MacOS 9.
+        Pre-v1.8, it was recommended that fonts should also contain 'space', 'CR' and '.null' glyphs. This might have been relevant for MacOS 9 applications.
     """
 )
 def com_google_fonts_check_mandatory_glyphs(ttFont):
-    """Font contains .notdef as first glyph?"""
+    """Font contains '.notdef' as its first glyph?"""
     from fontbakery.utils import glyph_has_ink
 
-    if (ttFont.getGlyphOrder()[0] == ".notdef"
-        and ".notdef" not in ttFont.getBestCmap().values()
-        and glyph_has_ink(ttFont, ".notdef")):
-        yield PASS, ("Font contains the .notdef glyph as the first glyph, it does "
-                     "not have a Unicode value assigned and contains a drawing.")
-    else:
-        yield WARN, ("Font should contain the .notdef glyph as the first glyph, "
-                     "it should not have a Unicode value assigned and should "
-                     "contain a drawing.")
+    passed = True
+    if ttFont.getGlyphOrder()[0] != ".notdef":
+        passed = False
+        yield WARN,\
+              Message('first-glyph',
+                      "Font should contain the .notdef glyph as the first glyph.")
+
+    if ".notdef" in ttFont.getBestCmap().values():
+        passed = False
+        yield WARN,\
+              Message('codepoint',
+                      f"Glyph '.notdef' should not have a Unicode codepoint value assigned,"
+                      f" but got 0x{ttFont.getBestCmap().values()['.notdef']:04X}.")
+
+    if not glyph_has_ink(ttFont, ".notdef"):
+        passed = False
+        yield WARN,\
+              Message('empty',
+                      "Glyph '.notdef' should contain a drawing, but it is empty.")
+
+    if passed:
+        yield PASS, "OK"
 
 
 @check(

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -339,8 +339,15 @@ def test_check_mandatory_glyphs():
     subsetter = fontTools.subset.Subsetter()
     subsetter.populate(glyphs="n")  # Arbitrarily remove everything except n.
     subsetter.subset(ttFont)
+    # So the check should complaing that the 1st glyph isnt '.notdef':
     assert_results_contain(check(ttFont),
-                           WARN, None) # FIXME: This needs a message keyword
+                           WARN, 'first-glyph')
+
+    # TODO: assert_results_contain(check(ttFont),
+    #                              WARN, 'codepoint')
+
+    # TODO: assert_results_contain(check(ttFont),
+    #                              WARN, 'empty')
 
 
 def test_check_whitespace_glyphs():


### PR DESCRIPTION
com.google.fonts/check/mandatory_glyphs
(issue #3086)