### PR TITLE
check/mandatory_avar_table: update description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/missing_small_caps_glyphs]:** Check small caps glyphs are available (issue #3154)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/mandatory_avar_table]:** Update rationale to mention that this check may be ignored if axis progressions are linear.
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
   - **[com.google.fonts/check/repo/dirname_matches_nameid_1]:** Added hints to GF specs for single-weight families to FAIL output (PR #3196)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5121,9 +5121,11 @@ def com_google_fonts_check_metadata_designer_profiles(family_metadata):
 @check(
     id = 'com.google.fonts/check/mandatory_avar_table',
     rationale = """
-        All high quality variable fonts include an avar table to correctly define axes progression rates.
+        Most variable fonts should include an avar table to correctly define axes progression rates.
 
         For example, a weight axis from 0% to 100% doesn't map directly to 100 to 1000, because a 10% progression from 0% may be too much to define the 200, while 90% may be too little to define the 900.
+        
+        If the progression rates of axes is linear, this check can be ignored. Fontmake will also skip adding an avar table if the progression rates are linear. However, we still recommend designers visually proof each instance is at the desired weight, width etc.
     """,
     conditions = ["is_variable_font"],
     misc_metadata = {


### PR DESCRIPTION
I've mentioned that an avar isn't necessary if the progressions are linear and added hints to fontmake and the need to visually proof.
