### PR TITLE
Shared conditions ligatures and ligature_glyphs should not use LigatureSubst.Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/metadata/has_regular]:** Added hints to GF specs for single-weight families to FAIL output (PR #3197)
   - **[com.google.fonts/check/gdef_mark_chars]:** Do not consider chars with Unicode category Mc, Spacing_Marks as (non spacing) mark class glyphs.
   - **[com.google.fonts/check/gdef_non_mark_chars]:** Same as com.google.fonts/check/gdef_mark_chars.
+  - **[com.google.fonts/check/kerning_for_non_ligated_sequences]:** Change 'ligatures' condition to match changes in fontTools 4.22.0.
+a - **[com.google.fonts/check/ligature_carets]:** Change 'ligature_glyphs' condition to match changes in fontTools 4.22.0. Updated rationale because fontmake 2.4.0 can compile ligature carets.
 
 
 ## 0.7.34 (2021-Jan-06)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5130,7 +5130,7 @@ def com_google_fonts_check_metadata_designer_profiles(family_metadata):
         Most variable fonts should include an avar table to correctly define axes progression rates.
 
         For example, a weight axis from 0% to 100% doesn't map directly to 100 to 1000, because a 10% progression from 0% may be too much to define the 200, while 90% may be too little to define the 900.
-        
+
         If the progression rates of axes is linear, this check can be ignored. Fontmake will also skip adding an avar table if the progression rates are linear. However, we still recommend designers visually proof each instance is at the desired weight, width etc.
     """,
     conditions = ["is_variable_font"],

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3937,9 +3937,7 @@ def com_google_fonts_check_integer_ppem_if_hinted(ttFont):
     rationale = """
         All ligatures in a font must have corresponding caret (text cursor) positions defined in the GDEF table, otherwhise, users may experience issues with caret rendering.
 
-        If using GlyphsApp, ligature carets can be set directly on canvas by accessing the `Glyph -> Set Anchors` menu option or by pressing the `Cmd+U` keyboard shortcut.
-
-        If designing with UFOs, (as of Oct 2020) ligature carets are not yet compiled by ufo2ft, and therefore will not build via FontMake. See googlefonts/ufo2ft/issues/329
+        If using GlyphsApp or UFOs, ligature carets can be defined as anchors with names starting with 'caret_'. These can be compiled with fontmake as of version v2.4.0.
     """,
     misc_metadata = {
         'request': 'https://github.com/googlefonts/fontbakery/issues/1225'

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -109,6 +109,8 @@ def superfamily_ttFonts(superfamily):
 
 @condition
 def ligatures(ttFont):
+    from fontTools.ttLib.tables.otTables import LigatureSubst
+
     all_ligatures = {}
     try:
         if "GSUB" in ttFont and ttFont["GSUB"].table.LookupList:
@@ -117,7 +119,7 @@ def ligatures(ttFont):
                     for index in record.Feature.LookupListIndex:
                         lookup = ttFont["GSUB"].table.LookupList.Lookup[index]
                         for subtable in lookup.SubTable:
-                            if subtable.Format == 1:
+                            if isinstance(subtable, LigatureSubst):
                                 for firstGlyph in subtable.ligatures.keys():
                                     all_ligatures[firstGlyph] = []
                                     for lig in subtable.ligatures[firstGlyph]:
@@ -130,6 +132,8 @@ def ligatures(ttFont):
 
 @condition
 def ligature_glyphs(ttFont):
+    from fontTools.ttLib.tables.otTables import LigatureSubst
+
     all_ligature_glyphs = []
     try:
         if "GSUB" in ttFont and ttFont["GSUB"].table.LookupList:
@@ -138,7 +142,7 @@ def ligature_glyphs(ttFont):
                     for index in record.Feature.LookupListIndex:
                         lookup = ttFont["GSUB"].table.LookupList.Lookup[index]
                         for subtable in lookup.SubTable:
-                            if subtable.Format == 1:
+                            if isinstance(subtable, LigatureSubst):
                                 for firstGlyph in subtable.ligatures.keys():
                                     for lig in subtable.ligatures[firstGlyph]:
                                         if lig.LigGlyph not in all_ligature_glyphs:


### PR DESCRIPTION
## Description
Checks that use `ligatures` and `ligature_glyphs` have an error and yield FAIL because of this change in [fontTools 4.22.0](https://github.com/fonttools/fonttools/releases/tag/4.22.0):
> * [ttLib] Remove .Format from Coverage, ClassDef, SingleSubst, LigatureSubst, AlternateSubst, MultipleSubst ([#2238](https://github.com/fonttools/fonttools/pull/2238)).
> ATTENTION: This will change your TTX dumps!

This replaces `subtable.Format == 1` by `isinstance(subtable, LigatureSubst)`.

The conditions are still problematic as outlined in #3047 and #3131, this will partially fix the issues as well. But a better approach is needed to collect ligature components glyphs and ligature glyphs.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

