### PR TITLE
[com.google.fonts/check/license/OFL_body_text]: Silently tolerate "http://" on the OFL.txt file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bug Fixes
   - Add a code-testing mechanism to ignore spurious ERRORs and use it for not letting the namecheck timeouts break our CI builds. (issue #3366)
 
+### Changes to existing checks
+  - **[com.google.fonts/check/license/OFL_body_text]**: Silently tolerate usage of "http://" on the OFL.txt file. (issue #3372)
+
 
 ## 0.7.38 (2021-Jun-23)
 ### New Checks

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -805,7 +805,7 @@ OFL_BODY_TEXT = \
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-http://scripts.sil.org/OFL
+https://scripts.sil.org/OFL
 
 
 -----------------------------------------------------------

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1111,12 +1111,14 @@ def com_google_fonts_check_license_OFL_copyright(license_contents):
 def com_google_fonts_check_license_OFL_body_text(license_contents):
     """Check OFL body text is correct.""" 
     from fontbakery.constants import OFL_BODY_TEXT
-    if not OFL_BODY_TEXT in license_contents:
+
+    if not OFL_BODY_TEXT in license_contents.replace("http://", "https://"):
         yield FAIL,\
               Message("incorrect-ofl-body-text",
                       "The OFL.txt body text is incorrect. Please use"
-                      " https://github.com/googlefonts/Unified-Font-Repository/blob/main/OFL.txt"
-                      " as a template. You should only modify the first line.")
+                      " https://github.com/googlefonts/Unified-Font-Repository"
+                      "/blob/main/OFL.txt as a template."
+                      " You should only modify the first line.")
     else:
         yield PASS, "OFL license body text is correct"
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -803,11 +803,20 @@ def test_check_license_ofl_body_text():
 
     # Our reference Montserrat family is know to have
     # a proper OFL.txt license file.
+    # NOTE: This is currently considered good
+    #       even though it uses an "http://" URL
     font = TEST_FILE("montserrat/Montserrat-Regular.ttf")
     ttFont = TTFont(font)
 
     assert_PASS(check(ttFont),
-                'with a good OFL.txt license')
+                'with a good OFL.txt license with "http://" url.')
+
+
+    # using "https://" is also considered good:
+    good_license = check["license_contents"].replace("http://", "https://")
+    assert_PASS(check(ttFont, {'license_contents': good_license}),
+                'with a good OFL.txt license with "https://" url.')
+
 
     # modify a tiny bit of the license text, to trigger the FAIL:
     bad_license = check["license_contents"].replace("SIL OPEN FONT LICENSE Version 1.1",


### PR DESCRIPTION
(issue #3372)