### PR TITLE
[com.google.fonts/check/STAT/gf-axisregistry] Ensure STAT table has Axis Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
+  - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4812,7 +4812,13 @@ def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont, GFAxisRegistry):
 
     passed = True
     format4_entries = False
-    for axis_value in ttFont['STAT'].table.AxisValueArray.AxisValue:
+    axis_value_array = ttFont['STAT'].table.AxisValueArray
+    if not axis_value_array:
+        yield FAIL, Message("missing-axis-values",
+                            "STAT table is missing Axis Value Records")
+        return
+
+    for axis_value in axis_value_array.AxisValue:
         if axis_value.Format == 4:
             coords = []
             for record in axis_value.AxisValueRecord:

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3450,13 +3450,19 @@ def test_check_STAT_gf_axisregistry():
     ttFont = TTFont(TEST_FILE("librecaslontext/LibreCaslonText[wght].ttf"))
     assert_PASS(check(ttFont))
 
-    # Finally, we'll break it by setting an invalid coordinate for "Bold":
+    # Let's break it by setting an invalid coordinate for "Bold":
     assert ttFont['STAT'].table.AxisValueArray.AxisValue[3].ValueNameID == ttFont['name'].names[4].nameID
     assert ttFont['name'].names[4].toUnicode() == "Bold"
     ttFont['STAT'].table.AxisValueArray.AxisValue[3].Value = 800 # instead of the expected 700
     # Note: I know it is AxisValue[3] and names[4] because I inspected the font using ttx.
     assert_results_contain(check(ttFont),
                            FAIL, "bad-coordinate")
+
+    # Let's remove all Axis Values. This will fail since we Google Fonts
+    # requires them.
+    ttFont['STAT'].table.AxisValueArray = None
+    assert_results_contain(check(ttFont),
+                           FAIL, "missing-axis-values")
 
 
 def test_check_metadata_consistent_axis_enumeration():


### PR DESCRIPTION
If a variable font doesn't contain any Axis Values, the following traceback is raised when using the googlefonts profile:

```
    * ERROR: Failed with AttributeError: 'NoneType' object has no attribute 'AxisValue'
           File "/Users/marcfoley/Type/upstream_families/robotoserif/venv/lib/python3.7/site-packages/fontbakery/checkrunner.py", line 366, in _exec_check
             for sub_result in result:  # Might raise.
           File "/Users/marcfoley/Type/upstream_families/robotoserif/venv/lib/python3.7/site-packages/fontbakery/profiles/googlefonts.py", line 4776, in com_google_fonts_check_STAT_gf_axisregistry_names
             for axis_value in ttFont['STAT'].table.AxisValueArray.AxisValue:
```

This is happening in the check `com.google.fonts/check/STAT/gf-axisregistry`.

The check just assumes that the STAT table will contain Axis Values, when this may not be the case. Since we do expect Axis Values, my pr will fail the check if the STAT AxisValueArray is empty.