### PR TITLE
Fixed build of Read The Docs documentation pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.8.2 (2021-Aug-??)
 ### Noteworthy code-changes
+  - Fixed build of Read The Docs documentation pages (issue #3313)
   - Now one can invoke Font Bakery with different filetypes (other than just TTFs or OTFs) and the checks will run or skip based on file-type. (issue #3169)
   - For this reason, `UFO Source` checks are now included in the `Universal` profile. (issue #3439)
   - We'll likely have source-level (GlyphsApp) checks soon using this mechanism.

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx == 3.5.4
 sphinx_rtd_theme
 recommonmark


### PR DESCRIPTION
Pinned sphinx to version 3.5.4

Later we may look more closely to see what changed in their API and if there's enough benefit (in terms of features) in updating our code to use their latest version.
(issue #3313)