### PR TITLE
Move reporter-specific write logic to reporters, simplify argparse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+
 ## 0.7.35 (2021-Mar-??)
 ### Release note
   - Axis Registry has been updated to commit https://github.com/google/fonts/tree/6418bd97834330f245cce4131ec3b8b98cb333be which includes changes to the `opsz` axis.
   - Format status output to improve readability. (issue #2052)
+  - Move reporter-specific write logic to reporters, simplify argparse (PR #3206)
 
 ### New Profile
   - new Type Network profile for checking some of their new axis proposals (issue #3130)

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -51,7 +51,7 @@ class AddReporterAction(argparse.Action):
      def __init__(self, option_strings, dest, nargs=None, **kwargs):
         self.cls = kwargs["cls"]
         del kwargs["cls"]
-        super(AddReporterAction, self).__init__(option_strings, dest, **kwargs)
+        super().__init__(option_strings, dest, **kwargs)
 
      def __call__(self, parser, namespace, values, option_string=None):
         if not hasattr(namespace, "reporters"):

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -47,6 +47,18 @@ from fontbakery.reporters.serialize import SerializeReporter
 from fontbakery.reporters.ghmarkdown import GHMarkdownReporter
 from fontbakery.reporters.html import HTMLReporter
 
+class AddReporterAction(argparse.Action):
+     def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        self.cls = kwargs["cls"]
+        del kwargs["cls"]
+        super(AddReporterAction, self).__init__(option_strings, dest, **kwargs)
+
+     def __call__(self, parser, namespace, values, option_string=None):
+        if not hasattr(namespace, "reporters"):
+            namespace.reporters = []
+        namespace.reporters.append((self.cls, values))
+
+
 def ArgumentParser(profile, profile_arg=True):
     argument_parser = \
         argparse.ArgumentParser(description="Check TTF files against a profile.",
@@ -137,16 +149,15 @@ def ArgumentParser(profile, profile_arg=True):
     argument_parser.add_argument('--light-theme', default=False, action='store_true',
                                  help='Use a color theme with light colors.')
 
-    argument_parser.add_argument('--json', default=False, type=argparse.FileType('w'),
+    argument_parser.add_argument('--json', default=False, action=AddReporterAction, cls=SerializeReporter,
                                  metavar= 'JSON_FILE',
                                  help='Write a json formatted report to JSON_FILE.')
 
-    argument_parser.add_argument('--ghmarkdown', default=False, type=argparse.FileType('w'),
+    argument_parser.add_argument('--ghmarkdown', default=False, action=AddReporterAction, cls=GHMarkdownReporter,
                                  metavar= 'MD_FILE',
                                  help='Write a GitHub-Markdown formatted report to MD_FILE.')
 
-    argument_parser.add_argument('--html', default=False,
-                                 type=argparse.FileType('w', encoding="utf-8"),
+    argument_parser.add_argument('--html', default=False,action=AddReporterAction, cls=HTMLReporter,
                                  metavar= 'HTML_FILE',
                                  help='Write a HTML report to HTML_FILE.')
 
@@ -321,46 +332,26 @@ def main(profile=None, values=None):
                          , skip_status_report=None if args.show_sections \
                                                    else (SECTIONSUMMARY, )
                          )
-    reporters = [tr.receive]
+    reporters = [tr]
+    if "reporters" not in args:
+        args.reporters = []
 
-    if args.json:
-        sr = SerializeReporter(runner=runner, collect_results_by=args.gather_by)
-        reporters.append(sr.receive)
-
-    if args.ghmarkdown:
-        mdr = GHMarkdownReporter(loglevels=args.loglevels,
-                                 runner=runner,
-                                 collect_results_by=args.gather_by)
-        reporters.append(mdr.receive)
-
-    if args.html:
-        hr = HTMLReporter(loglevels=args.loglevels,
-                          runner=runner,
-                          collect_results_by=args.gather_by)
-        reporters.append(hr.receive)
+    for reporter_class, output_file in args.reporters:
+        reporters.append(reporter_class(loglevels=args.loglevels,
+                             runner=runner,
+                             collect_results_by=args.gather_by,
+                             output_file=output_file
+                         ))
 
     if args.multiprocessing == 0:
         status_generator = runner.run()
     else:
         status_generator = multiprocessing_runner(args.multiprocessing, runner, runner_kwds)
 
-    distribute_generator(status_generator, reporters)
+    distribute_generator(status_generator, [reporter.receive for reporter in reporters])
 
-    if args.json:
-        import json
-        json.dump(sr.getdoc(), args.json, sort_keys=True, indent=4)
-        print(f'A report in JSON format has been'
-              f' saved to "{args.json.name}"')
-
-    if args.ghmarkdown:
-        args.ghmarkdown.write(mdr.get_markdown())
-        print(f'A report in GitHub Markdown format which can be useful\n'
-              f' for posting issues on a GitHub issue tracker has been\n'
-              f' saved to "{args.ghmarkdown.name}"')
-
-    if args.html:
-        args.html.write(hr.get_html())
-        print(f'A report in HTML format has been saved to "{args.html.name}"')
+    for reporter in reporters:
+        reporter.write()
 
     # Fail and error let the command fail
     return 1 if tr.worst_check_status in (ERROR, FAIL) else 0

--- a/Lib/fontbakery/reporters/__init__.py
+++ b/Lib/fontbakery/reporters/__init__.py
@@ -54,6 +54,14 @@ class FontbakeryReporter:
     def order(self):
         return self._order
 
+    def write(self):
+        if self.output_file is not None:
+            raise NotImplementedError(
+                f'{type(self)} does not implement the "write" method, '
+                'but it has an "output_file".'
+            )
+        # reporters without an output file do nothing here
+
     def _get_key(self, identity):
         section, check, iterargs = identity
         return (str(section) if section else section

--- a/Lib/fontbakery/reporters/__init__.py
+++ b/Lib/fontbakery/reporters/__init__.py
@@ -26,7 +26,7 @@ from fontbakery.checkrunner import (
             )
 
 class FontbakeryReporter:
-    def __init__(self, is_async=False, runner=None):
+    def __init__(self, is_async=False, runner=None, output_file=None, loglevels=None):
         self._started = None
         self._ended = None
         self._order = None
@@ -34,12 +34,14 @@ class FontbakeryReporter:
         self._indexes = {}
         self._tick = 0
         self._counter = Counter()
+        self.loglevels = loglevels
 
         # Runner should know if it is async!
         self.is_async = is_async
         self.runner = runner
 
         self._worst_check_status = None
+        self.output_file = output_file
 
     def run(self, order=None):
         """

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -12,6 +12,13 @@ class GHMarkdownReporter(SerializeReporter):
         super().__init__(**kwd)
         self.loglevels = loglevels
 
+    def write(self):
+        fh = open(self.output_file, "w")
+        fh.write(self.get_markdown())
+        print(f'A report in GitHub Markdown format which can be useful\n'
+              f' for posting issues on a GitHub issue tracker has been\n'
+              f' saved to "{self.output_file}"')
+
 
     def emoticon(self, name):
         return {

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -25,7 +25,12 @@ class HTMLReporter(fontbakery.reporters.serialize.SerializeReporter):
 
     def __init__(self, loglevels, **kwd):
         super().__init__(**kwd)
-        self.loglevels = loglevels
+
+    def write(self):
+        fh = open(self.output_file, "w", encoding="utf-8")
+        fh.write(self.get_html())
+        print(f'A report in HTML format has been saved to "{self.output_file}"')
+
 
     def get_html(self) -> str:
         """Return complete report as a HTML string."""

--- a/Lib/fontbakery/reporters/serialize.py
+++ b/Lib/fontbakery/reporters/serialize.py
@@ -148,3 +148,10 @@ class SerializeReporter(FontbakeryReporter):
                 doc['sections'].append(sectionDoc)
         self._doc = doc
         return doc
+
+    def write(self):
+        import json
+        fh = open(self.output_file, "w")
+        json.dump(self.getdoc(), fh, sort_keys=True, indent=4)
+        print(f'A report in JSON format has been saved to "{self.output_file}"')
+

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -369,6 +369,9 @@ class TerminalReporter(TerminalProgress):
         # status after ENDCHECK.
         self._render_async = self.is_async or check_threshold is not None
 
+    def write(self):
+        pass
+
     def _register(self, event):
         super()._register(event)
         status, message, (section, check, iterargs) = event

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -369,9 +369,6 @@ class TerminalReporter(TerminalProgress):
         # status after ENDCHECK.
         self._render_async = self.is_async or check_threshold is not None
 
-    def write(self):
-        pass
-
     def _register(self, event):
         super()._register(event)
         status, message, (section, check, iterargs) = event


### PR DESCRIPTION
Move reporter-specific write logic to reporters, simplify argparse

By doing so we can remove a lot of special-casing and make the reporter interface more parallel.