### PR TITLE
new check: Ensure default axis values are registered as fallback on the Google Fonts Axis Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.7.35 (2021-Jan-??)
-  - ...
+### New Profile
+  - new Type Network profile for checking some of their new axis proposals (issue #3130)
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New Profile
   - new Type Network profile for checking some of their new axis proposals (issue #3130)
 
+### New Checks
+  - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults']:** Ensure default axis values are registered as fallback on the Google Fonts Axis Registry (issue #3141)
+
 
 ## 0.7.34 (2021-Jan-06)
 ### New checks

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4775,7 +4775,7 @@ def com_google_fonts_check_gf_axisregistry_fvar_axis_defaults(ttFont, GFAxisRegi
         if axis.defaultValue not in fallbacks.values():
             passed = False
             yield FAIL, \
-                  message('not-registered',
+                  Message('not-registered',
                           f"The defaul value {axis.axisTag}:{axis.defaultValue} is not"
                           f" registered as an axis fallback name on the Google Axis Registry.\n"
                           f"\tYou should consider suggesting the addition of this value to the registry"

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4759,6 +4759,14 @@ def com_google_fonts_check_gf_axisregistry_valid_tags(family_metadata, GFAxisReg
     id = 'com.google.fonts/check/gf-axisregistry/fvar_axis_defaults',
     rationale = """
         Check that axis defaults have a corresponding fallback name registered at the Google Fonts Axis Registry, available at https://github.com/google/fonts/tree/master/axisregistry
+
+        This is necessary for the following reasons:
+
+        To get ZIP files downloads on Google Fonts to be accurate — otherwise the chosen default font is not generated. The Newsreader family, for instance, has a default value on the 'opsz' axis of 16pt. If 16pt was not a registered fallback position, then the ZIP file would instead include another position as default (such as 14pt).
+
+        For the Variable fonts to display the correct location on the specimen page.
+
+        For VF with no weight axis to be displayed at all. For instance, Ballet, which has no weight axis, was not appearing in sandbox because default position on 'opsz' axis was 16pt, and it was not yet a registered fallback positon.
     """,
     conditions = ['is_variable_font',
                   'GFAxisRegistry'],

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -153,6 +153,7 @@ FONT_FILE_CHECKS = [
     'com.google.fonts/check/varfont_duplicate_instance_names',
     'com.google.fonts/check/varfont/consistent_axes',
     'com.google.fonts/check/varfont/unsupported_axes',
+    'com.google.fonts/check/gf-axisregistry/fvar_axis_defaults',
     'com.google.fonts/check/STAT/gf-axisregistry',
     'com.google.fonts/check/STAT/axis_order',
     'com.google.fonts/check/mandatory_avar_table'
@@ -4750,6 +4751,36 @@ def com_google_fonts_check_gf_axisregistry_valid_tags(family_metadata, GFAxisReg
                           f"The font variation axis '{axis.tag}'"
                           f" is not yet registered on Google Fonts Axis Registry.")
 
+    if passed:
+        yield PASS, "OK"
+
+
+@check(
+    id = 'com.google.fonts/check/gf-axisregistry/fvar_axis_defaults',
+    rationale = """
+        Check that axis defaults have a corresponding fallback name registered at the Google Fonts Axis Registry, available at https://github.com/google/fonts/tree/master/axisregistry
+    """,
+    conditions = ['is_variable_font',
+                  'GFAxisRegistry'],
+    misc_metadata = {
+        'request': 'https://github.com/googlefonts/fontbakery/issues/3141'
+    }
+)
+def com_google_fonts_check_gf_axisregistry_fvar_axis_defaults(ttFont, GFAxisRegistry):
+    """ Validate defaults on fvar table match registered fallback names in GFAxisRegistry. """
+
+    passed = True
+    for axis in ttFont['fvar'].axes:
+        fallbacks = GFAxisRegistry[axis.axisTag]["fallbacks"]
+        if axis.defaultValue not in fallbacks.values():
+            passed = False
+            yield FAIL, \
+                  message('not-registered',
+                          f"The defaul value {axis.axisTag}:{axis.defaultValue} is not"
+                          f" registered as an axis fallback name on the Google Axis Registry.\n"
+                          f"\tYou should consider suggesting the addition of this value to the registry"
+                          f" or adopted one of the existing fallback names for this axis:\n"
+                          f"\t{fallbacks}")
     if passed:
         yield PASS, "OK"
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3421,6 +3421,21 @@ def test_check_gf_axisregistry_valid_tags():
                            FAIL, "bad-axis-tag")
 
 
+def test_check_gf_axisregistry_fvar_axis_defaults():
+    """Validate METADATA.pb axes tags are defined in gf-axisregistry."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/gf-axisregistry/fvar_axis_defaults")
+    # The default value for the axes in this reference varfont
+    # are properly registered in the registry:
+    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
+    assert_PASS(check(ttFont))
+
+    # And this value surely doen't map to a fallback name in the registry
+    ttFont['fvar'].axes[0].defaultValue = 123
+    assert_results_contain(check(ttFont),
+                           FAIL, "not-registered")
+
+
 def test_check_STAT_gf_axisregistry():
     """Validate STAT particle names and values match the fallback names in GFAxisRegistry."""
     check = CheckTester(googlefonts_profile,


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #3141