### PR TITLE
(WIP) Parse MD table and format MD from status message on terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Format status output to improve readability. (issue #2052)
   - Move reporter-specific write logic to reporters, simplify argparse (PR #3206)
   - Profile-specific `fontbakery.commands.check_...` removed and replaced with a call to `check_profile` with the appropriate profile. (PR #3218)
-  - HTML reporter parses and renders markdown. (PR #3212)
+  - HTML and Terminal reporter parses and renders markdown. (PR #3212) (PR #3227)
   - You can now pass (some) options to fontbakery using a configuration file, with the `--configuration` command line parameter. This configuration file is available to check code using the `config` parameter. (PR #3219)
   - All failing tests are now *required* to return a `Message` object containing a message code. (PR #3226)
 

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -583,7 +583,8 @@ def parse_md(md):
     md = re.sub(r'^[\t ]*\|', r'|', md, flags=re.MULTILINE)
     md = re.sub(r'\|[\t ]*$', r'|', md, flags=re.MULTILINE)
     tables = []
-    md = re.sub(table_re, lambda match: parse_md_table(match, tables), md, flags=re.MULTILINE|re.S)
+    md = re.sub(table_re, lambda match: parse_md_table(match, tables), md,
+                flags=re.MULTILINE | re.S)
     console = Console(width=70)
     with console.capture() as capture:
         console.print(Markdown(md))

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -609,7 +609,7 @@ def parse_md_table(match, tables_memo):
     sty_odd = Style(bgcolor="#111111", color='white')
     sty_even = Style(bgcolor="#222222", color='white')
     for row in table_header:
-        row = map(lambda cell: Align.center(cell), row)
+        row = map(Align.center, row)
         table.add_row(*row, style=sty_header)
     num = 0
     for row in table_body:

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -35,7 +35,7 @@ def is_negated(name):
 
 def colorless_len(str):
     import re
-    return len(re.sub('\x1b\\[[0-9;]+m', '', str))
+    return len(re.sub('\x1b(\\[[0-9;]+|\\].+)m', '', str))
 
 def text_flow(content, width=80, indent=0, left_margin=0, first_line_indent=0,
               space_padding=False, text_color="{}".format):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ cmarkgfm==0.5.3
 vharfbuzz==0.1.1
 collidoscope==0.0.6
 stringbrewer==0.0.1
+rich==10.0.1
 -e .

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,8 @@ setup(
         'cmarkgfm',
         'vharfbuzz',
         'collidoscope',
-        'stringbrewer'
-        'rich>=3.7.4'
+        'stringbrewer',
+        'rich'
     ],
     extras_require={
         'docs': [

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'vharfbuzz',
         'collidoscope',
         'stringbrewer'
+        'rich>=3.7.4'
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #2559

The MD parsing is done with [Rich](https://rich.readthedocs.io). Unfortunately it does not supports tables, so this path pre-parses the table notation and format that with `rich.table`.

![screenshot-md-example](https://user-images.githubusercontent.com/30254/114246257-8b70b500-9968-11eb-88c4-10d50abd603e.png)

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review
