### PR TITLE
New Check: Predictable family directory names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.8.2 (2021-Aug-??)
 ### Changes to existing checks
-#### GoogleFonts Profile
+#### On the Google Fonts Profile
   - **[com.google.fonts/check/metadata/designer_profiles]:** The `link` field is not currently used by the GFonts API, so it should be kept empty for now. (issue #3409)
+### New Checks
+#### Added to the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/family_directory_name]:** We want the directory name of a font family to be predictable and directly derived from the family name, all lowercased and removing spaces. (issue #3421)
 
 
 ## 0.8.1 (2021-Aug-11)
@@ -12,21 +15,21 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fix crash on is_OFL condition when a font project lacks a license. (issue #3393)
 
 ### Changes to existing checks
-#### AdobeFonts Profile
-  - Remove **check/dsig** override, which was now outdated because the original check implementation was just changed to actually suggest (with a WARN) the removal of any DSIG tables. (issue #3407)
+#### On the Universal Profile
+  - **[com.google.fonts/check/unwanted_tables]:** Stop rejecting MVAR table (issue #3400)
+  - **[com.google.fonts/check/required_tables]:** remove 'DSIG' from list of optional tables and improve wording on the check rationale. (issue #3398)
+  - **[com.google.fonts/check/outline_\*]:** Also print codepoints on the log messages (issue #3395)
 
-#### GoogleFonts Profile
-  - **[com.google.fonts/check/metadata/designer_profiles]:** Change "missing-link" FAIL to WARN (issue #3409)
-
-#### OpenType Profile
+#### On the OpenType Profile
   - **[com.google.fonts/check/dsig]:** We now recommend (with a WARN) completely removing the 'DSIG' table. We may make this a FAIL by November 2023 when the EOL date for MS Office 2013 is reached. (issue #3398)
   - **[com.google.fonts/check/gdef_mark_chars]:** Also print glyphnames on log messages (issue #3395)
   - **[com.google.fonts/check/gdef_spacing_marks]:** Also print glyphnames on log messages (issue #3395)
 
-#### Universal Profile
-  - **[com.google.fonts/check/unwanted_tables]:** Stop rejecting MVAR table (issue #3400)
-  - **[com.google.fonts/check/required_tables]:** remove 'DSIG' from list of optional tables and improve wording on the check rationale. (issue #3398)
-  - **[com.google.fonts/check/outline_\*]:** Also print codepoints on the log messages (issue #3395)
+#### On the Adobe Fonts Profile
+  - Remove **check/dsig** override, which was now outdated because the original check implementation was just changed to actually suggest (with a WARN) the removal of any DSIG tables. (issue #3407)
+
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/designer_profiles]:** Change "missing-link" FAIL to WARN (issue #3409)
 
 
 ## 0.8.0 (2021-Jul-21)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -64,7 +64,8 @@ METADATA_CHECKS = [
     'com.google.fonts/check/metadata/gf-axisregistry_bounds',
     'com.google.fonts/check/metadata/consistent_axis_enumeration',
     'com.google.fonts/check/metadata/escaped_strings',
-    'com.google.fonts/check/metadata/designer_profiles'
+    'com.google.fonts/check/metadata/designer_profiles',
+    'com.google.fonts/check/metadata/family_directory_name'
 ]
 
 DESCRIPTION_CHECKS = [
@@ -83,7 +84,7 @@ FAMILY_CHECKS = [
     'com.google.fonts/check/family/has_license',
     'com.google.fonts/check/family/control_chars',
     'com.google.fonts/check/family/tnum_horizontal_metrics',
-    'com.google.fonts/check/family/italics_have_roman_counterparts',
+    'com.google.fonts/check/family/italics_have_roman_counterparts'
 ]
 
 NAME_TABLE_CHECKS = [
@@ -92,7 +93,7 @@ NAME_TABLE_CHECKS = [
     'com.google.fonts/check/name/license_url',
     'com.google.fonts/check/name/family_and_style_max_length',
     'com.google.fonts/check/name/line_breaks',
-    'com.google.fonts/check/name/rfn',
+    'com.google.fonts/check/name/rfn'
 ]
 
 REPO_CHECKS = [
@@ -167,7 +168,7 @@ FONT_FILE_CHECKS = [
     'com.google.fonts/check/stylisticset_description',
     'com.google.fonts/check/os2/use_typo_metrics',
     'com.google.fonts/check/meta/script_lang_tags',
-    'com.google.fonts/check/no_debugging_tables',
+    'com.google.fonts/check/no_debugging_tables'
 ]
 
 GOOGLEFONTS_PROFILE_CHECKS = \
@@ -5568,6 +5569,30 @@ def com_google_fonts_check_no_debugging_tables(ttFont):
                       f" pre-production tables: {tables_list}")
     else:
         yield PASS, "OK"
+
+
+@check(
+    id = "com.google.fonts/check/metadata/family_directory_name",
+    rationale = """
+        We want the directory name of a font family to be predictable and directly derived from the family name, all lowercased and removing spaces.
+    """,
+    conditions = ['family_metadata',
+                  'family_directory'],
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/3421',
+)
+def com_google_fonts_check_metadata_family_directory_name(family_metadata, family_directory):
+    """Check font family directory name."""
+
+    dir_name = os.path.basename(family_directory)
+    expected = family_metadata.name.replace(" ", "").lower()
+    if expected != dir_name:
+        yield FAIL,\
+              Message("bad-directory-name",
+                      f'Family name on METADATA.pb is "{family_metadata.name}"\n'
+                      f'Directory name is "{dir_name}"\n'
+                      f'Expected "{expected}"')
+    else:
+        yield PASS, f'Directory name is "{dir_name}", as expected.'
 
 
 ###############################################################################

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3867,7 +3867,24 @@ def test_check_no_debugging_tables():
                         "com.google.fonts/check/no_debugging_tables")
 
     ttFont = TTFont(TEST_FILE("overpassmono/OverpassMono-Regular.ttf"))
-    assert_results_contain(check(ttFont), WARN, 'has-debugging-tables')
+    assert_results_contain(check(ttFont),
+                           WARN, 'has-debugging-tables')
 
     del ttFont["FFTM"]
     assert_PASS(check(ttFont))
+
+
+def test_check_metadata_family_directory_name():
+    """Check family directory name."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/metadata/family_directory_name")
+
+    ttFont = TEST_FILE("overpassmono/OverpassMono-Regular.ttf")
+    assert_PASS(check(ttFont))
+
+    # Note:
+    # Here I explicitly pass 'family_metadata' to avoid it being recomputed
+    # after I make the family_directory wrong:
+    assert_results_contain(check(ttFont, {'family_metadata': check['family_metadata'],
+                                          'family_directory': 'overpass'}),
+                           FAIL, 'bad-directory-name')


### PR DESCRIPTION
"We want the directory name of a font family to be
predictable and directly derived from the family name,
all lowercased and removing spaces."

com.google.fonts/check/metadata/family_directory_name
Added to the Google Fonts Profile
(issue #3421)