### PR TITLE
Workaround for beautifulsoup processing partial malformed sections

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -164,6 +164,12 @@ def registered_vendor_ids():
     CACHED = resource_filename('fontbakery',
                                'data/fontbakery-microsoft-vendorlist.cache')
     content = open(CACHED, encoding='utf-8').read()
+    # Strip all <A> HTML tags from the raw HTML. The current page contains a
+    # closing </A> for which no opening <A> is present, which causes
+    # beautifulsoup to silently stop processing that section from the error
+    # onwards. We're not using the href's anyway.
+    content = re.sub("<a[^>]*>", "", content)
+    content = re.sub("</a>", "", content)
     soup = BeautifulSoup(content, 'html.parser')
 
     IDs = [chr(c + ord('a')) for c in range(ord('z') - ord('a') + 1)]

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -168,8 +168,8 @@ def registered_vendor_ids():
     # closing </A> for which no opening <A> is present, which causes
     # beautifulsoup to silently stop processing that section from the error
     # onwards. We're not using the href's anyway.
-    content = re.sub("<a[^>]*>", "", content)
-    content = re.sub("</a>", "", content)
+    content = re.sub("<a[^>]*>", "", content, flags=re.IGNORECASE)
+    content = re.sub("</a>", "", content, flags=re.IGNORECASE)
     soup = BeautifulSoup(content, 'html.parser')
 
     IDs = [chr(c + ord('a')) for c in range(ord('z') - ord('a') + 1)]


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #3232. It is an ugly hack to work around beautifulsoup silently discarding entries, by removing all <A> tags before passing the font vendor table to BeautifulSoup's html parser.

I do not feel comfortable updating CHANGELOG.md, but do let me know if there's anything I can do to help. I have notified Microsoft of the underlying HTML error in the vendor list table.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

