### PR TITLE
Fix can_render_sample when METADATA.pb not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/contour_count]:** WARN if a font has a softhyphen. Also, if present, it should be non-spacing (and should have no contours). (issue #3486)
   - **[com.google.fonts/check/contour_count]:** Do not expect ZWNJ and ZWJ glyphs to have zero contours. (issue #3487)
+  - **[com.google.fonts/check/metadata/can_render_samples]:** Ensure METADATA.pb is present before running check (issue googlefonts/Unified-Font-Repository#62)
 
 
 ## 0.8.3 (2021-Oct-28)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5808,11 +5808,18 @@ def com_google_fonts_check_metadata_can_render_samples(ttFont, family_metadata):
     from fontbakery.utils import can_shape
 
     passed = True
+    if not family_metadata:
+       yield SKIP,\
+             Message('no-metadata',
+                     'No METADATA.pb file')
+       return
+
     if not family_metadata.sample_glyphs:
        passed = False
        yield SKIP,\
              Message('no-samples',
                      'No sample_glyphs on METADATA.pb')
+       return
 
     for name, glyphs in family_metadata.sample_glyphs.items():
         if not can_shape(ttFont, glyphs):


### PR DESCRIPTION
See https://github.com/googlefonts/Unified-Font-Repository/issues/62#issuecomment-956033601