### PR TITLE
Update seems_monospaced conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/gdef_non_mark_chars]:** Same as com.google.fonts/check/gdef_mark_chars.
   - **[com.google.fonts/check/kerning_for_non_ligated_sequences]:** Change 'ligatures' condition to match changes in fontTools 4.22.0.
 a - **[com.google.fonts/check/ligature_carets]:** Change 'ligature_glyphs' condition to match changes in fontTools 4.22.0. Updated rationale because fontmake 2.4.0 can compile ligature carets.
+  - **[com.google.fonts/check/monospace]:** Changed conditions of seems_monospaced returned by glyph_metrics_stats(), if less than 80% of ASCII characters are in the font then it seems monospaced when all glyphs have one of two widths, excluding control character glyphs, mark glyphs and zero-width glyphs, instead of always 80% of ASCII glyphs having the same width.
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -157,16 +157,45 @@ def glyph_metrics_stats(ttFont):
     """Returns a dict containing whether the font seems_monospaced,
     what's the maximum glyph width and what's the most common width.
 
-    For a font to be considered monospaced, at least 80% of
-    the ascii glyphs must have the same width."""
+    For a font to be considered monospaced, if at least 80% of ASCII
+    characters have glyphs, then at least 80% of must have the same width,
+    otherwise all glyphs of printable characters must have one of two widths
+    or be zero-width.
+    """
     glyph_metrics = ttFont['hmtx'].metrics
-    ascii_glyph_names = [ttFont.getBestCmap()[c] for c in range(32, 128)
+    ascii_glyph_names = [ttFont.getBestCmap()[c] for c in range(32, 127)
                          if c in ttFont.getBestCmap()]
-    ascii_widths = [adv for name, (adv, lsb) in glyph_metrics.items()
-                    if name in ascii_glyph_names and adv != 0]
-    ascii_width_count = Counter(ascii_widths)
-    ascii_most_common_width = ascii_width_count.most_common(1)[0][1]
-    seems_monospaced = ascii_most_common_width >= len(ascii_widths) * 0.8
+
+    if len(ascii_glyph_names) > 0.8 * (127 - 32):
+        ascii_widths = [adv for name, (adv, lsb) in glyph_metrics.items()
+                        if name in ascii_glyph_names and adv != 0]
+        ascii_width_count = Counter(ascii_widths)
+        ascii_most_common_width = ascii_width_count.most_common(1)[0][1]
+        seems_monospaced = ascii_most_common_width >= len(ascii_widths) * 0.8
+    else:
+        from fontTools import unicodedata
+        # Collect relevant glyphs.
+        relevant_glyph_names = set()
+        # Add character glyphs that are in one of these categories:
+        # Letter, Mark, Number, Punctuation, Symbol, Space_Separator.
+        # This excludes Line_Separator, Paragraph_Separator and Control.
+        for value, name in ttFont.getBestCmap().items():
+            if unicodedata.category(chr(value)).startswith(
+                ("L", "M", "N", "P", "S", "Zs")
+            ):
+                relevant_glyph_names.add(name)
+        # Remove character glyphs that are mark glyphs.
+        gdef = ttFont.get("GDEF")
+        if gdef:
+            marks = {name
+                     for name, c in gdef.table.GlyphClassDef.classDefs.items()
+                     if c == 3
+                    }
+            relevant_glyph_names.difference_update(marks)
+
+        widths = sorted({adv for name, (adv, lsb) in glyph_metrics.items()
+                         if name in relevant_glyph_names and adv != 0})
+        seems_monospaced = len(widths) <= 2
 
     width_max = max([adv for k, (adv, lsb) in glyph_metrics.items()])
     most_common_width = Counter([g for g in glyph_metrics.values()

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -158,9 +158,9 @@ def glyph_metrics_stats(ttFont):
     what's the maximum glyph width and what's the most common width.
 
     For a font to be considered monospaced, if at least 80% of ASCII
-    characters have glyphs, then at least 80% of must have the same width,
-    otherwise all glyphs of printable characters must have one of two widths
-    or be zero-width.
+    characters have glyphs, then at least 80% of those must have the same
+    width, otherwise all glyphs of printable characters must have one of
+    two widths or be zero-width.
     """
     glyph_metrics = ttFont['hmtx'].metrics
     ascii_glyph_names = [ttFont.getBestCmap()[c] for c in range(32, 127)

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -65,6 +65,7 @@ def test_check_monospace():
     """ Checking correctness of monospaced metadata. """
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/monospace")
+    import string
     from fontbakery.constants import (PANOSE_Proportion,
                                       IsFixedWidth)
 
@@ -107,7 +108,7 @@ def test_check_monospace():
     cmap = ttFont["cmap"]
     for subtable in list(cmap.tables):
         # Remove A-Z, a-z from cmap
-        for code in list(range(0x41, 0x5B)) + list(range(0x61, 0x7B)):
+        for code in list(map(ord, string.ascii_letters)):
             if subtable.cmap.get(code):
                 del subtable.cmap[code]
     assert_results_contain(check(ttFont),
@@ -169,7 +170,7 @@ def test_check_monospace():
     cmap = ttFont["cmap"]
     for subtable in list(cmap.tables):
         # Remove A-Z, a-z from cmap
-        for code in list(range(0x41, 0x5B)) + list(range(0x61, 0x7B)):
+        for code in list(map(ord, string.ascii_letters)):
             if subtable.cmap.get(code):
                 del subtable.cmap[code]
 


### PR DESCRIPTION
## Description
When a font doesn’t have ASCII characters like A-Za-z, but at least
80% of ASCII character glyphs with the same width, for example if it has
tabular figures, fontbakery would assume it is a monospace font and
com.google.fonts/check/monospace would fail.

This replaces the conditions to be that at least 80% of glyphs of Unicode
characters should have one of two widths, excluding glyphs of control
characters, mark glyphs or zero-width glyphs.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

