### PR TITLE
Fixed Sphinx-docs code by using the latest API...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.8.4 (2021-Nov-??)
 ### Noteworthy code-changes
+  - Updated Sphinx-docs extension code to use the latest API so that we can have FontBakery online docs properly build once more at https://font-bakery.readthedocs.io (issue #3313)
+  - Also improved the documentation of checks, now displaying the contents of the `proposal` metadata fields. (Also issue #3313)
   - Fixed readability of tracebacks on ERROR messages on the text terminal (issue #3482)
   - Update fonts_public.proto and fonts_public_pb2.py
 

--- a/Lib/fontbakery/fonts_profile.py
+++ b/Lib/fontbakery/fonts_profile.py
@@ -14,7 +14,7 @@ from fontbakery.errors import ValueValidationError
 @dataclass
 class FileDescription:
     name: str
-    extensions: [str]
+    extensions: list
     singular: str
     description: str
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1886,7 +1886,7 @@ def com_google_fonts_check_metadata_menu_and_latin(family_metadata):
 @check(
     id = 'com.google.fonts/check/metadata/subsets_order',
     conditions = ['family_metadata'],
-    proposal = 'check/087'
+    proposal = 'legacy:check/087'
 )
 def com_google_fonts_check_metadata_subsets_order(family_metadata):
     """METADATA.pb subsets should be alphabetically ordered."""

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -P
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = FontBakery
 SOURCEDIR     = source

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx == 3.5.4
-sphinx_rtd_theme
-recommonmark
+sphinx == 4.3.0
+sphinx_rtd_theme == 1.0.0
+recommonmark == 0.7.1

--- a/docs/source/fontbakery/commands/index.rst
+++ b/docs/source/fontbakery/commands/index.rst
@@ -5,13 +5,6 @@ commands
 .. toctree::
    :maxdepth: 1
 
-   check_adobefonts
-   check_googlefonts
-   check_notofonts
-   check_opentype
    check_profile
-   check_ufo_sources
-   check_universal
-
    generate_glyphdata
    build_contributors


### PR DESCRIPTION
...so that we can have FontBakery online docs properly build once more at https://font-bakery.readthedocs.io

Also improved the documentation of checks, now displaying the contents of the `proposal` metadata fields.
(issue #3313)