### PR TITLE
[fvar profile] Update fvar opsz Regular instance coordinate range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.7.37 (2021-May-??)
 ### Release notes
-  - ...
+
+
+### Changes to existing checks
+  - **[com.google.fonts/check/varfont/regular_opsz_coord]:** update the "Regular" instance opsz axis range  guidance to 10 - 16 from 9 - 13 according to updated [OT spec](https://docs.microsoft.com/en-gb/typography/opentype/spec/dvaraxistag_opsz) (PR #3292)
 
 
 ## 0.7.36 (2021-May-14)

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -120,7 +120,7 @@ def com_google_fonts_check_varfont_regular_ital_coord(ttFont, regular_ital_coord
     rationale = """
         According to the Open-Type spec's registered design-variation tag 'opsz' available at https://docs.microsoft.com/en-gb/typography/opentype/spec/dvaraxistag_opsz
 
-        If a variable font has a 'opsz' (Optical Size) axis, then the coordinate of its 'Regular' instance is recommended to be a value in the range 9 to 13.
+        If a variable font has an 'opsz' (Optical Size) axis, then the coordinate of its 'Regular' instance is recommended to be a value in the range 10 to 16.
     """,
     conditions = ['is_variable_font',
                   'regular_opsz_coord'],
@@ -129,16 +129,16 @@ def com_google_fonts_check_varfont_regular_ital_coord(ttFont, regular_ital_coord
     }
 )
 def com_google_fonts_check_varfont_regular_opsz_coord(ttFont, regular_opsz_coord):
-    """The variable font 'opsz' (Optical Size) axis coordinate should be between 9 and 13 on the 'Regular' instance."""
+    """The variable font 'opsz' (Optical Size) axis coordinate should be between 10 and 16 on the 'Regular' instance."""
 
-    if regular_opsz_coord >= 9 and regular_opsz_coord <= 13:
+    if regular_opsz_coord >= 10 and regular_opsz_coord <= 16:
         yield PASS, ("Regular:opsz coordinate ({regular_opsz_coord}) looks good.")
     else:
         yield WARN,\
               Message("out-of-range",
                       f'The "opsz" (Optical Size) coordinate'
                       f' on the "Regular" instance is recommended'
-                      f' to be a value in the range 9 to 13.'
+                      f' to be a value in the range 10 to 16.'
                       f' Got {regular_opsz_coord} instead.')
 
 

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -123,14 +123,14 @@ def test_check_varfont_regular_opsz_coord():
     ttFont["fvar"].axes.append(new_axis)
 
     # and specify a bad coordinate for the Regular:
-    ttFont["fvar"].instances[0].coordinates["opsz"] = 8
+    ttFont["fvar"].instances[0].coordinates["opsz"] = 9
     # Note: I know the correct instance index for this hotfix because
     # I inspected the our reference CabinVF using ttx
 
     # Then we ensure the problem is detected:
     assert_results_contain(check(ttFont),
                            WARN, 'out-of-range',
-                           'with a bad Regular:opsz coordinate (8)...')
+                           'with a bad Regular:opsz coordinate (9)...')
 
     # We try yet another bad value
     # and the check should detect the problem:

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -109,7 +109,7 @@ def test_check_varfont_regular_ital_coord():
 
 def test_check_varfont_regular_opsz_coord():
     """ The variable font 'opsz' (Optical Size) axis coordinate
-        should be between 9 and 13 on the 'Regular' instance. """
+        should be between 10 and 16 on the 'Regular' instance. """
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/varfont/regular_opsz_coord")
     from fontTools.ttLib.tables._f_v_a_r import Axis
@@ -134,12 +134,12 @@ def test_check_varfont_regular_opsz_coord():
 
     # We try yet another bad value
     # and the check should detect the problem:
-    assert_results_contain(check(ttFont, {"regular_opsz_coord": 14}),
+    assert_results_contain(check(ttFont, {"regular_opsz_coord": 20}),
                            WARN, 'out-of-range',
-                           'with another bad Regular:opsz value (14)...')
+                           'with another bad Regular:opsz value (20)...')
 
     # We then test with good default opsz values:
-    for value in [9, 10, 11, 12, 13]:
+    for value in [10, 11, 12, 13, 14, 15, 16]:
         assert_PASS(check(ttFont, {"regular_opsz_coord": value}),
                     f'with a good Regular:opsz coordinate ({value})...')
 

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -134,9 +134,9 @@ def test_check_varfont_regular_opsz_coord():
 
     # We try yet another bad value
     # and the check should detect the problem:
-    assert_results_contain(check(ttFont, {"regular_opsz_coord": 20}),
+    assert_results_contain(check(ttFont, {"regular_opsz_coord": 17}),
                            WARN, 'out-of-range',
-                           'with another bad Regular:opsz value (20)...')
+                           'with another bad Regular:opsz value (17)...')
 
     # We then test with good default opsz values:
     for value in [10, 11, 12, 13, 14, 15, 16]:


### PR DESCRIPTION
The guidance @ https://docs.microsoft.com/en-gb/typography/opentype/spec/dvaraxistag_opsz was updated to a new range since this test was originally developed

This PR updates the "Regular" instance opsz value guidance to 10 - 16 from 9 - 13
