### PR TITLE
Setup check results overrides via configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.3 (2021-Sep-??)
 ### Noteworthy code-changes
   - This release drops Python 3.6 support (issue #3459)
-  - Check statuses may now be replaced in the configuration file. See USAGE.md for examples.
+  - Check statuses may now be replaced in the configuration file. See USAGE.md for examples. (PR #3469)
 
 ### New Checks
 #### Added to the Universal Profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## 0.8.3 (2021-Sep-??)
 ### Noteworthy code-changes
   - This release drops Python 3.6 support (issue #3459)
+  - Check statuses may now be replaced in the configuration file. See USAGE.md for examples.
 
 ### New Checks
 #### Added to the Universal Profile

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -194,6 +194,20 @@ explicit_checks = [
 
 - Instead of using `--order` to specify the check order, a list of checks can be provided using the `custom_order` key.
 
+Additionally, the configuration file can be used to replace the status of
+particular checks. To do this, you will need to know the *message ID*,
+which is reported with the result. For example, when the
+`com.google.fonts/check/mandatory_glyphs` check reports that the `.notdef`
+glyph does not contain any outlines, it reports the message ID `empty` and
+a `WARN` status. To replace this status and have it return a `FAIL` instead,
+place this in the configuration file (if you are using YAML format):
+
+```
+overrides:
+  com.google.fonts/check/mandatory_glyphs:
+    empty: FAIL
+```
+
 Individual checks and profiles may give semantics to additional configuration values; the whole configuration file is passed to checks which request access to it.
 
 #### Old Command Line Tools

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -126,3 +126,25 @@ OK = 123
     stdout = result.stdout.decode()
     assert "FAIL: 0" in stdout
     os.unlink(config.name)
+
+
+def test_config_override():
+    """Test we can override check statuses in the configuration file"""
+    config = tempfile.NamedTemporaryFile(delete=False)
+    config.write(b"""
+overrides:
+  com.google.fonts/check/file_size:
+    large-font: FAIL
+explicit_checks:
+  - com.google.fonts/check/file_size
+""")
+    config.close()
+    test_font = os.path.join("data", "test", "varfont", "inter", "Inter[slnt,wght].ttf")
+    result = subprocess.run(["fontbakery", "check-googlefonts",
+        "-C",
+        "--config", config.name,
+        test_font], stdout=subprocess.PIPE)
+    stdout = result.stdout.decode()
+    # This font has a WARN here, so should now FAIL
+    assert "FAIL: 1" in stdout
+    os.unlink(config.name)


### PR DESCRIPTION
## Description

This pull request allows the user to have the results of specific checks be replaced based on the configuration file.

For example, a user developing CJK files will add this to `fontbakery.yaml`:

```
overrides:
  com.google.fonts/check/file_size:
    massive_font: WARN
```

## To Do
- [X] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

