### PR TITLE
check/gf-axisregistry/fvar_axis_defaults: skip axes which are not in GF Axis Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/missing_small_caps_glyphs]:** Check small caps glyphs are available (issue #3154)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults]:** Only check axes which are in the GF Axis Registry (PR #3217)
   - **[com.google.fonts/check/integer_ppem_if_hinted]:** Format message with newlines.
   - **[com.google.fonts/check/STAT/gf-axisregistry]:** Ensure that STAT tables contain Axis Values
   - **[com.google.fonts/check/repo/dirname_matches_nameid_1]:** Added hints to GF specs for single-weight families to FAIL output (PR #3196)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4803,6 +4803,8 @@ def com_google_fonts_check_gf_axisregistry_fvar_axis_defaults(ttFont, GFAxisRegi
 
     passed = True
     for axis in ttFont['fvar'].axes:
+        if axis.axisTag not in GFAxisRegistry:
+            continue
         fallbacks = GFAxisRegistry[axis.axisTag]["fallbacks"]
         if axis.defaultValue not in fallbacks.values():
             passed = False


### PR DESCRIPTION
Atm, this check will ERROR if a font contains an axis which isn't in our axis registry.

Will update the CHANGELOG now.