### PR TITLE
Move nested component check to googlefonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.8.2 (2021-Aug-??)
 ### Changes to existing checks
+#### On the OpenType Profile
+  - **[com.google.fonts/check/glyf_nested_components]:** Nested components are permitted by the OpenType specification, so this check has been moved to the Google Fonts profile. (issue #3424)
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/metadata/designer_profiles]:** The `link` field is not currently used by the GFonts API, so it should be kept empty for now. (issue #3409)
 ### New Checks

--- a/Lib/fontbakery/profiles/glyf.py
+++ b/Lib/fontbakery/profiles/glyf.py
@@ -125,39 +125,3 @@ def com_google_fonts_check_glyf_non_transformed_duplicate_components(ttFont):
     else:
         yield PASS, ("Glyphs do not contain duplicate components which have"
                      " the same x,y coordinates.")
-
-
-@check(
-    id = 'com.google.fonts/check/glyf_nested_components',
-    rationale = """
-        There have been bugs rendering variable fonts with nested components. Additionally, some static fonts with nested components have been reported to have rendering and printing issues.
-
-        For more info, see:
-        * https://github.com/googlefonts/fontbakery/issues/2961
-        * https://github.com/arrowtype/recursive/issues/412
-    """,
-    conditions = ['is_ttf'],
-    proposal = 'https://github.com/googlefonts/fontbakery/issues/2961'
-)
-def com_google_fonts_check_glyf_nested_components(ttFont):
-    """Check glyphs do not have components which are themselves components."""
-    from fontbakery.utils import pretty_print_list
-    failed = []
-    for glyph_name in ttFont['glyf'].keys():
-        glyph = ttFont['glyf'][glyph_name]
-        if not glyph.isComposite():
-            continue
-        for comp in glyph.components:
-            if ttFont['glyf'][comp.glyphName].isComposite():
-                failed.append(glyph_name)
-    if failed:
-        formatted_list = "\t* " + pretty_print_list(failed,
-                                                    shorten=10,
-                                                    sep="\n\t* ")
-        yield FAIL, \
-              Message('found-nested-components',
-                      f"The following glyphs have components which"
-                      f" themselves are component glyphs:\n"
-                      f"{formatted_list}")
-    else:
-        yield PASS, ("Glyphs do not contain nested components.")

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -73,7 +73,6 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/maxadvancewidth',
     'com.google.fonts/check/points_out_of_bounds',
     'com.google.fonts/check/glyf_non_transformed_duplicate_components',
-    'com.google.fonts/check/glyf_nested_components',
     'com.google.fonts/check/all_glyphs_have_codepoints',
     'com.google.fonts/check/code_pages',
     'com.google.fonts/check/layout_valid_feature_tags',

--- a/tests/profiles/glyf_test.py
+++ b/tests/profiles/glyf_test.py
@@ -69,19 +69,3 @@ def test_check_glyf_non_transformed_duplicate_components():
     ttFont['glyf']['quotedbl'].components[1].y = 0
     assert_results_contain(check(ttFont),
                            FAIL, 'found-duplicates')
-
-
-def test_check_glyf_nested_components():
-    """Check glyphs do not have nested components."""
-    check = CheckTester(opentype_profile,
-                        "com.google.fonts/check/glyf_nested_components")
-
-    ttFont = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
-    assert_PASS(check(ttFont))
-
-    # We need to create a nested component. "second" has components, so setting
-    # one of "quotedbl"'s components to "second" should do it.
-    ttFont['glyf']['quotedbl'].components[0].glyphName = "second"
-
-    assert_results_contain(check(ttFont),
-                           FAIL, 'found-nested-components')

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2758,6 +2758,22 @@ def test_check_fontv():
                 'with one that follows the suggested scheme ...')
 
 
+def test_check_glyf_nested_components():
+    """Check glyphs do not have nested components."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/glyf_nested_components")
+
+    ttFont = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
+    assert_PASS(check(ttFont))
+
+    # We need to create a nested component. "second" has components, so setting
+    # one of "quotedbl"'s components to "second" should do it.
+    ttFont['glyf']['quotedbl'].components[0].glyphName = "second"
+
+    assert_results_contain(check(ttFont),
+                           FAIL, 'found-nested-components')
+
+
 # Temporarily disabling this code-test since check/negative_advance_width itself
 # is disabled waiting for an implementation targetting the
 # actual root cause of the issue.


### PR DESCRIPTION
## Description

This pull request addresses the problems described at issue #3424, moving the `com.google.fonts/check/glyf_nested_components` check from the Opentype to the GF profile.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [ ] request a review