### PR TITLE
Document reason for rejection of the 'prop' table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.8.2 (2021-Aug-??)
 ### Changes to existing checks
+#### On the Universal Profile
+  - **[com.google.fonts/check/unwanted_tables]:** Documented reason for rejection of the 'prop' table. It is a table used on Apple's OSX-specific AAT and new fonts should not be using that. (issue #3411)
+
 #### On the OpenType Profile
   - **[com.google.fonts/check/glyf_nested_components]:** Nested components are permitted by the OpenType specification, so this check has been moved to the Google Fonts profile. (issue #3424)
+
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/metadata/designer_profiles]:** The `link` field is not currently used by the GFonts API, so it should be kept empty for now. (issue #3409)
+
 ### New Checks
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/transformed_components]:** Ensure component transforms do not perform scaling or rotation (which causes hinting and rasterization issues). (issue #2011)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -648,7 +648,9 @@ def com_google_fonts_check_unwanted_tables(ttFont):
         'TSI2': 'Table contains data only used in VTT',
         'TSI3': 'Table contains data only used in VTT',
         'TSI5': 'Table contains data only used in VTT',
-        'prop': '', # FIXME: Why is this one unwanted?
+        'prop': ('Table used on AAT, Apple\'s OS X specific technology.'
+                 ' Although Harfbuzz now has optional AAT support,'
+                 ' new fonts should not be using that.'),
     }
     unwanted_tables_found = []
     for table in ttFont.keys():


### PR DESCRIPTION
"It is a table used on Apple's OSX-specific AAT and new fonts should not be using that."
Universal Profile: com.google.fonts/check/unwanted_tables
(issue #3411)