### PR TITLE
Change FILE_MODULE_NAME_PREFIX to '.' fixes #3161

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -1906,7 +1906,7 @@ class Profile:
         return result
 
 
-FILE_MODULE_NAME_PREFIX = 'fontbakery.__file_modules.'
+FILE_MODULE_NAME_PREFIX = '.'
 def get_module_from_file(filename):
     # filename = 'my/path/to/file.py'
     # module_name = 'file_module.file_py'


### PR DESCRIPTION

## Description
This pull request addresses the problems described at issue #3161

It looks like this is sufficient to address the `ImportError` vs. `ModuleNotFoundError` preference as described. It also keeps `-j` multiprocessing mode of `check-profile` working. However, I did not test this with many cases so it may cause regressions.