### PR TITLE
Prepare traceback to be MD formated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.8.4 (2021-Nov-??)
+### Noteworthy code-changes
+  - Fix bad traceback display (issue #3482)
+
 ### Changes to existing checks
 #### Migrations
   - **[com.google.fonts/check/contour_count]:** moved from `Google Fonts` profile to `Universal` profile. (issue #3491)

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -382,6 +382,7 @@ class TerminalReporter(TerminalProgress):
             self._collected_results[key][message.name] += 1
 
     def _render_event_sync(self, print, event):
+        import re
         status, msg, (section, check, iterargs) = event
 
         if not status.weight >= self._structure_threshold \
@@ -452,12 +453,15 @@ class TerminalReporter(TerminalProgress):
                 message = str(msg)
 
             if hasattr(msg, 'traceback'):
-                message += '\n' + '\n  ↳ '.join(msg.traceback.split('\n'))
+                message = re.sub(r'(<[^<>]*>)', r'**`\1`**', message, flags=re.MULTILINE)
+                traceback = '  \n`' + '`  \n`'.join(msg.traceback.strip().split('\n')) + '`'
+                traceback = re.sub(r'\n`\s*(File ".*)`', r'\n  ↳ \1', traceback)
+                traceback = re.sub(r'\n`\s*(.*)', r'\n`\1', traceback)
+                message += traceback
 
             formated_msg = '{} {}'.format(formatStatus(self.theme, status), message)
             formated_msg = parse_md(formated_msg)
-            if hasattr(message, 'traceback'):
-                formated_msg += '\n' + '\n  ↳ '.join(message.traceback.split('\n'))
+
             print(text_flow(formated_msg,
                             width=76,
                             indent=4,


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #3482

It helps to identify affected functions, it's files and the call lines:
![error](https://user-images.githubusercontent.com/30254/140000413-676e9f64-abfe-4cb6-b1a8-491dbd143cdc.png)

I believe this is enough, however, if a special case breaks the formatting I can update the traceback pre-format, or even remove it from MD processor.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

