### PR TITLE
Allow testing of different kinds of file

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -77,8 +77,9 @@ class CheckRunner:
         self._exclude_checks = config["exclude_checks"]
         self._iterargs = OrderedDict()
         for singular, plural in profile.iterargs.items():
-            values[plural] = tuple(values[plural])
-            self._iterargs[singular] = len(values[plural])
+            if plural in values:
+                values[plural] = tuple(values[plural])
+                self._iterargs[singular] = len(values[plural])
 
         if not values_can_override_profile_names:
             for name in values:

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -261,7 +261,12 @@ def main(profile=None, values=None):
         add_profile_arg = True
 
     argument_parser, values_keys = ArgumentParser(profile, profile_arg=add_profile_arg)
-    args = argument_parser.parse_args()
+    try:
+        args = argument_parser.parse_args()
+    except ValueValidationError as e:
+        print(e)
+        argument_parser.print_usage()
+        sys.exit(1)
 
     # The default Windows Terminal just displays the escape codes. The argument
     # parser above therefore has these options disabled.

--- a/Lib/fontbakery/fonts_profile.py
+++ b/Lib/fontbakery/fonts_profile.py
@@ -21,10 +21,10 @@ class FileDescription:
 
 class FontsProfile(Profile):
     accepted_files = [
-      FileDescription(name="fonts", singular="font", extensions=[".otf",".ttf"], description="OpenType binary"),
-      FileDescription(name="ufos", singular="ufo", extensions=[".ufo"], description="UFO source"),
-      FileDescription(name="designspaces", singular="designspace", extensions=[".designspace"], description="Designspace"),
-      FileDescription(name="glyphs_files", singular="glyphs_file", extensions=[".glyphs"], description="Glyphs source"),
+        FileDescription(name="fonts", singular="font", extensions=[".otf",".ttf"], description="OpenType binary"),
+        FileDescription(name="ufos", singular="ufo", extensions=[".ufo"], description="UFO source"),
+        FileDescription(name="designspaces", singular="designspace", extensions=[".designspace"], description="Designspace"),
+        FileDescription(name="glyphs_files", singular="glyphs_file", extensions=[".glyphs"], description="Glyphs source"),
     ]
 
     def setup_argparse(self, argument_parser):
@@ -61,8 +61,8 @@ class FontsProfile(Profile):
                           accepted = True
                           any_accepted = True
                     if not accepted:
-                        logging.info(f"Skipping '{file}' as it does not seem "
-                                       "to be accepted by this profile.")
+                        logging.info("Skipping '{}' as it does not seem "
+                                       "to be accepted by this profile.".format(file))
                 if not any_accepted:
                     raise ValueValidationError('No applicable files found')
 
@@ -75,26 +75,26 @@ class FontsProfile(Profile):
             action=MergeAction,
             help='file path(s) to check. Wildcards like *.ttf are allowed.')
 
-        return tuple([x.name for x in self.accepted_files])
+        return tuple(x.name for x in self.accepted_files)
 
     def get_family_checks(self):
         family_checks = self.get_checks_by_dependencies('ttFonts')
         return family_checks
 
     @classmethod
-    def _expected_values(self):
+    def _expected_values(cls):
         return { val.name:
           ExpectedValue(val.name,
                         default = [],
                         description = f"A list of the {val.description} file paths to check",
                         force=True
                         )
-          for val in self.accepted_files
+          for val in cls.accepted_files
         }
 
     @classmethod
-    def _iterargs(self):
-        return { val.singular: val.name for val in self.accepted_files }
+    def _iterargs(cls):
+        return { val.singular: val.name for val in cls.accepted_files }
 
 def profile_factory(**kwds):
     from fontbakery.profiles.shared_conditions import ttFont

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -232,6 +232,7 @@ def ftxvalidator_cmd():
 
 @check(
     id = 'com.google.fonts/check/ftxvalidator_is_available',
+    conditions = ["fonts"],
     rationale = """
         There's no reasonable (and legal) way to run the command `ftxvalidator` of the Apple Font Tool Suite on a non-macOS machine. I.e. on GNU+Linux or Windows etc.
 


### PR DESCRIPTION
## Description

This implements the ideas in #3169, and is a prerequisite to revisiting the "designspace profile" idea.

With this PR in place, the FontsProfile has a list of file types and destinations, and sorts the list of files passed on the command line into the relevant destinations, which are then injected into checks.

The destinations defined in FontsProfile by this PR are:

* fonts: *.otf, *.ttf
* ufos: *.ufo
* designspaces: *.designspace
* glyphs_files: *.glyphs

Now any check can take e.g. `glyphs_file` as a parameter to test a Glyphs file. Notice how with this the `ufo_sources` profile becomes much simpler.

## To Do
- [ ] update `CHANGELOG.md` (will do when we are happy with the concept)
- [ ] wait for all checks to pass
- [ ] request a review
