### PR TITLE
Fix display of percentage

### DIFF
--- a/Lib/fontbakery/profiles/outline.py
+++ b/Lib/fontbakery/profiles/outline.py
@@ -85,7 +85,7 @@ def com_google_fonts_check_outline_alignment_miss(ttFont, outlines_dict):
 @check(
     id = "com.google.fonts/check/outline_short_segments",
     rationale = f"""
-        This check looks for outline segments which seem particularly short (less than {SHORT_PATH_EPSILON}%% of the overall path length).
+        This check looks for outline segments which seem particularly short (less than {SHORT_PATH_EPSILON:.1%} of the overall path length).
 
         This check is not run for variable fonts, as they may legitimately have short segments. As this check is liable to generate significant numbers of false positives, it will pass if there are more than {FALSE_POSITIVE_CUTOFF} reported short segments.
     """,


### PR DESCRIPTION
## Description
This pull request fixes the display of the percentage value in the rationale text for the `com.google.fonts/check/outline_short_segments` check.

old text:

          This check looks for outline segments which seem particularly short (less 
      than 0.006%% of the overall path length).

new text:

          This check looks for outline segments which seem particularly short (less 
      than 0.6% of the overall path length).

Note: this fixes both the magnitude (0.006 = 0.6%) and the display of the `%` (presumably at some point in the past the string was changed from a `.format()` style to a Python f-string.

I haven't written a test, but you can check the output with:

    fontbakery check-universal -c com.google.fonts/check/outline_short_segments ./data/test/wonky_paths/WonkySourceSansPro-Regular.otf


## To Do
- [x] update `CHANGELOG.md` (I really don't think we need a CHANGELOG for this)
- [ ] wait for all checks to pass
- [ ] request a review

