### PR TITLE
Fix terminal reporter

### DIFF
--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -451,7 +451,7 @@ class TerminalReporter(TerminalProgress):
                 message = str(msg)
 
             if hasattr(msg, 'traceback'):
-                message += '\n' + '\n  ↳ '.join(message.traceback.split('\n'))
+                message += '\n' + '\n  ↳ '.join(msg.traceback.split('\n'))
 
             logmsg = text_flow(message,
                                width=76,


### PR DESCRIPTION
`message` is a string. We should be using `msg.traceback` instead since we're checking if this attrib exists in the line above.