### PR TITLE
Prefer "placeholder" over "dummy"

### DIFF
--- a/Lib/fontbakery/profiles/dsig.py
+++ b/Lib/fontbakery/profiles/dsig.py
@@ -11,7 +11,7 @@ from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unus
 
         As we approach the EOL date, it is now considered better to completely remove the table.
 
-        But if you still want your font to support OpenType features on Office 2013, then you may find it handy to add a fake signature on a dummy DSIG table by running one of the helper scripts provided at https://github.com/googlefonts/gftools
+        But if you still want your font to support OpenType features on Office 2013, then you may find it handy to add a fake signature on a placeholder DSIG table by running one of the helper scripts provided at https://github.com/googlefonts/gftools
 
         Reference: https://github.com/googlefonts/fontbakery/issues/1845
     """,
@@ -26,7 +26,7 @@ def com_google_fonts_check_dsig(ttFont):
         yield WARN,\
               Message("found-DSIG",
                       "This font has a digital signature (DSIG table) which"
-                      " is only required - even if only a dummy placeholder"
+                      " is only required - even if only a placeholder"
                       " - on old programs like MS Office 2013 in order to"
                       " work properly.\n"
                       "The current recommendation is to completely"

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -427,7 +427,7 @@ def com_google_fonts_check_description_git_url(description_html):
     rationale = """
         Sometimes people write malformed HTML markup. This check should ensure the file is good.
 
-        Additionally, when packaging families for being pushed to the `google/fonts` git repo, if there is no DESCRIPTION.en_us.html file, some older versions of the `add_font.py` tool insert a dummy description file which contains invalid html. This file needs to either be replaced with an existing description file or edited by hand.
+        Additionally, when packaging families for being pushed to the `google/fonts` git repo, if there is no DESCRIPTION.en_us.html file, some older versions of the `add_font.py` tool insert a placeholder description file which contains invalid html. This file needs to either be replaced with an existing description file or edited by hand.
     """,
     proposal = ['legacy:check/004',
                 'https://github.com/googlefonts/fontbakery/issues/2664']

--- a/Lib/fontbakery/profiles/notofonts.py
+++ b/Lib/fontbakery/profiles/notofonts.py
@@ -59,7 +59,7 @@ def com_google_fonts_check_cmap_unexpected_subtables(ttFont):
         EXPECTED_SUBTABLES.extend([
             # Adobe says historically some programs used these to identify
             # the script in the font.  The encodingID is the quickdraw
-            # script manager code.  These are dummy tables.
+            # script manager code.  These are placeholder tables.
             (6, PlatformID.MACINTOSH, MacintoshEncodingID.JAPANESE),
             (6, PlatformID.MACINTOSH, MacintoshEncodingID.CHINESE_TRADITIONAL),
             (6, PlatformID.MACINTOSH, MacintoshEncodingID.KOREAN),


### PR DESCRIPTION
## Description

As per [Google's recommendation for inclusive language](https://developers.google.com/style/inclusive-documentation) I've removed all uses of "dummy". 

## To Do
- [x] update `CHANGELOG.md` (not required)
- [ ] wait for all checks to pass
- [ ] request a review

