### PR TITLE
The `license` condition now accepts multiple license files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## 0.7.35 (2021-Jan-??)
+## 0.7.35 (2021-Mar-??)
 ### Release note
   - Axis Registry has been updated to commit https://github.com/google/fonts/tree/6418bd97834330f245cce4131ec3b8b98cb333be which includes changes to the `opsz` axis.
 
 ### New Profile
   - new Type Network profile for checking some of their new axis proposals (issue #3130)
   - **[com.google.fonts/check/kern_table]:** add FAIL when non-character glyph present, WARN when no format-0 subtable present.
+
+### Bugfixes
+  - **license** condition now assumes that all license files in a given project repo are identical if more than one is found. With that some checks wont be skipped. We should have a fontbakery check to ensuring that assumption is valid, though. (issue #3172)
 
 ### New Checks
   - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults']:** Ensure default axis values are registered as fallback on the Google Fonts Axis Registry (issue #3141)

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -248,8 +248,10 @@ def license_contents(license_path):
 @condition
 def license_path(licenses):
     """Get license path."""
-    # return license if there is exactly one license
-    return licenses[0] if len(licenses) == 1 else None
+    # This assumes that a repo can have multiple license files
+    # and they're all the same.
+    # FIXME: We should have a fontbakery check for that, though!
+    return licenses[0]
 
 
 @condition


### PR DESCRIPTION
It assumes that all license files in a given project repo are identical if more than one is found.
With that some checks wont be skipped.
We should have a fontbakery check to ensuring that assumption is valid, though.
(issue #3172)