### PR TITLE
Check for debugging tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/layout_valid_script_tags]:** Check if the font contains any invalid script tags. (PR #3359, issue #3355)
   - **[com.google.fonts/check/layout_valid_language_tags]:** Check if the font contains any invalid language tags. (PR #3359, issue #3355)
   - **[com.google.fonts/check/meta/script_lang_tags]:** Ensure fonts have ScriptLangTags declared on the 'meta' table. (issue #3349)
+  - **[com.google.fonts/check/no_debugging_tables]:** Ensure fonts do not contain any preproduction tables. (issue #3357)
 
 ### Bug Fixes
   - Add a code-testing mechanism to ignore spurious ERRORs and use it for not letting the namecheck timeouts break our CI builds. (issue #3366)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5501,26 +5501,24 @@ def com_google_fonts_check_meta_script_lang_tags(ttFont):
 
 
 @check(
-    id="com.google.fonts/check/no_debugging_tables",
-    rationale="""
-        Tables such as `Debg` are useful in the pre-production stages of font
-        development, but add unnecessary bloat to a production font and should
-        be removed before release.
+    id = "com.google.fonts/check/no_debugging_tables",
+    rationale = """
+        Tables such as `Debg` are useful in the pre-production stages of font development, but add unnecessary bloat to a production font and should be removed before release.
     """,
-    severity=6,
-    proposal="https://github.com/googlefonts/fontbakery/issues/3357",
+    severity = 6,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/3357',
 )
 def com_google_fonts_check_no_debugging_tables(ttFont):
-    """Ensure fonts do not contain any preproduction tables."""
+    """Ensure fonts do not contain any pre-production tables."""
 
     DEBUGGING_TABLES = ["Debg", "FFTM"]
     found = [t for t in DEBUGGING_TABLES if t in ttFont]
     if found:
-        yield WARN, Message(
-            "has-debugging-tables",
-            "This font file contains the following pre-production tables:"
-            + ", ".join(found),
-        )
+        tables_list = ", ".join(found)
+        yield WARN,\
+              Message("has-debugging-tables",
+                      f"This font file contains the following"
+                      f" pre-production tables: {tables_list}")
     else:
         yield PASS, "OK"
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -166,6 +166,7 @@ FONT_FILE_CHECKS = [
     'com.google.fonts/check/stylisticset_description',
     'com.google.fonts/check/os2/use_typo_metrics',
     'com.google.fonts/check/meta/script_lang_tags',
+    'com.google.fonts/check/no_debugging_tables',
 ]
 
 GOOGLEFONTS_PROFILE_CHECKS = \
@@ -5497,6 +5498,31 @@ def com_google_fonts_check_meta_script_lang_tags(ttFont):
             yield INFO,\
                   Message('slng-tag',
                           f"{ttFont['meta'].data['slng']}")
+
+
+@check(
+    id="com.google.fonts/check/no_debugging_tables",
+    rationale="""
+        Tables such as `Debg` are useful in the pre-production stages of font
+        development, but add unnecessary bloat to a production font and should
+        be removed before release.
+    """,
+    severity=6,
+    proposal="https://github.com/googlefonts/fontbakery/issues/3357",
+)
+def com_google_fonts_check_no_debugging_tables(ttFont):
+    """Ensure fonts do not contain any preproduction tables."""
+
+    DEBUGGING_TABLES = ["Debg", "FFTM"]
+    found = [t for t in DEBUGGING_TABLES if t in ttFont]
+    if found:
+        yield WARN, Message(
+            "has-debugging-tables",
+            "This font file contains the following pre-production tables:"
+            + ", ".join(found),
+        )
+    else:
+        yield PASS, "OK"
 
 
 ###############################################################################

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3826,3 +3826,15 @@ def test_check_meta_script_lang_tags():
     del ttFont["meta"]
     assert_results_contain(check(ttFont),
                            WARN, 'lacks-meta-table')
+
+
+def test_check_no_debugging_tables():
+    """Ensure fonts do not contain any preproduction tables."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/no_debugging_tables")
+
+    ttFont = TTFont(TEST_FILE("overpassmono/OverpassMono-Regular.ttf"))
+    assert_results_contain(check(ttFont), WARN, 'has-debugging-tables')
+
+    del ttFont["FFTM"]
+    assert_PASS(check(ttFont))


### PR DESCRIPTION
This implements the check requested in #3357:

- Add a check for blacklisted opentype tables
- Add a test for the check
- Add a changelog entry for the check.
