### PR TITLE
 Fix is_OFL condition crash when lacking a license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.8.1 (2021-Aug-??)
-  - ...
+### Bug fixes
+  - Fix crash on is_OFL condition when a font project lacks a license. (issue #3393)
 
 
 ## 0.8.0 (2021-Jul-21)

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -275,7 +275,7 @@ def license(license_path):
 
 @condition
 def is_ofl(license):
-    return "OFL" in license
+    return license and "OFL" in license
 
 
 @condition


### PR DESCRIPTION
 (issue #3393)