### PR TITLE
googlefonts: newlines in message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New Checks
   - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults']:** Ensure default axis values are registered as fallback on the Google Fonts Axis Registry (issue #3141)
 
+### Changes to existing checks
+  - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
+
 
 ## 0.7.34 (2021-Jan-06)
 ### New checks

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3928,13 +3928,13 @@ def com_google_fonts_check_integer_ppem_if_hinted(ttFont):
                        "This can be accomplished by using the"
                        " 'gftools fix-hinting' command.\n"
                        "\n"
-                       "# create virtualenv"
+                       "# create virtualenv\n"
                        "python3 -m venv venv"
                        "\n"
-                       "# activate virtualenv"
+                       "# activate virtualenv\n"
                        "source venv/bin/activate"
                        "\n"
-                       "# install gftools"
+                       "# install gftools\n"
                        "pip install git+https://www.github.com"
                        "/googlefonts/tools"))
 


### PR DESCRIPTION
This is a followup to pull request #3151 that was automatically closed by mistake when this project renamed its **"master"** branch to **"main"**.

**Be sure to also read all the comments posted in the original PR (#3151)**

Original PR description as submitted on Feb 25, 2021 by @moyogo:
----

## Description
This pull request adds newline to the message of `com.google.fonts/check/integer_ppem_if_hinted`

Before the change the message was:
> This can be accomplished by using the 'gftools fix-hinting' command.
> 
> # create virtualenvpython3 -m venv venv
> 
> # activate virtualenvsource venv/bin/activate
> # install gftoolspip install git+https://www.github.com/googlefonts/tools

After the change the message is:
> This can be accomplished by using the 'gftools fix-hinting' command.
> 
> # create virtualenv
> python3 -m venv venv
> # activate virtualenv
> source venv/bin/activate
> # install gftools
> pip install git+https://www.github.com/googlefonts/tools


## To Do
- [x] update `CHANGELOG.md`
- [x] all checks to pass
- [x] request a review

----
**Be sure to also read all the comments posted in the original PR (#3151)**
