### PR TITLE
Use first findable font to check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
-  - **[com.google.fonts/check/repo/dirname_matches_nameid_1]:** Use first findable font to check in case family is single-weight non-regular ("One" appended to family name)
+  - **[com.google.fonts/check/repo/dirname_matches_nameid_1]:** Added hints to GF specs for single-weight families to FAIL output
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
+  - **[com.google.fonts/check/repo/dirname_matches_nameid_1]:** Use first findable font to check in case family is single-weight non-regular ("One" appended to family name)
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4248,24 +4248,22 @@ def com_google_fonts_check_repo_dirname_match_nameid_1(fonts,
     from fontbakery.utils import (get_name_entry_strings,
                                   get_absolute_path,
                                   get_regular)
-    font = get_regular(fonts)
-    if not font:
-        # Family is a single-weight non-regular font, family name has appended "One"
-        if "One-" in fonts[0]:
-            font = fonts[0]
-        # No regular found
-        else:
-            yield FAIL,\
-                Message("lacks-regular",
-                        "The font seems to lack a regular.")
-            return
+    regular = get_regular(fonts)
+    if not regular:
+        yield FAIL,\
+              Message("lacks-regular",
+                      "The font seems to lack a regular."
+                      " If family consists of a single-weight non-Regular style only,"
+                      " consider the Google Fonts specs for this case:"
+                      " https://github.com/googlefonts/gf-docs/tree/main/Spec#single-weight-families")
+        return
 
-    entry = get_name_entry_strings(TTFont(font), NameID.FONT_FAMILY_NAME)[0]
+    entry = get_name_entry_strings(TTFont(regular), NameID.FONT_FAMILY_NAME)[0]
     expected = entry.lower()
     expected = "".join(expected.split(' '))
     expected = "".join(expected.split('-'))
 
-    license, familypath, filename = get_absolute_path(font).split(os.path.sep)[-3:]
+    license, familypath, filename = get_absolute_path(regular).split(os.path.sep)[-3:]
     if familypath == expected:
         yield PASS, "OK"
     else:

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4248,19 +4248,24 @@ def com_google_fonts_check_repo_dirname_match_nameid_1(fonts,
     from fontbakery.utils import (get_name_entry_strings,
                                   get_absolute_path,
                                   get_regular)
-    regular = get_regular(fonts)
-    if not regular:
-        yield FAIL,\
-              Message("lacks-regular",
-                      "The font seems to lack a regular.")
-        return
+    font = get_regular(fonts)
+    if not font:
+        # Family is a single-weight non-regular font, family name has appended "One"
+        if "One-" in fonts[0]:
+            font = fonts[0]
+        # No regular found
+        else:
+            yield FAIL,\
+                Message("lacks-regular",
+                        "The font seems to lack a regular.")
+            return
 
-    entry = get_name_entry_strings(TTFont(regular), NameID.FONT_FAMILY_NAME)[0]
+    entry = get_name_entry_strings(TTFont(font), NameID.FONT_FAMILY_NAME)[0]
     expected = entry.lower()
     expected = "".join(expected.split(' '))
     expected = "".join(expected.split('-'))
 
-    license, familypath, filename = get_absolute_path(regular).split(os.path.sep)[-3:]
+    license, familypath, filename = get_absolute_path(font).split(os.path.sep)[-3:]
     if familypath == expected:
         yield PASS, "OK"
     else:


### PR DESCRIPTION
## Description
Use first findable font to check in case family is single-weight non-regular ("One" appended to family name) in `com.google.fonts/check/repo/dirname_matches_nameid_1`

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

