### PR TITLE
Improve reporting of shaping differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - This release drops Python 3.6 support (issue #3459)
   - Check statuses may now be replaced in the configuration file. See USAGE.md for examples. (PR #3469)
 
+### Changes to existing checks
+#### On the Universal Profile
+  - **[com.google.fonts/check/shaping/regression]:** Improve reporting of shaping differences. (PR #3472)
+
 ### New Checks
 #### Added to the Universal Profile
   - **[com.google.fonts/check/unreachable_glyphs]:** Check if the font contains any glyphs not reachable by codepoint or substitution rules (issue #3160)

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -66,13 +66,14 @@ def create_report_item(vharfbuzz,
                        buf2=None,
                        type="item",
                        extra_data=None):
-    message = f'<div class="shaping">\n\n{message}\n'
     if text:
         message += f': <span class="tf">{text}</span>'
+
     if type == "item":
         message = f"<li>{message}</li>\n"
-    if type == "header":
+    elif type == "header":
         message = get_stylesheet(vharfbuzz) + f"\n<h4>{message}</h4>\n"
+
     if extra_data:
         message += f"\n\n<pre>{extra_data}</pre>\n\n"
 
@@ -97,12 +98,14 @@ def create_report_item(vharfbuzz,
     # Now draw it as SVG
     if buf1:
         message += "\nGot: " + fix_svg(vharfbuzz.buf_to_svg(buf1))
+
     if buf2 and isinstance(buf2, FakeBuffer):
         try:
             message += " Expected: " + fix_svg(vharfbuzz.buf_to_svg(buf2))
         except KeyError:
             pass
-    return message + "\n\n</div>"
+
+    return f'<div class="shaping">\n\n{message}\n\n</div>'
 
 
 def get_from_test_with_default(test, configuration, el, default=None):


### PR DESCRIPTION
## Description

This improves the reporting of failed shaping regression tests within the shaping check.

Before:

<img width="522" alt="Screenshot 2021-10-04 at 13 28 55" src="https://user-images.githubusercontent.com/106728/135851386-8f7af53b-1ac8-432a-a535-9ebec43711f7.png">

After:

<img width="367" alt="Screenshot 2021-10-04 at 13 29 23" src="https://user-images.githubusercontent.com/106728/135851442-b2491dcc-ec9f-42e4-a761-62610f4f8e27.png">


## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

