### PR TITLE
Update googlefonts.py/max_length from 1k to 2k max chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/os2/use_typo_metrics]:** Confirm that OS/2.fsSelection bit 7 (USE TYPO METRICS) is set (PR #3314, issue #3241)
 
 ### Dependencies
-  - Drop again the usage of unidecode due to licensing policies (issue #3316).
+  - Drop again the usage of unidecode due to licensing policies (issue #3316)
+
+### Changes to existing checks
+  - **[com.google.fonts/check/description/max_length]:** nowadays the Google Fonts specimen pages allow for longer texts without upsetting the balance of the page. So the new limit is 2,000 characters. (PR #3337)
 
 
 ## 0.7.37 (2021-May-20)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -420,17 +420,24 @@ def com_google_fonts_check_description_min_length(description):
 
 @check(
     id = 'com.google.fonts/check/description/max_length',
-    conditions = ['description']
+    conditions = ['description'],
+    rationale = """
+        The fonts.google.com catalog specimen pages 2016 to 2020 were placed in a narrow area of the page.
+        That meant a maximum limit of 1,000 characters was good, so that the narrow column did not extent that section of the page to be too long.
+        
+        But with the "v4" redesign of 2020, the specimen pages allow for longer texts without upsetting the balance of the page.
+        So currently the limit before warning is 2,000 characters.
+    """,
 )
 def com_google_fonts_check_description_max_length(description):
-    """DESCRIPTION.en_us.html must have less than 1000 bytes."""
-    if len(description) >= 1000:
+    """DESCRIPTION.en_us.html must have less than 2000 bytes."""
+    if len(description) >= 2000:
         yield FAIL,\
               Message("too-long",
                       "DESCRIPTION.en_us.html must"
-                      " have size smaller than 1000 bytes.")
+                      " have size smaller than 2000 bytes.")
     else:
-        yield PASS, "DESCRIPTION.en_us.html is smaller than 1000 bytes."
+        yield PASS, "DESCRIPTION.en_us.html is smaller than 2,000 bytes."
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -321,25 +321,25 @@ def test_check_description_min_length():
 
 
 def test_check_description_max_length():
-    """ DESCRIPTION.en_us.html must have less than 1000 bytes. """
+    """ DESCRIPTION.en_us.html must have less than 2000 bytes. """
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/description/max_length")
 
     font = TEST_FILE("nunito/Nunito-Regular.ttf")
 
-    bad_length = 'a' * 1001
+    bad_length = 'a' * 2001
     assert_results_contain(check(font, {"description": bad_length}),
                            FAIL, "too-long",
-                           'with 1001-byte buffer...')
+                           'with 2001-byte buffer...')
 
-    bad_length = 'a' * 1000
+    bad_length = 'a' * 2000
     assert_results_contain(check(font, {"description": bad_length}),
                            FAIL, "too-long",
-                           'with 1000-byte buffer...')
+                           'with 2000-byte buffer...')
 
-    good_length = 'a' * 999
+    good_length = 'a' * 1999
     assert_PASS(check(font, {"description": good_length}),
-                'with 999-byte buffer...')
+                'with 1999-byte buffer...')
 
 
 def test_check_description_eof_linebreak():


### PR DESCRIPTION
## Description
This pull request addresses a problem I noticed in https://github.com/google/fonts/pull/3518 where the description was not overly long but still got a WARN result.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [x] request a review

