### PR TITLE
update check: com.google.fonts/check/vertical_metrics_regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/shaping/collides]:** Check that OpenType shaping does not produce glyphs which collide with one another (e.g. `ïï`).
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/vertical_metrics_regressions]:** Raise a fail if a non-CJK family's win metrics have changed and fsSelection bit 7 hasn't been enabled, or the fonts currently served on Google Fonts already have the bit enabled.
   - **[com.google.fonts/check/kern_table]:** add FAIL when non-character glyph present, WARN when no format-0 subtable present.
   - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults]:** Only check axes which are in the GF Axis Registry (PR #3217)
   - **[com.google.fonts/check/mandatory_avar_table]:** Update rationale to mention that this check may be ignored if axis progressions are linear.

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3176,7 +3176,7 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
 
         remote2 = copy(remote)
         for key, ttfont in remote2.items():
-            ttfont["OS/2"].fsSelection = ttfont["OS/2"].fsSelection ^ 0b10000000
+            ttfont["OS/2"].fsSelection &= ~(1 << 7)
         assert_results_contain(check(ttFonts, remote2),
                                FAIL, "bad-typo-ascender",
                                'with a remote family which does not have'
@@ -3194,6 +3194,14 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
                     ' enabled but the checked fonts vertical metrics have been'
                     ' set so its typo and hhea metrics match the remote'
                     ' fonts win metrics.')
+
+        ttFonts4 = copy(ttFonts)
+        for ttFont in ttFonts4:
+            ttFont['OS/2'].fsSelection &= ~(1 << 7)
+        assert_results_contain(check(ttFonts4, remote),
+                               PASS, "bad-fselection-bit7",
+                               'it must have OS/2 fsSelection bit 7 enabled.')
+
     #
     #else:
     #  TODO: There should be a warning message here


### PR DESCRIPTION
Raise a fail if the family being checked already exists on Google Fonts and it doesn't have OS/2 fsSelection 7 enabled and it isn't a cjk family.

We need to ensure that upgraded families have this bit enabled so we can freely set the Win metrics without worrying that we're going to change the visual line height in future family updates. Many font updates add new writing systems which contain deeper/taller glyphs so it's quite a common scenario.


Fixes #3241