### PR TITLE
Remove check/dsig override from AdobeFonts profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix crash on is_OFL condition when a font project lacks a license. (issue #3393)
 
 ### Changes to existing checks
+#### AdobeFonts Profile
+  - Remove **check/dsig** override, which was now outdated because the original check implementation was just changed to actually suggest (with a WARN) the removal of any DSIG tables. (issue #3407)
 #### OpenType Profile
   - **[com.google.fonts/check/dsig]:** We now recommend (with a WARN) completely removing the 'DSIG' table. We may make this a FAIL by November 2023 when the EOL date for MS Office 2013 is reached. (issue #3398)
   - **[com.google.fonts/check/gdef_mark_chars]:** Also print glyphnames on log messages (issue #3395)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -23,7 +23,6 @@ ADOBEFONTS_PROFILE_CHECKS = \
     ]
 
 OVERRIDDEN_CHECKS = [
-    'com.google.fonts/check/dsig',
     'com.google.fonts/check/whitespace_glyphs',
     'com.google.fonts/check/valid_glyphnames',
 ]
@@ -112,17 +111,6 @@ def com_adobe_fonts_check_find_empty_letters(ttFont):
 
 
 profile.auto_register(globals())
-
-
-profile.check_log_override(
-    # from `opentype` profile:
-    'com.google.fonts/check/dsig',
-    reason = 'For Adobe this issue is not as severe ' \
-           + 'as assessed in the original check.',
-    overrides = (
-        ('lacks-signature', WARN, KEEP_ORIGINAL_MESSAGE)
-    ,)
-)
 
 
 profile.check_log_override(


### PR DESCRIPTION
Outdated since the original check implementation changed to actually suggest (with a WARN) the removal of any DSIG tables.
(issue #3407)