### PR TITLE
use Chris Simpkins' dehinter instead of ttfautohint-py to dehint font files while computing the file-size impact of hinting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bugfixes
   - **license** condition now assumes that all license files in a given project repo are identical if more than one is found. With that some checks wont be skipped. We should have a fontbakery check to ensuring that assumption is valid, though. (issue #3172)
   - **license_path** condition: do not cause an ERROR on families lacking a license file. (issue #3201)
+  - use Chris Simpkins' dehinter instead of ttfautohint-py to dehint font files while computing the file-size impact of hinting. (issue #3229)
 
 ### New Checks
   - **[com.google.fonts/check/cjk_vertical_metrics_regressions]:** Check CJK family has the same vertical metrics as the same family hosted on Google Fonts (issue #3242)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1426,7 +1426,7 @@ def com_google_fonts_check_has_ttfautohint_params(ttFont):
         This check finds which version of ttfautohint was used, by inspecting name table entries and then finds which version of ttfautohint is currently installed in the system.
     """
 )
-def com_google_fonts_check_old_ttfautohint(ttFont, hinting_stats):
+def com_google_fonts_check_old_ttfautohint(ttFont, hinting_stats, installed_ttfa):
     """Font has old ttfautohint applied?"""
     from fontbakery.utils import get_name_entry_strings
 
@@ -1447,7 +1447,7 @@ def com_google_fonts_check_old_ttfautohint(ttFont, hinting_stats):
         used = list(map(int, used.split(".")))
         return installed > used
 
-    if not hinting_stats:
+    if not installed_ttfa:
         yield ERROR,\
               Message("not-available",
                       "ttfautohint is not available.")
@@ -1470,7 +1470,6 @@ def com_google_fonts_check_old_ttfautohint(ttFont, hinting_stats):
                       f" Such font version strings are currently:"
                       f" {version_strings}")
     else:
-        installed_ttfa = hinting_stats["version"]
         try:
             if installed_version_is_newer(installed_ttfa,
                                           ttfa_version):

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -291,23 +291,23 @@ def hinting_stats(font):
     """
     Return file size differences for a hinted font compared to an dehinted version of same file
     """
-    from ttfautohint import ttfautohint, libttfautohint
     from io import BytesIO
+    from dehinter.font import dehint
     from fontTools.ttLib import TTFont
     from fontTools.subset import main as pyftsubset
     from fontbakery.profiles.shared_conditions import (is_ttf,
                                                        is_cff,
                                                        is_cff2)
 
-    if is_ttf(TTFont(font)):
-        original_buffer = BytesIO()
-        TTFont(font).save(original_buffer)
-        dehinted_buffer = ttfautohint(in_buffer=original_buffer.getvalue(),
-                                      dehint=True)
-        dehinted_size = len(dehinted_buffer)
-        version = libttfautohint.version_string
-
-    elif is_cff(TTFont(font)) or is_cff2(TTFont(font)):
+    ttFont = TTFont(font)
+    if is_ttf(ttFont):
+        version = "" # TODO
+        dehinted_buffer = BytesIO()
+        dehint(ttFont, verbose=False)
+        ttFont.save(dehinted_buffer)
+        dehinted_buffer.seek(0)
+        dehinted_size = len(dehinted_buffer.read())
+    elif is_cff(ttFont) or is_cff2(ttFont):
         ext = os.path.splitext(font)[1]
         tmp = font.replace(ext, "-tmp-dehinted%s" % ext)
         args = [font,

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -287,6 +287,22 @@ def familyname(font):
 
 
 @condition
+def installed_ttfa():
+   import subprocess
+   ttfa_cmd = ["ttfautohint",
+               "-V"]  # print version info
+   try:
+       ttfa_output = subprocess.check_output(ttfa_cmd,
+                                             stderr=subprocess.STDOUT)
+   except FileNotFoundError:
+       return None
+
+   installed = re.search(r'ttfautohint ([^-\n]*)(-.*)?\n',
+                         ttfa_output.decode('utf-8')).group(1)
+   return installed
+
+
+@condition
 def hinting_stats(font):
     """
     Return file size differences for a hinted font compared to an dehinted version of same file
@@ -299,9 +315,10 @@ def hinting_stats(font):
                                                        is_cff,
                                                        is_cff2)
 
+    hinted_size = os.stat(font).st_size
     ttFont = TTFont(font)
+
     if is_ttf(ttFont):
-        version = "" # TODO
         dehinted_buffer = BytesIO()
         dehint(ttFont, verbose=False)
         ttFont.save(dehinted_buffer)
@@ -326,7 +343,6 @@ def hinting_stats(font):
         pyftsubset(args)
 
         dehinted_size = os.stat(tmp).st_size
-        version = "" # TODO If there is a way, extract the psautohint version used?
         os.remove(tmp)
 
     else:
@@ -334,8 +350,7 @@ def hinting_stats(font):
 
     return {
         "dehinted_size": dehinted_size,
-        "hinted_size": os.stat(font).st_size,
-        "version": version
+        "hinted_size": hinted_size,
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup4==4.9.3
 toml==0.10.2
 PyYAML==5.4.1
 defcon==0.8.1
+dehinter==3.1.0
 font-v==1.0.5
 fontTools[ufo,lxml,unicode]==4.22.1
 lxml==4.6.3
@@ -10,7 +11,6 @@ opentype-sanitizer==8.1.3.post1
 pip-api==0.0.20
 protobuf==3.15.8
 requests==2.25.1
-ttfautohint-py==0.4.3
 ufolint==1.2.0
 unidecode==1.2.0
 beziers==0.3.1

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'toml',
         'PyYAML',
         'defcon',
+        'dehinter>=3.1.0', # 3.1.0 added dehinter.font.hint function
         'font-v',
         'fontTools[ufo,lxml,unicode]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
         'lxml',
@@ -72,7 +73,6 @@ setup(
         'protobuf>=3.7.0',  # 3.7.0 fixed a bug on parsing some METADATA.pb files
                             # (see https://github.com/googlefonts/fontbakery/issues/2200)
         'requests',
-        'ttfautohint-py',
         'ufolint',
         'unidecode',
         'beziers',


### PR DESCRIPTION
(issue #3229)