### PR TITLE
Status log formating to improve readability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.7.35 (2021-Jan-??)
 ### Release note
   - Axis Registry has been updated to commit https://github.com/google/fonts/tree/6418bd97834330f245cce4131ec3b8b98cb333be which includes changes to the `opsz` axis.
+  - Format status output to improve readability.
 
 ### New Profile
   - new Type Network profile for checking some of their new axis proposals (issue #3130)
@@ -15,7 +16,6 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
-
 
 ## 0.7.34 (2021-Jan-06)
 ### New checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.7.35 (2021-Mar-??)
 ### Release note
   - Axis Registry has been updated to commit https://github.com/google/fonts/tree/6418bd97834330f245cce4131ec3b8b98cb333be which includes changes to the `opsz` axis.
-  - Format status output to improve readability.
+  - Format status output to improve readability. (issue #2052)
 
 ### New Profile
   - new Type Network profile for checking some of their new axis proposals (issue #3130)

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -440,10 +440,17 @@ class TerminalReporter(TerminalProgress):
         # Log statuses have weights >= 0
         # log_statuses = (INFO, WARN, PASS, SKIP, FAIL, ERROR, DEBUG)
         if status.weight >= self._log_threshold:
-            print('    * {}: {}'.format(formatStatus(self.theme, status),
-                                        message))
+            from fontbakery.utils import text_flow
+            status_name = getattr(status, 'name', status)
+            formated_msg = '{} {}'.format(formatStatus(self.theme, status), message)
             if hasattr(message, 'traceback'):
-                print('        ','\n         '.join(message.traceback.split('\n')))
+                formated_msg += '\n' + '\n  ↳ '.join(message.traceback.split('\n'))
+            print(text_flow(formated_msg,
+                            width=76,
+                            indent=4,
+                            first_line_indent=-1 -len(status_name),
+                            left_margin=6,
+                            space_padding=True))
 
 
         if status == ENDCHECK:

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -448,7 +448,7 @@ class TerminalReporter(TerminalProgress):
             print(text_flow(formated_msg,
                             width=76,
                             indent=4,
-                            first_line_indent=-1 -len(status_name),
+                            first_line_indent=-1-len(status_name),
                             left_margin=6,
                             space_padding=True))
 

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -18,9 +18,11 @@ import os
 from fontTools.ttLib import TTFont
 from typing import Text, Optional
 
-def text_flow(content, width=80, indent=0, left_margin=0,
+
+def text_flow(content, width=80, indent=0, left_margin=0, first_line_indent=0,
               space_padding=False, text_color="{}".format):
     result = ""
+    line_num = 0
     for line in content.split("\n"):
         if line.strip() == "":
             if space_padding:
@@ -30,7 +32,13 @@ def text_flow(content, width=80, indent=0, left_margin=0,
 
         words = line.split(" ")
         while words:
-            this_line = " " * left_margin + words.pop(0)
+            line_num += 1
+            if line_num == 1:
+                size = left_margin + first_line_indent
+                inside_indent = " " * size
+            else:
+                inside_indent = " " * left_margin
+            this_line = inside_indent + words.pop(0)
 
             if len(this_line) > width:
                 # let's see what we can do to make it fit

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-
+import re
 import pytest
 
 
@@ -33,6 +33,33 @@ def test_command_check_googlefonts():
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_output(["fontbakery", "check-googlefonts"])
+
+
+def test_status_log_is_indented():
+    """Test if statuses are printed in a limited boundary."""
+    test_font = os.path.join("data", "test", "nunito", "Nunito-Regular.ttf")
+
+    result = subprocess.run(["fontbakery", "check-googlefonts",
+        "-c", "old_ttfautohint", "-c", "font_copyright",
+        test_font], capture_output=True)
+
+    p = re.compile('([^][a-zA-Z0-9@:,.()\'"\n ])', re.I | re.M)
+    stdout = p.sub('#', result.stdout.decode()).split('\n')
+    assert '\n'.join(stdout[24:30]) == '\n'.join([
+    '     #[0#31#40mFAIL#[0m Name Table entry: Copyright notices should match a      ',
+    '          pattern similar to: "Copyright 2019 The Familyname Project Authors    ',
+    '          (git url)"                                                            ',
+    '          But instead we have got:                                              ',
+    '          "Copyright 2014 The Nunito Project Authors (contact@sansoxygen.com)"  ',
+    '          [code: bad#notice#format]                                             '
+    ])
+    assert '\n'.join(stdout[10:15]) == '\n'.join([
+    '     #[0#36#40mINFO#[0m Could not detect which version of ttfautohint was used  ',
+    '          in this font. It is typically specified as a comment in the font      ',
+    "          version entries of the 'name' table. Such font version strings are    ",
+    "          currently: ['Version 3.000', 'Version 3.000'] [code:                  ",
+    '          version#not#detected]                                                 '
+    ])
 
 
 def test_command_check_profile():

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import re
 import pytest
 
@@ -35,6 +36,7 @@ def test_command_check_googlefonts():
         subprocess.check_output(["fontbakery", "check-googlefonts"])
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 def test_status_log_is_indented():
     """Test if statuses are printed in a limited boundary."""
     test_font = os.path.join("data", "test", "nunito", "Nunito-Regular.ttf")


### PR DESCRIPTION
## Description
This pull request aligns the status messages with an indentation that allows to put the status name just before the first line. This layout remembers a "info window" and we can find the same text alignment on a terminal in the arguments lists from most man pages.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

(issue #2052)