### PR TITLE
New check: com.google.fonts/check/family/italics_have_roman_counterparts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## 0.7.39 (2021-Jul-??)
+## 0.8.0 (2021-Jul-??)
 ### New Checks
+  - **[com.google.fonts/check/family/italics_have_roman_counterparts]:** Ensure Italic styles have Roman counterparts. (issue #1733)
   - **[com.google.fonts/check/layout_valid_feature_tags]:** Check if the font contains any invalid feature tags. (PR #3359, issue #3355)
   - **[com.google.fonts/check/layout_valid_script_tags]:** Check if the font contains any invalid script tags. (PR #3359, issue #3355)
   - **[com.google.fonts/check/layout_valid_language_tags]:** Check if the font contains any invalid language tags. (PR #3359, issue #3355)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -83,6 +83,7 @@ FAMILY_CHECKS = [
     'com.google.fonts/check/family/has_license',
     'com.google.fonts/check/family/control_chars',
     'com.google.fonts/check/family/tnum_horizontal_metrics',
+    'com.google.fonts/check/family/italics_have_roman_counterparts',
 ]
 
 NAME_TABLE_CHECKS = [
@@ -4305,6 +4306,60 @@ def com_google_fonts_check_family_control_chars(ttFonts):
                       f"{msg_unacceptable}")
     else:
         yield PASS, ("Unacceptable control characters were not identified.")
+
+
+@check(
+    id = 'com.google.fonts/check/family/italics_have_roman_counterparts',
+    rationale = """
+        For each font family on Google Fonts, every Italic style must have a Roman sibling.
+
+        This kind of problem was first observed at [1] where the Bold style was missing but BoldItalic was included.
+
+        [1] https://github.com/google/fonts/pull/1482
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/1733'
+)
+def com_google_fonts_check_family_italics_have_roman_counterparts(fonts):
+    """Ensure Italic styles have Roman counterparts."""
+
+    italics = [f for f in fonts if 'Italic' in f]
+    missing_roman = []
+    for italic in italics:
+        if '-' not in os.path.basename(italic) \
+            or len(os.path.basename(italic).split('-')[-1].split('.')) != 2:
+            yield WARN,\
+                  Message('bad-filename',
+                          f"Filename seems to be incorrect: '{italic}'")
+
+        style = os.path.basename(italic).split('-')[-1].split('.')[0]
+        is_varfont = '[' in style
+
+        # to remove the axes syntax used on variable-font filenames:
+        if is_varfont:
+            style = style.split('[')[0]
+
+        if style == 'Italic':
+            if is_varfont:
+                # "Familyname-Italic[wght,wdth].ttf" => "Familyname[wght,wdth].ttf"
+                roman_counterpart = italic.replace('-Italic', '')
+            else:
+                # "Familyname-Italic.ttf" => "Familyname-Regular.ttf"
+                roman_counterpart = italic.replace('Italic', 'Regular')
+        else:
+            # "Familyname-BoldItalic[wght,wdth].ttf" => "Familyname-Bold[wght,wdth].ttf"
+            roman_counterpart = italic.replace('Italic', '')
+
+        if roman_counterpart not in fonts:
+            missing_roman.append(italic)
+
+    if missing_roman:
+        from fontbakery.utils import pretty_print_list
+        missing_roman = pretty_print_list(missing_roman)
+        yield FAIL,\
+              Message('missing-roman',
+                      f"Italics missing a Roman counterpart: {missing_roman}")
+    else:
+        yield PASS, "OK"
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3063,6 +3063,50 @@ def test_check_family_control_chars():
                            'with multiple bad fonts that have multiple bad chars...')
 
 
+def test_check_family_italics_have_roman_counterparts():
+    """Ensure Italic styles have Roman counterparts."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/family/italics_have_roman_counterparts")
+
+    # The path used here, "some-crazy.path/", is meant to ensure
+    # that the parsing code does not get lost when trying to
+    # extract the style of a font file.
+    fonts = ['some-crazy.path/merriweather/Merriweather-BlackItalic.ttf',
+             'some-crazy.path/merriweather/Merriweather-Black.ttf',
+             'some-crazy.path/merriweather/Merriweather-BoldItalic.ttf',
+             'some-crazy.path/merriweather/Merriweather-Bold.ttf',
+             'some-crazy.path/merriweather/Merriweather-Italic.ttf',
+             'some-crazy.path/merriweather/Merriweather-LightItalic.ttf',
+             'some-crazy.path/merriweather/Merriweather-Light.ttf',
+             'some-crazy.path/merriweather/Merriweather-Regular.ttf']
+
+    assert_PASS(check(fonts),
+                'with a good family...')
+
+    fonts.pop(-1) # remove the last one, which is the Regular
+    assert 'some-crazy.path/merriweather/Merriweather-Regular.ttf' not in fonts
+    assert 'some-crazy.path/merriweather/Merriweather-Italic.ttf' in fonts
+    assert_results_contain(check(fonts),
+                           FAIL, 'missing-roman',
+                           'with a family that has an Italic but lacks a Regular.')
+
+    fonts.append('some-crazy.path/merriweather/MerriweatherItalic.ttf')
+    assert_results_contain(check(fonts),
+                           WARN, 'bad-filename',
+                           'with a family that has a non-canonical italic filename.')
+
+    # This check must also be able to deal with variable fonts!
+    fonts = ["cabinvfbeta/CabinVFBeta-Italic[wdth,wght].ttf",
+             "cabinvfbeta/CabinVFBeta[wdth,wght].ttf"]
+    assert_PASS(check(fonts),
+                'with a good set of varfonts...')
+
+    fonts = ["cabinvfbeta/CabinVFBeta-Italic[wdth,wght].ttf"]
+    assert_results_contain(check(fonts),
+                           FAIL, 'missing-roman',
+                           'with an Italic varfont that lacks a Roman counterpart.')
+
+
 def NOT_IMPLEMENTED__test_com_google_fonts_check_repo_dirname_match_nameid_1():
     """Are any unacceptable control characters present in font files?"""
     # check = CheckTester(googlefonts_profile,


### PR DESCRIPTION
Ensure Italic styles have Roman counterparts.
(issue #1733)