### PR TITLE
Add a configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Move reporter-specific write logic to reporters, simplify argparse (PR #3206)
   - Profile-specific `fontbakery.commands.check_...` removed and replaced with a call to `check_profile` with the appropriate profile. (PR #3218)
   - HTML reporter parses and renders markdown. (PR #3212)
+  - You can now pass (some) options to fontbakery using a configuration file, with the `--configuration` command line parameter. This configuration file is available to check code using the `config` parameter. (PR #3219)
 
 ### New Profile
   - Created a Type Network profile for checking some of their new axis proposals (issue #3130)

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -69,7 +69,7 @@ class CheckRunner:
         # TODO: transform all iterables that are list like to tuples
         # to make sure that they won't change anymore.
         # Also remove duplicates from list like iterables
-
+        self.config = config
         self._custom_order = config["custom_order"]
         self._explicit_checks = config["explicit_checks"]
         self._exclude_checks = config["exclude_checks"]
@@ -323,6 +323,9 @@ class CheckRunner:
         if nametype == "derived_iterables":
             condition_name, simple = self._profile.get(name)
             return self._derive_iterable_condition(condition_name, simple, path)
+
+        if nametype == "config":
+            return self.config
 
         if has_fallback:
             return fallback

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -62,19 +62,17 @@ class CheckRunner:
         self,
         profile,
         values,
+        config,
         values_can_override_profile_names=True,
-        custom_order=None,
-        explicit_checks=None,
-        exclude_checks=None,
         use_cache=True,
     ):
         # TODO: transform all iterables that are list like to tuples
         # to make sure that they won't change anymore.
         # Also remove duplicates from list like iterables
 
-        self._custom_order = custom_order
-        self._explicit_checks = explicit_checks
-        self._exclude_checks = exclude_checks
+        self._custom_order = config["custom_order"]
+        self._explicit_checks = config["explicit_checks"]
+        self._exclude_checks = config["exclude_checks"]
         self._iterargs = OrderedDict()
         for singular, plural in profile.iterargs.items():
             values[plural] = tuple(values[plural])

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -15,6 +15,7 @@
 #
 
 from fontbakery.checkrunner import CheckRunner
+from fontbakery.configuration import Configuration
 from fontbakery.profile import Profile, get_module_profile
 
 
@@ -99,7 +100,7 @@ class CheckTester:
                 values = {'fonts': [v.reader.file.name for v in values],
                           'ttFonts': values}
 
-        self.runner = CheckRunner(self.profile, values, explicit_checks=[self.check_id])
+        self.runner = CheckRunner(self.profile, values, Configuration(explicit_checks=[self.check_id]))
         for check_identity in self.runner.order:
             _, check, _ = check_identity
             if check.id != self.check_id:

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -71,6 +71,10 @@ def ArgumentParser(profile, profile_arg=True):
 
     values_keys = profile.setup_argparse(argument_parser)
 
+    argument_parser.add_argument('--configuration',
+                                 dest='configfile',
+                                 help='Read configuration file (TOML/YAML).\n')
+
     argument_parser.add_argument(
         "-c",
         "--checkid",
@@ -278,11 +282,17 @@ def main(profile=None, values=None):
             if hasattr(args, key):
                 values_[key] = getattr(args, key)
 
-    configuration = Configuration(
+    if args.configfile:
+        configuration = Configuration.from_config_file(args.configfile)
+    else:
+        configuration = Configuration()
+
+    # Command line args overrides config, but only if given
+    configuration.maybe_override(Configuration(
       custom_order=args.order,
       explicit_checks=args.checkid,
       exclude_checks=args.exclude_checkid
-    )
+    ))
     runner_kwds = dict(values=values_, config=configuration)
     try:
         runner = CheckRunner(profile, **runner_kwds)

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -20,6 +20,7 @@ from fontbakery.checkrunner import (
             , FAIL
             , SECTIONSUMMARY
             )
+from fontbakery.configuration import Configuration
 from fontbakery.profile import (Profile, get_module_profile)
 
 from fontbakery.errors import ValueValidationError
@@ -277,11 +278,12 @@ def main(profile=None, values=None):
             if hasattr(args, key):
                 values_[key] = getattr(args, key)
 
-    runner_kwds = dict( values=values_
-                      , custom_order=args.order
-                      , explicit_checks=args.checkid
-                      , exclude_checks=args.exclude_checkid
-                      )
+    configuration = Configuration(
+      custom_order=args.order,
+      explicit_checks=args.checkid,
+      exclude_checks=args.exclude_checkid
+    )
+    runner_kwds = dict(values=values_, config=configuration)
     try:
         runner = CheckRunner(profile, **runner_kwds)
     except ValueValidationError as e:

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -289,9 +289,9 @@ def main(profile=None, values=None):
 
     # Command line args overrides config, but only if given
     configuration.maybe_override(Configuration(
-      custom_order=args.order,
-      explicit_checks=args.checkid,
-      exclude_checks=args.exclude_checkid
+        custom_order=args.order,
+        explicit_checks=args.checkid,
+        exclude_checks=args.exclude_checkid
     ))
     runner_kwds = dict(values=values_, config=configuration)
     try:

--- a/Lib/fontbakery/configuration.py
+++ b/Lib/fontbakery/configuration.py
@@ -1,0 +1,22 @@
+import toml
+import yaml
+
+
+class Configuration(dict):
+    def __init__(self, **kwargs):
+        self.update(kwargs)
+        for required_arg in ["custom_order", "explicit_checks", "exclude_checks"]:
+            if required_arg not in self:
+                self[required_arg] = None
+
+    @classmethod
+    def from_config_file(cls, filename):
+        try:
+            config = toml.load(filename)
+        except toml.TomlDecodeError as e:
+            # Try yaml
+            config = yaml.safe_load(open(filename))
+        if not isinstance(config, dict):
+            raise Exception(f"Can't understand config file {imported}.")
+        return cls(**config)
+

--- a/Lib/fontbakery/configuration.py
+++ b/Lib/fontbakery/configuration.py
@@ -20,3 +20,8 @@ class Configuration(dict):
             raise Exception(f"Can't understand config file {imported}.")
         return cls(**config)
 
+    def maybe_override(self, other):
+        for key, value in other.items():
+            if value is not None:
+                self[key] = value
+

--- a/Lib/fontbakery/configuration.py
+++ b/Lib/fontbakery/configuration.py
@@ -4,7 +4,7 @@ import yaml
 
 class Configuration(dict):
     def __init__(self, **kwargs):
-        self.update(kwargs)
+        super().__init__(kwargs)
         for required_arg in ["custom_order", "explicit_checks", "exclude_checks"]:
             if required_arg not in self:
                 self[required_arg] = None
@@ -13,11 +13,11 @@ class Configuration(dict):
     def from_config_file(cls, filename):
         try:
             config = toml.load(filename)
-        except toml.TomlDecodeError as e:
+        except toml.TomlDecodeError:
             # Try yaml
             config = yaml.safe_load(open(filename))
         if not isinstance(config, dict):
-            raise Exception(f"Can't understand config file {imported}.")
+            raise Exception(f"Can't understand config file {filename}.")
         return cls(**config)
 
     def maybe_override(self, other):

--- a/Lib/fontbakery/profile.py
+++ b/Lib/fontbakery/profile.py
@@ -118,7 +118,9 @@ class Profile:
           b) add some validation, so that we know the values match
              our expectations! These values must be treated as user input!
         """
-        self._namespace = {}
+        self._namespace = {
+          "config": "config"  # Filled in by checkrunner
+        }
 
         self.iterargs = {}
         if iterargs:

--- a/Lib/fontbakery/profile.py
+++ b/Lib/fontbakery/profile.py
@@ -119,7 +119,7 @@ class Profile:
              our expectations! These values must be treated as user input!
         """
         self._namespace = {
-          "config": "config"  # Filled in by checkrunner
+            "config": "config"  # Filled in by checkrunner
         }
 
         self.iterargs = {}

--- a/docs/source/developer/writing-profiles.md
+++ b/docs/source/developer/writing-profiles.md
@@ -472,6 +472,11 @@ profile = FontsProfile(
       )
 ```
 
+#### Access to the configuration object
+
+You can also inject the `config` parameter into your checks in order to gain
+access to any configuration file passed in by the user. The `config` parameter
+will contain a dictionary with the parsed configuration file.
 
 #### Explicit Namespace Overrides `force=True`
 

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -95,9 +95,15 @@ Here's the output of `fontbakery check-googlefonts -h`:
 
     optional arguments:
       -h, --help            show this help message and exit
+      --configuration CONFIGFILE
+                            Read configuration file (TOML/YAML).
       -c CHECKID, --checkid CHECKID
                             Explicit check-ids to be executed.
                             Use this option multiple times to select multiple checks.
+      -x EXCLUDE_CHECKID, --exclude-checkid EXCLUDE_CHECKID
+                            Exclude check-ids (or parts of their name) from
+                            execution. Use this option multiple times to
+                            exclude multiple checks.
       -v, --verbose         Shortcut for `-l PASS`.
       -l LOGLEVEL, --loglevel LOGLEVEL
                             Report checks with a result of this status or higher.
@@ -149,6 +155,32 @@ This will create a folder called `check_results/` then run the `check-googlefont
 This is a wrapper around the Microsoft Font Validator.
 
 Usage is similar to the check-googlefonts command described above.
+
+### Configuration file
+
+Some command-line parameters can be configured in a configuration file.
+This may be in TOML or YAML format, and the name of this file is passed in
+on the fontbakery command line with the `--configuration` parameter.
+(`--config` for short.)
+
+Currently, the following command-line parameters can be specified in the
+configuration file:
+
+- Instead of using `-c` to specify checks, a list of checks can be provided using the `explicit_checks` key:
+
+```
+explicit_checks = [
+    'com.google.fonts/check/family/underline_thickness',
+    'com.google.fonts/check/family/panose_proportion',
+    'com.google.fonts/check/family/panose_familytype',
+]
+```
+
+- Instead of using `-x` to exclude checks, a list of checks to exclude can be provided using the `exclude_checks` key.
+
+- Instead of using `--order` to specify the check order, a list of checks can be provided using the `custom_order` key.
+
+Individual checks and profiles may give semantics to additional configuration values; the whole configuration file is passed to checks which request access to it.
 
 #### Old Command Line Tools
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 --index-url https://pypi.python.org/simple/
 beautifulsoup4==4.9.3
+toml==0.10.2
+PyYAML==5.4.1
 defcon==0.7.2
 font-v==1.0.5
 fontTools[ufo,lxml,unicode]==4.18.2

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
     setup_requires=['setuptools_scm'],
     install_requires=[
         'beautifulsoup4',
+        'toml',
+        'PyYAML',
         'defcon',
         'font-v',
         'fontTools[ufo,lxml,unicode]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -102,7 +102,7 @@ def test_command_config_file():
     test_font = os.path.join("data", "test", "nunito", "Nunito-Regular.ttf")
     result = subprocess.run(["fontbakery", "check-googlefonts",
         "--config", config.name,
-        test_font], capture_output=True)
+        test_font], stdout=subprocess.PIPE)
     stdout = result.stdout.decode()
     assert "running 1 individual check" in stdout
     os.unlink(config.name)
@@ -122,7 +122,7 @@ OK = 123
         "-C",
         "--config", config.name,
         test_profile,
-        test_font], capture_output=True)
+        test_font], stdout=subprocess.PIPE)
     stdout = result.stdout.decode()
     assert "FAIL: 0" in stdout
     os.unlink(config.name)

--- a/tests/profiles/a_test_profile.py
+++ b/tests/profiles/a_test_profile.py
@@ -1,0 +1,23 @@
+from fontbakery.callable import check
+from fontbakery.section import Section
+from fontbakery.status import PASS, FAIL, WARN
+from fontbakery.fonts_profile import profile_factory
+from fontbakery.message import Message
+
+profile = profile_factory(default_section=Section("Just a Test"))
+
+@check(
+    id='com.google.fonts/check_for_testing/configuration',
+    rationale="""
+        Check that we can inject the configuration object and read it.
+    """,
+)
+def com_google_fonts_check_for_testing_configuration(config):
+    """Check if we can inject a config file"""
+    if config and "a_test_profile" in config and config["a_test_profile"]["OK"] == 123:
+        yield PASS, 'we have injected a config'
+    else:
+        yield FAIL, "config variable didn't look like we expected"
+
+
+profile.auto_register(globals())

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -9,6 +9,7 @@ from fontbakery.codetesting import (assert_results_contain,
                                     portable_path,
                                     TEST_FILE,
                                     CheckTester)
+from fontbakery.configuration import Configuration
 from fontbakery.constants import (NameID,
                                   PlatformID,
                                   WindowsEncodingID,
@@ -121,7 +122,7 @@ def test_example_checkrunner_based(cabin_regular_path):
     from fontbakery.checkrunner import CheckRunner
     from fontbakery.profiles.googlefonts import profile
     values = dict(fonts=[cabin_regular_path])
-    runner = CheckRunner(profile, values, explicit_checks=['com.google.fonts/check/vendor_id'])
+    runner = CheckRunner(profile, values, Configuration(explicit_checks=['com.google.fonts/check/vendor_id']))
 
     # we could also reuse the `iterargs` that was assigned in the previous
     # for loop, but this here is more explicit


### PR DESCRIPTION
## Description

As part of getting #3177 ready to land, we need to get rid of hard-coded paths and replace them with paths coming in from an external configuration object. This PR:

* Adds the concept of a configuration object.
* Allows loading the configuration file in either TOML or YAML format. (TOML is more designer friendly; see gftools for YAML nightmares...)
* Uses the config file for `custom_order`, `explicit_checks` and `exclude_checks`, while allowing the command-line to override the values in the config file.
* Allows the configuration object to be injected into a check using the `config` parameter.
* Includes docs and tests...

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [ ] request a review

