### PR TITLE
Cater for single-weight non-regular family 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
-  - **[com.google.fonts/check/metadata/has_regular]:** Cater for single-weight non-regular family ("One" appended to family name)
+  - **[com.google.fonts/check/metadata/has_regular]:** Added hints to GF specs for single-weight families to FAIL output
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
+  - **[com.google.fonts/check/metadata/has_regular]:** Cater for single-weight non-regular family ("One" appended to family name)
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1861,14 +1861,16 @@ def com_google_fonts_check_metadata_has_regular(family_metadata):
 
     if has_regular_style(family_metadata):
         yield PASS, "Family has a Regular style."
-    elif family_metadata.name.endswith(" One") and not has_regular_style(family_metadata):
-        yield PASS, "Family is single-weight non-regular ('One' appended to family name)."
     else:
         yield FAIL,\
               Message("lacks-regular",
                       "This family lacks a Regular"
                       " (style: normal and weight: 400)"
-                      " as required by Google Fonts standards.")
+                      " as required by Google Fonts standards."
+                      " "
+                      " If family consists of a single-weight non-Regular style only,"
+                      " consider the Google Fonts specs for this case:"
+                      " https://github.com/googlefonts/gf-docs/tree/main/Spec#single-weight-families")
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1867,7 +1867,6 @@ def com_google_fonts_check_metadata_has_regular(family_metadata):
                       "This family lacks a Regular"
                       " (style: normal and weight: 400)"
                       " as required by Google Fonts standards."
-                      " "
                       " If family consists of a single-weight non-Regular style only,"
                       " consider the Google Fonts specs for this case:"
                       " https://github.com/googlefonts/gf-docs/tree/main/Spec#single-weight-families")

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1861,6 +1861,8 @@ def com_google_fonts_check_metadata_has_regular(family_metadata):
 
     if has_regular_style(family_metadata):
         yield PASS, "Family has a Regular style."
+    elif family_metadata.name.endswith(" One") and not has_regular_style(family_metadata):
+        yield PASS, "Family is single-weight non-regular ('One' appended to family name)."
     else:
         yield FAIL,\
               Message("lacks-regular",

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1854,7 +1854,7 @@ def com_google_fonts_check_metadata_familyname(family_metadata):
     conditions = ['family_metadata']
 )
 def com_google_fonts_check_metadata_has_regular(family_metadata):
-    """METADATA.pb: According Google Fonts standards,
+    """METADATA.pb: According to Google Fonts standards,
        families should have a Regular style.
     """
     from .googlefonts_conditions import has_regular_style


### PR DESCRIPTION
## Description
Cater for single-weight non-regular family ("One" appended to family name) in `com.google.fonts/check/metadata/has_regular`

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

