### PR TITLE
Fix a bug in check/whitespace_ink affecting Ogham Space Mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Dependencies
   - Drop again the usage of unidecode due to licensing policies (issue #3316)
 
+### Bug Fixes
+  - Fixed a bug in check/whitespace_ink affecting Ogham Space Mark. The set of codepoints was created incorrectly because we forgot to use parentheses in the expression, which resulted in the set of non-drawing codepoints to still include the ogham space mark codepoint (quite the opposite of what the comment said we were doing there :-P) Now the check handles it properly and I also added a test case to ensure we do not reintroduce the bug. (issue #3345)
+
 ### Changes to existing checks
   - **[com.google.fonts/check/description/max_length]:** nowadays the Google Fonts specimen pages allow for longer texts without upsetting the balance of the page. So the new limit is 2,000 characters. (PR #3337)
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -541,7 +541,7 @@ def com_google_fonts_check_whitespace_ink(ttFont):
     # Make the set of non drawing characters.
     # OGHAM SPACE MARK U+1680 is removed as it is
     # a whitespace that should have a drawing.
-    NON_DRAWING = WHITESPACE_CHARACTERS | EXTRA_NON_DRAWING - {0x1680}
+    NON_DRAWING = (WHITESPACE_CHARACTERS | EXTRA_NON_DRAWING) - {0x1680}
 
     passed = True
     for codepoint in sorted(NON_DRAWING):

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -485,6 +485,10 @@ def test_check_whitespace_ink():
     test_font = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
     assert_PASS(check(test_font))
 
+    test_font["cmap"].tables[0].cmap[0x1680] = "a"
+    assert_PASS(check(test_font),
+                'because Ogham space mark does have ink.')
+
     test_font["cmap"].tables[0].cmap[0x0020] = "uni1E17"
     assert_results_contain(check(test_font),
                            FAIL, 'has-ink',


### PR DESCRIPTION
The set of codepoints was created incorrectly because we forgot to use parentheses in the expression, which resulted in the set of non-drawing codepoints to still include the ogham space mark codepoint (quite the opposite of what the comment said we were doing there :-P)
Now the check handles it properly and I also added a test case to ensure we do not reintroduce the bug.
(issue #3345)