### PR TITLE
new check: com.google.fonts/check/cjk_not_enough_glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **license_path** condition: do not cause an ERROR on families lacking a license file. (issue #3201)
 
 ### New Checks
+  - **[com.google.fonts/check/cjk_sparse_glyphs]:** Warn users if there are less than 40 CJK glyphs in a font.
   - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults]:** Ensure default axis values are registered as fallback on the Google Fonts Axis Registry (issue #3141)
   - **[com.google.fonts/check/description/family_update]:** On a family update, the DESCRIPTION.en_us.html file should ideally also be updated. (issue #3182)
   - **[com.google.fonts/check/missing_small_caps_glyphs]:** Check small caps glyphs are available (issue #3154)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **license_path** condition: do not cause an ERROR on families lacking a license file. (issue #3201)
 
 ### New Checks
-  - **[com.google.fonts/check/cjk_sparse_glyphs]:** Warn users if there are less than 40 CJK glyphs in a font.
+  - **[com.google.fonts/check/cjk_not_enough_glyphs]:** Warn users if there are less than 40 CJK glyphs in a font. (PR #3214)
   - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults]:** Ensure default axis values are registered as fallback on the Google Fonts Axis Registry (issue #3141)
   - **[com.google.fonts/check/description/family_update]:** On a family update, the DESCRIPTION.en_us.html file should ideally also be updated. (issue #3182)
   - **[com.google.fonts/check/missing_small_caps_glyphs]:** Check small caps glyphs are available (issue #3154)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -152,7 +152,7 @@ FONT_FILE_CHECKS = [
     'com.google.fonts/check/contour_count',
     'com.google.fonts/check/vertical_metrics_regressions',
     'com.google.fonts/check/cjk_vertical_metrics',
-    'com.google.fonts/check/cjk_sparse_glyphs',
+    'com.google.fonts/check/cjk_not_enough_glyphs',
     'com.google.fonts/check/varfont_instance_coordinates',
     'com.google.fonts/check/varfont_instance_names',
     'com.google.fonts/check/varfont_duplicate_instance_names',
@@ -4574,18 +4574,24 @@ def com_google_fonts_check_cjk_vertical_metrics(ttFont):
 
 
 @check(
-    id = 'com.google.fonts/check/cjk_sparse_glyphs',
+    id = 'com.google.fonts/check/cjk_not_enough_glyphs',
     conditions = ['is_cjk_font'],
-    description = """Hangul has 40 characters and it's the smallest CJK writing system. If a font contains less CJK glyphs than this writing system, raise a warn and inform the user that some glyphs may be encoded incorrectly."""
+    rationale = """
+        Hangul has 40 characters and it's the smallest CJK writing system. If a font contains less CJK glyphs than this writing system, raise a warn and inform the user that some glyphs may be encoded incorrectly."""
 )
-def com_google_fonts_check_cjk_sparse_glyphs(ttFont):
+def com_google_fonts_check_cjk_not_enough_glyphs(ttFont):
+    """Does the font contain less than 40 CJK characters?"""
     from .shared_conditions import get_cjk_glyphs
     cjk_glyphs = get_cjk_glyphs(ttFont)
     cjk_glyph_count = len(cjk_glyphs)
     if cjk_glyph_count < 40:
+        if cjk_glyph_count == 1:
+            first_line = f"There is only {cjk_glyph_count} CJK glyph when there needs "
+        else:
+            first_line = f"There are only {cjk_glyph_count} CJK glyphs when there needs "
         yield WARN, \
-              Message('cjk-sparse-glyphs',
-                      f"There are only {cjk_glyph_count} CJK glyphs when there needs "
+              Message('cjk-not-enough-glyphs',
+                      first_line + \
                       f"to be at least 40 in order to support the smallest CJK writing "
                       f"system, Hangul. The following CJK glyphs were found "
                       f"{cjk_glyphs}. Please check that these "

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4586,17 +4586,19 @@ def com_google_fonts_check_cjk_not_enough_glyphs(ttFont):
     cjk_glyph_count = len(cjk_glyphs)
     if cjk_glyph_count < 40:
         if cjk_glyph_count == 1:
-            first_line = f"There is only {cjk_glyph_count} CJK glyph when there needs "
+            N_CJK_glyphs = f"There is only one CJK glyph"
         else:
-            first_line = f"There are only {cjk_glyph_count} CJK glyphs when there needs "
+            N_CJK_glyphs = f"There are only {cjk_glyph_count} CJK glyphs"
+
         yield WARN, \
               Message('cjk-not-enough-glyphs',
-                      first_line + \
-                      f"to be at least 40 in order to support the smallest CJK writing "
-                      f"system, Hangul. The following CJK glyphs were found "
-                      f"{cjk_glyphs}. Please check that these "
-                      f"glyphs have the correct unicodes.")
-    yield PASS, "Font has the correct quantity of CJK glyphs"
+                      f"{N_CJK_glyphs} when there needs to be at least 40"
+                      f" in order to support the smallest CJK writing system, Hangul.\n"
+                      f"The following CJK glyphs were found:\n"
+                      f"{cjk_glyphs}\n"
+                      f"Please check that these glyphs have the correct unicodes.")
+    else:
+        yield PASS, "Font has the correct quantity of CJK glyphs"
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4561,7 +4561,7 @@ def com_google_fonts_check_cjk_not_enough_glyphs(ttFont):
     from .shared_conditions import get_cjk_glyphs
     cjk_glyphs = get_cjk_glyphs(ttFont)
     cjk_glyph_count = len(cjk_glyphs)
-    if cjk_glyph_count < 40:
+    if cjk_glyph_count > 0 and cjk_glyph_count < 40:
         if cjk_glyph_count == 1:
             N_CJK_glyphs = "There is only one CJK glyph"
         else:

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4563,7 +4563,7 @@ def com_google_fonts_check_cjk_not_enough_glyphs(ttFont):
     cjk_glyph_count = len(cjk_glyphs)
     if cjk_glyph_count < 40:
         if cjk_glyph_count == 1:
-            N_CJK_glyphs = f"There is only one CJK glyph"
+            N_CJK_glyphs = "There is only one CJK glyph"
         else:
             N_CJK_glyphs = f"There are only {cjk_glyph_count} CJK glyphs"
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -152,6 +152,7 @@ FONT_FILE_CHECKS = [
     'com.google.fonts/check/contour_count',
     'com.google.fonts/check/vertical_metrics_regressions',
     'com.google.fonts/check/cjk_vertical_metrics',
+    'com.google.fonts/check/cjk_sparse_glyphs',
     'com.google.fonts/check/varfont_instance_coordinates',
     'com.google.fonts/check/varfont_instance_names',
     'com.google.fonts/check/varfont_duplicate_instance_names',
@@ -4570,6 +4571,26 @@ def com_google_fonts_check_cjk_vertical_metrics(ttFont):
 
     if not failed and not warn:
         yield PASS, 'Vertical metrics are good'
+
+
+@check(
+    id = 'com.google.fonts/check/cjk_sparse_glyphs',
+    conditions = ['is_cjk_font'],
+    description = """Hangul has 40 characters and it's the smallest CJK writing system. If a font contains less CJK glyphs than this writing system, raise a warn and inform the user that some glyphs may be encoded incorrectly."""
+)
+def com_google_fonts_check_cjk_sparse_glyphs(ttFont):
+    from .shared_conditions import get_cjk_glyphs
+    cjk_glyphs = get_cjk_glyphs(ttFont)
+    cjk_glyph_count = len(cjk_glyphs)
+    if cjk_glyph_count < 40:
+        yield WARN, \
+              Message('cjk-sparse-glyphs',
+                      f"There are only {cjk_glyph_count} CJK glyphs when there needs "
+                      f"to be at least 40 in order to support the smallest CJK writing "
+                      f"system, Hangul. The following CJK glyphs were found "
+                      f"{cjk_glyphs}. Please check that these "
+                      f"glyphs have the correct unicodes.")
+    yield PASS, "Font has the correct quantity of CJK glyphs"
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4549,7 +4549,12 @@ def com_google_fonts_check_cjk_vertical_metrics(ttFont):
     id = 'com.google.fonts/check/cjk_not_enough_glyphs',
     conditions = ['is_cjk_font'],
     rationale = """
-        Hangul has 40 characters and it's the smallest CJK writing system. If a font contains less CJK glyphs than this writing system, raise a warn and inform the user that some glyphs may be encoded incorrectly."""
+        Hangul has 40 characters and it's the smallest CJK writing system.
+        If a font contains less CJK glyphs than this writing system, we inform the user that some glyphs may be encoded incorrectly.
+    """,
+    misc_metadata = {
+        'request': 'https://github.com/googlefonts/fontbakery/pull/3214'
+    }
 )
 def com_google_fonts_check_cjk_not_enough_glyphs(ttFont):
     """Does the font contain less than 40 CJK characters?"""

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -351,6 +351,20 @@ def is_cjk_font(ttFont):
 
 
 @condition
+def get_cjk_glyphs(ttFont):
+    """Return all glyphs which belong to a CJK unicode block"""
+    from fontbakery.constants import CJK_UNICODE_RANGES
+    results = []
+    cjk_unicodes = set()
+    for start, end in CJK_UNICODE_RANGES:
+        cjk_unicodes |= set(u for u in range(start, end+1))
+    for uni, glyph_name in ttFont.getBestCmap().items():
+        if uni in cjk_unicodes:
+            results.append(glyph_name)
+    return results
+
+
+@condition
 def typo_metrics_enabled(ttFont):
     return ttFont['OS/2'].fsSelection & 0b10000000 > 0
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3285,6 +3285,26 @@ def test_check_cjk_vertical_metrics():
                            'if font hhea and win metrics are greater than 1.5 * upm')
 
 
+def test_check_cjk_sparse_glyphs():
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/cjk_sparse_glyphs")
+    ttFont = TTFont(cjk_font)
+    assert_PASS(check(ttFont),
+                'for Source Han Sans')
+
+    ttFont = TTFont(TEST_FILE("montserrat/Montserrat-Regular.ttf"))
+    assert_PASS(check(ttFont),
+                'for Montserrat')
+
+    # Let's modify Montserrat's cmap so there's a cjk glyph
+    cmap = ttFont['cmap'].getcmap(3,1)
+    # Add first character of the CJK unified Ideographs
+    cmap.cmap[0x4E00] = "A"
+    assert_results_contain(check(ttFont),
+                           WARN, "cjk-sparse-glyphs",
+                           "There are only 1 CJK glyphs")
+
+
 def test_check_varfont_instance_coordinates(vf_ttFont):
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/varfont_instance_coordinates")

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3285,9 +3285,9 @@ def test_check_cjk_vertical_metrics():
                            'if font hhea and win metrics are greater than 1.5 * upm')
 
 
-def test_check_cjk_sparse_glyphs():
+def test_check_cjk_not_enough_glyphs():
     check = CheckTester(googlefonts_profile,
-                        "com.google.fonts/check/cjk_sparse_glyphs")
+                        "com.google.fonts/check/cjk_not_enough_glyphs")
     ttFont = TTFont(cjk_font)
     assert_PASS(check(ttFont),
                 'for Source Han Sans')
@@ -3301,8 +3301,13 @@ def test_check_cjk_sparse_glyphs():
     # Add first character of the CJK unified Ideographs
     cmap.cmap[0x4E00] = "A"
     assert_results_contain(check(ttFont),
-                           WARN, "cjk-sparse-glyphs",
-                           "There are only 1 CJK glyphs")
+                           WARN, "cjk-not-enough-glyphs",
+                           "There is only 1 CJK glyphs")
+    # Add second character of the CJK unified Ideographs
+    cmap.cmap[0x4E01] = "B"
+    assert_results_contain(check(ttFont),
+                           WARN, "cjk-not-enough-glyphs",
+                           "There are only 2 CJK glyphs")
 
 
 def test_check_varfont_instance_coordinates(vf_ttFont):


### PR DESCRIPTION
I've seen several families that are being classed as CJK when they shouldn't be. In most cases, a handful of the family's glyphs are being assigned cjk unicodes when it's clear that the glyphs belong to another block.

Before implementing this check, I thought about modifying the `is_cjk_font` condition to be less greedy. However, I'd personally prefer this condition to remain greedy and have this check instead since it may show designers errors in their fonts that would've otherwise have fallen through the cracks.

cc @chrissimpkins @vv-monsalve 

Once this is merged, it should help you identify glyphs which are triggering the cjk vertical metrics check when it shouldn't as well.