### PR TITLE
Split out `variable_font_filename` into a reusable condition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bug Fixes
   - fix crash on *glyph_metrics_stats* condition (issue #3273)
 
+### Changes to existing checks
+  - **[com.google.fonts/check/canonical_filename]:** Split out `variable_font_filename` into a reusable condition (issue #3274)
+
 
 ## 0.7.35 (2021-May-12)
 ### Release notes

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -37,6 +37,28 @@ def is_cff2(ttFont):
 
 
 @condition
+def variable_font_filename(ttFont):
+    from fontbakery.utils import get_name_entry_strings
+    from fontbakery.constants import (MacStyle,
+                                      NameID)
+    familynames = get_name_entry_strings(ttFont, NameID.FONT_FAMILY_NAME)
+    typo_familynames = get_name_entry_strings(ttFont, NameID.TYPOGRAPHIC_FAMILY_NAME)
+    if familynames == []:
+        return None
+
+    familyname = typo_familynames[0] if typo_familynames else familynames[0]
+    familyname = "".join(familyname.split(' ')) #remove spaces
+    if bool(ttFont["head"].macStyle & MacStyle.ITALIC):
+        familyname+="-Italic"
+
+    tags = ttFont["fvar"].axes
+    tags = list(map(lambda t: t.axisTag, tags))
+    tags.sort()
+    tags = "[{}]".format(",".join(tags))
+    return f"{familyname}{tags}.ttf"
+
+
+@condition
 def family_directory(font):
     """Get the path of font project directory."""
     if font:

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -207,6 +207,7 @@ def test_check_canonical_filename():
                            FAIL, 'invalid-char',
                            'with filename containing an underscore...')
 
+    # TODO: FAIL, 'unknown-name'
     # TODO: FAIL, 'bad-static-filename'
     # TODO: FAIL, 'varfont-with-static-filename'
 


### PR DESCRIPTION
And use it on **com.google.fonts/check/canonical_filename**
(issue #3274)