### PR TITLE
Refactor vertical metrics checks (attempt 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **license_path** condition: do not cause an ERROR on families lacking a license file. (issue #3201)
 
 ### New Checks
+  - **[com.google.fonts/check/cjk_vertical_metrics_regressions]:** Check CJK family has the same vertical metrics as the same family hosted on Google Fonts (issue #3242)
   - **[com.google.fonts/check/cjk_not_enough_glyphs]:** Warn users if there are less than 40 CJK glyphs in a font. (PR #3214)
   - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults]:** Ensure default axis values are registered as fallback on the Google Fonts Axis Registry (issue #3141)
   - **[com.google.fonts/check/description/family_update]:** On a family update, the DESCRIPTION.en_us.html file should ideally also be updated. (issue #3182)
@@ -31,6 +32,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/iso15008_proportions]:** Check that fonts designed for use in in-car environments have suitable proportions (issue #3250)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/vertical_metrics_regressions]:** Skip check if fonts are CJK (issue #3242) and refactor fsSelection bit 7 requirements (issue #3241).
   - **[com.google.fonts/check/kern_table]:** add FAIL when non-character glyph present, WARN when no format-0 subtable present.
   - **[com.google.fonts/check/gf-axisregistry/fvar_axis_defaults]:** Only check axes which are in the GF Axis Registry (PR #3217)
   - **[com.google.fonts/check/mandatory_avar_table]:** Update rationale to mention that this check may be ignored if axis progressions are linear.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4395,16 +4395,24 @@ def com_google_fonts_check_vertical_metrics_regressions(regular_ttFont, regular_
     if gf_has_typo_metrics:
         if not ttFont_has_typo_metrics:
             failed = True
-            yield FAIL, "Enable typo metrics"
+            yield FAIL, Message("bad-fsselection-bit7",
+                                "fsSelection bit 7 needs to be enabled because "
+                                "the family on Google Fonts has it enabled.")
+            # faux enable it so we can see which metrics also need changing
             ttFont_has_typo_metrics = True
         expected_ascender = math.ceil(gf_font['OS/2'].sTypoAscender * upm_scale)
         expected_descender = math.ceil(gf_font['OS/2'].sTypoDescender * upm_scale)
     else:
-        if (gf_font['OS/2'].usWinAscent, gf_font['OS/2'].usWinDescent) != \
-           (ttFont['OS/2'].usWinAscent, ttFont['OS/2'].usWinDescent):
+        if (math.ceil(gf_font['OS/2'].usWinAscent * upm_scale),
+            math.ceil(gf_font['OS/2'].usWinDescent * upm_scale)) != \
+           (math.ceil(ttFont['OS/2'].usWinAscent),
+            math.ceil(ttFont['OS/2'].usWinDescent)):
                if not ttFont_has_typo_metrics:
                    failed = True
-                   yield FAIL, "Enable typo metrics since win metrics have changed"
+                   yield FAIL, Message("bad-fsselection-bit7",
+                                       "fsSelection bit 7 needs to be enabled "
+                                       "because the win metrics differ from "
+                                       "the family on Google Fonts.")
                    ttFont_has_typo_metrics = True
         expected_ascender = math.ceil(gf_font["OS/2"].usWinAscent * upm_scale)
         expected_descender = -math.ceil(gf_font["OS/2"].usWinDescent * upm_scale)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4419,7 +4419,12 @@ def com_google_fonts_check_vertical_metrics_regressions(regular_ttFont, regular_
         expected_ascender = math.ceil(gf_ttFont["OS/2"].usWinAscent * upm_scale)
         expected_descender = -math.ceil(gf_ttFont["OS/2"].usWinDescent * upm_scale)
 
-    full_font_name = ttFont['name'].getName(4, 3, 1, 1033).toUnicode()
+    full_font_name = ttFont['name'].getName(
+        NameID.FULL_FONT_NAME,
+        PlatformID.WINDOWS,
+        UnicodeEncodingID.UNICODE_1_1,
+        WindowsLanguageID.ENGLISH_USA
+    ).toUnicode()
     typo_ascender = ttFont['OS/2'].sTypoAscender
     typo_descender = ttFont['OS/2'].sTypoDescender
     hhea_ascender = ttFont['hhea'].ascent

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4383,12 +4383,12 @@ def com_google_fonts_check_vertical_metrics_regressions(regular_ttFont, regular_
                                     get_instance_axis_value,
                                     typo_metrics_enabled)
 
-    gf_font = regular_remote_style
+    gf_ttFont = regular_remote_style
     ttFont = regular_ttFont
 
-    upm_scale = ttFont['head'].unitsPerEm / gf_font['head'].unitsPerEm
+    upm_scale = ttFont['head'].unitsPerEm / gf_ttFont['head'].unitsPerEm
 
-    gf_has_typo_metrics = typo_metrics_enabled(gf_font)
+    gf_has_typo_metrics = typo_metrics_enabled(gf_ttFont)
     ttFont_has_typo_metrics = typo_metrics_enabled(ttFont)
 
     failed = False
@@ -4400,11 +4400,13 @@ def com_google_fonts_check_vertical_metrics_regressions(regular_ttFont, regular_
                                 "the family on Google Fonts has it enabled.")
             # faux enable it so we can see which metrics also need changing
             ttFont_has_typo_metrics = True
-        expected_ascender = math.ceil(gf_font['OS/2'].sTypoAscender * upm_scale)
-        expected_descender = math.ceil(gf_font['OS/2'].sTypoDescender * upm_scale)
+        expected_ascender = math.ceil(gf_ttFont['OS/2'].sTypoAscender * upm_scale)
+        expected_descender = math.ceil(gf_ttFont['OS/2'].sTypoDescender * upm_scale)
     else:
-        if (math.ceil(gf_font['OS/2'].usWinAscent * upm_scale),
-            math.ceil(gf_font['OS/2'].usWinDescent * upm_scale)) != \
+        # if the win metrics have changed, the updated fonts must have bit 7
+        # enabled
+        if (math.ceil(gf_ttFont['OS/2'].usWinAscent * upm_scale),
+            math.ceil(gf_ttFont['OS/2'].usWinDescent * upm_scale)) != \
            (math.ceil(ttFont['OS/2'].usWinAscent),
             math.ceil(ttFont['OS/2'].usWinDescent)):
                if not ttFont_has_typo_metrics:
@@ -4414,8 +4416,8 @@ def com_google_fonts_check_vertical_metrics_regressions(regular_ttFont, regular_
                                        "because the win metrics differ from "
                                        "the family on Google Fonts.")
                    ttFont_has_typo_metrics = True
-        expected_ascender = math.ceil(gf_font["OS/2"].usWinAscent * upm_scale)
-        expected_descender = -math.ceil(gf_font["OS/2"].usWinDescent * upm_scale)
+        expected_ascender = math.ceil(gf_ttFont["OS/2"].usWinAscent * upm_scale)
+        expected_descender = -math.ceil(gf_ttFont["OS/2"].usWinDescent * upm_scale)
 
     full_font_name = ttFont['name'].getName(4, 3, 1, 1033).toUnicode()
     typo_ascender = ttFont['OS/2'].sTypoAscender
@@ -4561,10 +4563,10 @@ def com_google_fonts_check_cjk_vertical_metrics_regressions(regular_ttFont, regu
     """Check if the vertical metrics of a CJK family are similar to the same
     family hosted on Google Fonts."""
     import math
-    gf_font = regular_remote_style
+    gf_ttFont = regular_remote_style
     ttFont = regular_ttFont
 
-    upm_scale = ttFont['head'].unitsPerEm / gf_font['head'].unitsPerEm
+    upm_scale = ttFont['head'].unitsPerEm / gf_ttFont['head'].unitsPerEm
 
     failed = False
     for tbl, attrib in [
@@ -4577,7 +4579,7 @@ def com_google_fonts_check_cjk_vertical_metrics_regressions(regular_ttFont, regu
         ("hhea", "descent"),
         ("hhea", "lineGap"),
         ]:
-        gf_val = math.ceil(getattr(gf_font[tbl], attrib) * upm_scale)
+        gf_val = math.ceil(getattr(gf_ttFont[tbl], attrib) * upm_scale)
         f_val = math.ceil(getattr(ttFont[tbl], attrib))
         if gf_val != f_val:
             failed = True

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -452,6 +452,20 @@ def remote_styles(familyname_with_spaces):
 
 
 @condition
+def regular_remote_style(remote_styles):
+    if not remote_styles:
+        return None
+    if "Regular" in remote_styles:
+        return remote_styles["Regular"]
+
+    for style, font in remote_styles.items():
+        if is_variable_font(font):
+            if get_instance_axis_value(font, "Regular", "wght"):
+                return font
+    return list(remote_styles.items())[0][1]
+
+
+@condition
 def api_gfonts_ttFont(style, remote_styles):
     """Get a TTFont object of a font downloaded from Google Fonts
        corresponding to the given TTFont object of

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -466,6 +466,22 @@ def regular_remote_style(remote_styles):
 
 
 @condition
+def regular_ttFont(ttFonts):
+    from .shared_conditions import is_variable_font
+    for ttFont in ttFonts:
+        if "-Regular." in os.path.basename(ttFont.reader.file.name):
+            return ttFont
+        nametable = ttFont['name']
+        # Some static fonts may not have Regular in their stylenames.
+        if nametable.getName(2, 3, 1, 0x409).toUnicode() == "Regular" and nametable.getName(17, 3, 1, 0x409) == None:
+            return ttFont
+        if is_variable_font(ttFont):
+            if get_instance_axis_value(ttFont, "Regular", "wght"):
+                return ttFont
+    return None
+
+
+@condition
 def api_gfonts_ttFont(style, remote_styles):
     """Get a TTFont object of a font downloaded from Google Fonts
        corresponding to the given TTFont object of

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -453,6 +453,7 @@ def remote_styles(familyname_with_spaces):
 
 @condition
 def regular_remote_style(remote_styles):
+    from .shared_conditions import is_variable_font, get_instance_axis_value
     if not remote_styles:
         return None
     if "Regular" in remote_styles:
@@ -467,13 +468,14 @@ def regular_remote_style(remote_styles):
 
 @condition
 def regular_ttFont(ttFonts):
-    from .shared_conditions import is_variable_font
+    from .shared_conditions import is_variable_font, get_instance_axis_value
     for ttFont in ttFonts:
         if "-Regular." in os.path.basename(ttFont.reader.file.name):
             return ttFont
         nametable = ttFont['name']
         # Some static fonts may not have Regular in their stylenames.
-        if nametable.getName(2, 3, 1, 0x409).toUnicode() == "Regular" and nametable.getName(17, 3, 1, 0x409) == None:
+        if nametable.getName(2, 3, 1, 0x409).toUnicode() == "Regular" and \
+           nametable.getName(17, 3, 1, 0x409) == None:
             return ttFont
         if is_variable_font(ttFont):
             if get_instance_axis_value(ttFont, "Regular", "wght"):

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -2,7 +2,12 @@ import os
 import re
 
 from fontbakery.callable import condition
-from fontbakery.constants import NameID
+from fontbakery.constants import (
+    NameID,
+    PlatformID,
+    UnicodeEncodingID,
+    WindowsLanguageID
+)
 
 # -------------------------------------------------------------------
 # FIXME! Redundant with @condition canonical_stylename(font)?
@@ -473,9 +478,15 @@ def regular_ttFont(ttFonts):
         if "-Regular." in os.path.basename(ttFont.reader.file.name):
             return ttFont
         nametable = ttFont['name']
-        # Some static fonts may not have Regular in their stylenames.
-        if nametable.getName(2, 3, 1, 0x409).toUnicode() == "Regular" and \
-           nametable.getName(17, 3, 1, 0x409) == None:
+        sub_family = nametable.getName(NameID.FONT_SUBFAMILY_NAME,
+                                       PlatformID.WINDOWS,
+                                       UnicodeEncodingID.UNICODE_1_1,
+                                       WindowsLanguageID.ENGLISH_USA)
+        typo_sub_family = nametable.getName(NameID.TYPOGRAPHIC_SUBFAMILY_NAME,
+                                            PlatformID.WINDOWS,
+                                            UnicodeEncodingID.UNICODE_1_1,
+                                            WindowsLanguageID.ENGLISH_USA)
+        if sub_family and sub_family.toUnicode() == "Regular" and not typo_sub_family:
             return ttFont
         if is_variable_font(ttFont):
             if get_instance_axis_value(ttFont, "Regular", "wght"):

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -17,6 +17,7 @@ from fontbakery.constants import (NameID,
                                   MacintoshEncodingID,
                                   MacintoshLanguageID)
 from fontbakery.profiles import googlefonts as googlefonts_profile
+import math
 
 check_statuses = (ERROR, FAIL, SKIP, PASS, WARN, INFO, DEBUG)
 
@@ -3156,8 +3157,6 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
                 family_metadata)
     from copy import deepcopy
 
-    family_meta = family_metadata(metadata_file(family_directory(cabin_fonts[0])))
-
     remote = regular_ttFont([TTFont(f) for f in cabin_fonts])
     ttFont = regular_ttFont([TTFont(f) for f in cabin_fonts])
 
@@ -3208,7 +3207,6 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
     remote5 = deepcopy(remote)
     ttFont5 = deepcopy(ttFont)
 
-    import math
     remote5["OS/2"].fsSelection &= ~(1 << 7)
     remote5["head"].unitsPerEm = 2000
     # divide by 2 since we've doubled the upm
@@ -3217,10 +3215,10 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
     ttFont5["hhea"].ascent = math.ceil(remote5["OS/2"].usWinAscent / 2)
     ttFont5["hhea"].descent = math.ceil(-remote5["OS/2"].usWinDescent / 2)
     assert_PASS(check(ttFont5, remote5),
-                'with a remote family which does not have typo metrics'
-                ' enabled but the checked fonts vertical metrics have been'
-                ' set so its typo and hhea metrics match the remote'
-                ' fonts win metrics.')
+                'with a remote family which does not have typo metrics '
+                'enabled but the checked fonts vertical metrics have been '
+                'set so its typo and hhea metrics match the remote '
+                'fonts win metrics.')
 
 
     remote6 = deepcopy(remote)
@@ -3307,8 +3305,6 @@ def test_check_cjk_vertical_metrics():
 
 def test_check_cjk_vertical_metrics_regressions():
     from copy import deepcopy
-    from fontbakery.profiles.googlefonts import com_google_fonts_check_cjk_vertical_metrics_regressions as check
-
 
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/cjk_vertical_metrics_regressions")
@@ -3316,7 +3312,7 @@ def test_check_cjk_vertical_metrics_regressions():
     ttFont = TTFont(cjk_font)
     regular_remote_style = deepcopy(ttFont)
 
-    # Check on copy
+    # Check on duplicate
     regular_remote_style = deepcopy(ttFont)
     assert_PASS(check(ttFont, {"regular_remote_style": regular_remote_style}),
                 'for Source Han Sans')
@@ -3325,15 +3321,15 @@ def test_check_cjk_vertical_metrics_regressions():
     ttFont2 = deepcopy(ttFont)
     ttFont2['hhea'].ascent = 0
     assert_results_contain(check(ttFont2, {"regular_remote_style": regular_remote_style}),
-                            FAIL, "cjk-metric-regression",
-                            'hhea ascent is 0 when it should be 880')
+                           FAIL, "cjk-metric-regression",
+                           'hhea ascent is 0 when it should be 880')
 
     # Change upm of font being checked
     ttFont3 = deepcopy(ttFont)
     ttFont3['head'].unitsPerEm = 2000
     assert_results_contain(check(ttFont3, {"regular_remote_style": regular_remote_style}),
-                            FAIL, "cjk-metric-regression",
-                            'upm is 2000 and vert metrics values are not updated')
+                           FAIL, "cjk-metric-regression",
+                           'upm is 2000 and vert metrics values are not updated')
 
     # Change upm of checked font and update vert metrics
     ttFont4 = deepcopy(ttFont)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3164,7 +3164,7 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
     assert_PASS(check(ttFont, remote),
                 'with a good family...')
 
-    # FAIL with a changed vertical metric value
+    # FAIL with a changed vertical metric values
     remote2 = deepcopy(remote)
     ttFont2 = deepcopy(ttFont)
     ttFont2['OS/2'].sTypoAscender = 0
@@ -3172,11 +3172,20 @@ def test_check_vertical_metrics_regressions(cabin_ttFonts):
                            FAIL, 'bad-typo-ascender',
                            'with a family which has an incorrect typoAscender...')
 
-    # TODO:
-    #   FAIL, "bad-typo-descender"
-    #   FAIL, "bad-hhea-ascender"
-    #   FAIL, "bad-hhea-descender"
+    ttFont2['OS/2'].sTypoDescender = 0
+    assert_results_contain(check(ttFont2, remote2),
+                           FAIL, 'bad-typo-descender',
+                           'with a family which has an incorrect typoDescender...')
 
+    ttFont2['hhea'].ascent = 0
+    assert_results_contain(check(ttFont2, remote2),
+                           FAIL, 'bad-hhea-ascender',
+                           'with a family which has an incorrect hhea ascender...')
+
+    ttFont2['hhea'].descent = 0
+    assert_results_contain(check(ttFont2, remote2),
+                           FAIL, 'bad-hhea-descender',
+                           'with a family which has an incorrect hhea descender...')
 
     # Fail if family on Google Fonts has fsSelection bit 7 enabled but checked fonts don't
     remote3 = deepcopy(remote)


### PR DESCRIPTION
I'm going to refactor the vertical metric checks into the following four separate checks:

1. Check vertical metrics
2. Check vertical metrics regressions
3. Check CJK vertical metrics
4. Check CJK vertical metric regressions

This will be much cleaner than our current setup.