### PR TITLE
Added families to CamelCase exception

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2571,7 +2571,7 @@ def com_google_fonts_check_metadata_nameid_family_and_full_names(ttFont, font_me
 @check(
     id = 'com.google.fonts/check/metadata/fontname_not_camel_cased',
     conditions = ['font_metadata',
-                  'not whitelist_camelcased_familyname'],
+                  'not camelcased_familyname_exception'],
     proposal = 'legacy:check/109'
 )
 def com_google_fonts_check_metadata_fontname_not_camel_cased(font_metadata):

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -422,7 +422,10 @@ def whitelist_camelcased_familyname(font):
         "UnifrakturMaguntia"
         "MonteCarlo"
         "WindSong"
-        "RUSerius"
+        "JetBrains Mono"
+        "RocknRoll One"
+        "Rock 3D"
+        "DotGothic16"
     ]
     for familyname in familynames:
         if familyname in font:

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -409,26 +409,29 @@ def font_familyname(font_familynames):
     return font_familynames[0]
 
 
-# TODO: Design special case handling for whitelists/blacklists
+# TODO: Design special case handling mechanism:
 # https://github.com/googlefonts/fontbakery/issues/1540
 @condition
-def whitelist_camelcased_familyname(font):
-    familynames = [
+def camelcased_familyname_exception(familyname):
+    '''In general, we would not like to have camel-cased
+       familynames but there are a few exceptions to that
+       rule, that we keep listed here, for now.
+    '''
+    for exception in [
+        "3D", # seen in "Rock 3D"
         "BenchNine",
+        "DotGothic", # seen in "DotGothic16"
         "FakeFont",
+        "JetBrains", # seen in "JetBrains Mono"
         "McLaren",
         "MedievalSharp",
+        "RocknRoll", # seen in "RocknRoll One"
         "UnifrakturCook",
         "UnifrakturMaguntia",
         "MonteCarlo",
         "WindSong",
-        "JetBrains Mono",
-        "RocknRoll One",
-        "Rock 3D",
-        "DotGothic16",
-    ]
-    for familyname in familynames:
-        if familyname in font:
+    ]:
+        if exception in familyname:
             return True
 
 

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -419,13 +419,13 @@ def whitelist_camelcased_familyname(font):
         "McLaren",
         "MedievalSharp",
         "UnifrakturCook",
-        "UnifrakturMaguntia"
-        "MonteCarlo"
-        "WindSong"
-        "JetBrains Mono"
-        "RocknRoll One"
-        "Rock 3D"
-        "DotGothic16"
+        "UnifrakturMaguntia",
+        "MonteCarlo",
+        "WindSong",
+        "JetBrains Mono",
+        "RocknRoll One",
+        "Rock 3D",
+        "DotGothic16",
     ]
     for familyname in familynames:
         if familyname in font:


### PR DESCRIPTION
JetBrains Mono
RocknRoll One
Rock 3D
DotGothic16

And removed RUSerius since not in Library anymore (replaced by "Are you serius")

## Description
This pull request addresses these families' recurring FAILS about Camel Case names.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [x] request a review

