### PR TITLE
Allow configuring Harfbuzz subshaper in shaping JSON

### DIFF
--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -96,7 +96,7 @@ def get_from_test_with_default(test, configuration, el, default=None):
 
 def get_shaping_parameters(test, configuration):
     params = {}
-    for el in ["script", "language", "direction", "features"]:
+    for el in ["script", "language", "direction", "features", "shaper"]:
         params[el] = get_from_test_with_default(test, configuration, el)
     return params
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ufolint==1.2.0
 unidecode==1.1.2
 beziers==0.1.0
 cmarkgfm==0.5.3
-vharfbuzz==0.1.0
+vharfbuzz==0.1.1
 collidoscope==0.0.6
 stringbrewer==0.0.1
 -e .


### PR DESCRIPTION
## Description

This is a minor update to the shaping check. When shaping, one may wish to check how CoreText or Uniscribe shapes a string, as well as Harfbuzz. This allows the user to configure a `shaper` parameter in the JSON file which runs the test on an alternate shaping engine. (This is implemented by passing the parameter to vharfbuzz which in turn passes it to uharfbuzz.)

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

