### PR TITLE
New command line flag: `-F, --full-list` to print full lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.8.5 (2021-Dec-??)
+### Noteworthy code-changes
+  - New command line flag: `-F, --full-list` to print full lists (`pretty_print_list` method) even when the total number of items exceeds a certain threashold. (issues #3173 and #3512)
+
 ### New Checks
 #### Added to the Universal Profile
   - **[com.google.fonts/check/cjk_chws_feature]:** Ensure CJK fonts contain chws/vchw features. (issue #3363)

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -131,7 +131,7 @@ class CheckTester:
 
         self.runner = CheckRunner(self.profile,
                                   values,
-                                  Configuration(explicit_checks=[self.check_id]))
+                                  Configuration(explicit_checks=[self.check_id], full_lists=True))
         for check_identity in self.runner.order:
             _, check, _ = check_identity
             if check.id != self.check_id:

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -147,6 +147,9 @@ def ArgumentParser(profile, profile_arg=True):
     argument_parser.add_argument('-L', '--list-checks', default=False, action='store_true',
                                  help='List the checks available in the selected profile.')
 
+    argument_parser.add_argument('-F', '--full-lists', default=False, action='store_true',
+                                 help='Do not shorten lists of items.')
+
     argument_parser.add_argument('--dark-theme', default=False, action='store_true',
                                  help='Use a color theme with dark colors.')
 
@@ -301,7 +304,8 @@ def main(profile=None, values=None):
     configuration.maybe_override(Configuration(
         custom_order=args.order,
         explicit_checks=args.checkid,
-        exclude_checks=args.exclude_checkid
+        exclude_checks=args.exclude_checkid,
+        full_lists=args.full_lists
     ))
     runner_kwds = dict(values=values_, config=configuration)
     try:

--- a/Lib/fontbakery/profiles/gdef.py
+++ b/Lib/fontbakery/profiles/gdef.py
@@ -36,7 +36,7 @@ def _get_mark_class_glyphnames(ttFont):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2877'
 )
-def com_google_fonts_check_gdef_spacing_marks(ttFont):
+def com_google_fonts_check_gdef_spacing_marks(ttFont, config):
     """Check glyphs in mark glyph class are non-spacing."""
     from fontbakery.utils import pretty_print_list
 
@@ -55,8 +55,8 @@ def com_google_fonts_check_gdef_spacing_marks(ttFont):
                        for glyphname in spacing_glyphnames_in_mark_glyph_class
                        if glyphname not in cmap.values()]
             formatted_list = "\t " +\
-                             pretty_print_list(sorted(glyphs),
-                                               shorten=10,
+                             pretty_print_list(config,
+                                               sorted(glyphs),
                                                sep=", ")
             yield WARN,\
                   Message('spacing-mark-glyphs',
@@ -78,7 +78,7 @@ def com_google_fonts_check_gdef_spacing_marks(ttFont):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2877'
 )
-def com_google_fonts_check_gdef_mark_chars(ttFont):
+def com_google_fonts_check_gdef_mark_chars(ttFont, config):
     """Check mark characters are in GDEF mark glyph class."""
     from fontbakery.utils import pretty_print_list
 
@@ -93,9 +93,9 @@ def com_google_fonts_check_gdef_mark_chars(ttFont):
 
         if mark_chars_not_in_mark_class:
             formatted_marks = "\t " +\
-                pretty_print_list(sorted(f"{cmap[c]} (U+{c:04X})"
+                pretty_print_list(config,
+                                  sorted(f"{cmap[c]} (U+{c:04X})"
                                          for c in mark_chars_not_in_mark_class),
-                                  shorten=None,
                                   sep=", ")
             yield WARN,\
                   Message('mark-chars',
@@ -118,7 +118,7 @@ def com_google_fonts_check_gdef_mark_chars(ttFont):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2877'
 )
-def com_google_fonts_check_gdef_non_mark_chars(ttFont):
+def com_google_fonts_check_gdef_non_mark_chars(ttFont, config):
     """Check GDEF mark glyph class doesn't have characters that are not marks."""
     from fontbakery.utils import pretty_print_list
 
@@ -145,9 +145,9 @@ def com_google_fonts_check_gdef_non_mark_chars(ttFont):
                     if char in nonmark_chars:
                         nonmark_chars_in_mark_class.add(char)
             formatted_nonmarks = "\t " +\
-                                 pretty_print_list(sorted("U+%04X" % c for c in
+                                 pretty_print_list(config,
+                                                   sorted("U+%04X" % c for c in
                                                           nonmark_chars_in_mark_class),
-                                                   shorten=None,
                                                    sep=", ")
             yield WARN,\
                   Message('non-mark-chars',

--- a/Lib/fontbakery/profiles/glyf.py
+++ b/Lib/fontbakery/profiles/glyf.py
@@ -47,7 +47,7 @@ def com_google_fonts_check_glyf_unused_data(ttFont):
     conditions = ['is_ttf'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/735'
 )
-def com_google_fonts_check_points_out_of_bounds(ttFont):
+def com_google_fonts_check_points_out_of_bounds(ttFont, config):
     """Check for points out of bounds."""
     from fontbakery.utils import pretty_print_list
     passed = True
@@ -63,8 +63,8 @@ def com_google_fonts_check_points_out_of_bounds(ttFont):
                 out_of_bounds.append((glyphName, x, y))
 
     if not passed:
-        formatted_list = "\t* " + pretty_print_list(out_of_bounds,
-                                                    shorten=10,
+        formatted_list = "\t* " + pretty_print_list(config,
+                                                    out_of_bounds,
                                                     sep="\n\t* ")
         yield WARN,\
               Message("points-out-of-bounds",
@@ -92,7 +92,7 @@ def com_google_fonts_check_points_out_of_bounds(ttFont):
     conditions = ['is_ttf'],
     proposal = 'https://github.com/googlefonts/fontbakery/pull/2709'
 )
-def com_google_fonts_check_glyf_non_transformed_duplicate_components(ttFont):
+def com_google_fonts_check_glyf_non_transformed_duplicate_components(ttFont, config):
     """Check glyphs do not have duplicate components which have the same x,y coordinates."""
     from fontbakery.utils import pretty_print_list
     failed = []
@@ -114,8 +114,8 @@ def com_google_fonts_check_glyf_non_transformed_duplicate_components(ttFont):
             else:
                 seen.append(comp_info)
     if failed:
-        formatted_list = "\t* " + pretty_print_list(failed,
-                                                    shorten=10,
+        formatted_list = "\t* " + pretty_print_list(config,
+                                                    failed,
                                                     sep="\n\t* ")
         yield FAIL, \
               Message('found-duplicates',

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -976,9 +976,9 @@ def com_google_fonts_check_vendor_id(ttFont, registered_vendor_ids):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/pull/2488'
 )
-def com_google_fonts_check_glyph_coverage(ttFont):
+def com_google_fonts_check_glyph_coverage(ttFont, config):
     """Check `Google Fonts Latin Core` glyph coverage."""
-    from fontbakery.utils import pretty_print_list
+    from fontbakery.utils import bullet_list
     from fontbakery.constants import GF_latin_core
 
     font_codepoints = set()
@@ -993,14 +993,8 @@ def com_google_fonts_check_glyph_coverage(ttFont):
         missing = ['0x%04X (%s)' % (c, GF_latin_core[c][1]) for c in sorted(diff)]
         yield FAIL,\
               Message("missing-codepoints",
-                      f"Missing required codepoints:"
-                      f" {pretty_print_list(missing, shorten=4)}")
-        if len(missing) > 4:
-            missing_list = "\n\t\t".join(missing)
-            yield INFO,\
-                  Message("missing-codepoints-verbose",
-                          f"Here's the full list of required codepoints"
-                          f" still missing:\n\t\t{missing_list}")
+                      f"Missing required codepoints:\n"
+                      f"{bullet_list(config, missing)}")
     else:
         yield PASS, "OK"
 
@@ -1113,7 +1107,7 @@ def com_google_fonts_check_usweightclass(ttFont, expected_style):
     conditions = ['gfonts_repo_structure'],
     proposal = 'legacy:check/028'
 )
-def com_google_fonts_check_family_has_license(licenses):
+def com_google_fonts_check_family_has_license(licenses, config):
     """Check font has a license."""
     from fontbakery.utils import pretty_print_list
 
@@ -1122,7 +1116,7 @@ def com_google_fonts_check_family_has_license(licenses):
         yield FAIL,\
               Message("multiple",
                       f"More than a single license file found:"
-                      f" {pretty_print_list(filenames)}")
+                      f" {pretty_print_list(config, filenames)}")
     elif not licenses:
         yield FAIL,\
               Message("no-license",
@@ -1459,7 +1453,7 @@ def com_google_fonts_check_hinting_impact(font, hinting_stats):
     configs = ["WARN_SIZE",
                "FAIL_SIZE"]
 )
-def com_google_fonts_check_file_size(font, config):
+def com_google_fonts_check_file_size(font):
     """Ensure files are not too large."""
     size = os.stat(font).st_size
     if size > FAIL_SIZE:
@@ -3650,7 +3644,7 @@ def com_google_fonts_check_negative_advance_width(ttFont):
     conditions = ['is_ttf'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2961'
 )
-def com_google_fonts_check_glyf_nested_components(ttFont):
+def com_google_fonts_check_glyf_nested_components(ttFont, config):
     """Check glyphs do not have components which are themselves components."""
     from fontbakery.utils import pretty_print_list
     failed = []
@@ -3662,8 +3656,8 @@ def com_google_fonts_check_glyf_nested_components(ttFont):
             if ttFont['glyf'][comp.glyphName].isComposite():
                 failed.append(glyph_name)
     if failed:
-        formatted_list = "\t* " + pretty_print_list(failed,
-                                                    shorten=10,
+        formatted_list = "\t* " + pretty_print_list(config,
+                                                    failed,
                                                     sep="\n\t* ")
         yield FAIL,\
               Message('found-nested-components',
@@ -4378,7 +4372,7 @@ def com_google_fonts_check_family_control_chars(ttFonts):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1733'
 )
-def com_google_fonts_check_family_italics_have_roman_counterparts(fonts):
+def com_google_fonts_check_family_italics_have_roman_counterparts(fonts, config):
     """Ensure Italic styles have Roman counterparts."""
 
     italics = [f for f in fonts if 'Italic' in f]
@@ -4413,7 +4407,8 @@ def com_google_fonts_check_family_italics_have_roman_counterparts(fonts):
 
     if missing_roman:
         from fontbakery.utils import pretty_print_list
-        missing_roman = pretty_print_list(missing_roman)
+        missing_roman = pretty_print_list(config,
+                                          missing_roman)
         yield FAIL,\
               Message('missing-roman',
                       f"Italics missing a Roman counterpart: {missing_roman}")
@@ -4550,7 +4545,7 @@ def com_google_fonts_check_repo_upstream_yaml_has_required_fields(upstream_yaml)
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2903'
 )
-def com_google_fonts_check_repo_zip_files(family_directory):
+def com_google_fonts_check_repo_zip_files(family_directory, config):
     """A font repository should not include ZIP files"""
     from fontbakery.utils import (filenames_ending_in,
                                   pretty_print_list)
@@ -4563,8 +4558,8 @@ def com_google_fonts_check_repo_zip_files(family_directory):
     if not zip_files:
         yield PASS, 'OK'
     else:
-        files_list = pretty_print_list(zip_files,
-                                       shorten=None,
+        files_list = pretty_print_list(config,
+                                       zip_files,
                                        sep='\n\t* ')
         yield FAIL,\
               Message("zip-files",
@@ -4997,7 +4992,7 @@ def com_google_fonts_check_varfont_unsupported_axes(ttFont):
     conditions = ['is_variable_font'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3187'
 )
-def com_google_fonts_check_varfont_grade_reflow(ttFont):
+def com_google_fonts_check_varfont_grade_reflow(ttFont, config):
     """ Ensure VFs with the GRAD axis do not vary horizontal advance. """
     from fontbakery.profiles.shared_conditions import grad_axis
     from fontbakery.utils import (all_kerning,
@@ -5019,7 +5014,8 @@ def com_google_fonts_check_varfont_grade_reflow(ttFont):
                 bad_glyphs.append(glyph)
 
     if bad_glyphs:
-        bad_glyphs_list = pretty_print_list(bad_glyphs)
+        bad_glyphs_list = pretty_print_list(config,
+                                            bad_glyphs)
         yield FAIL,\
               Message("grad-causes-reflow",
                       f"The following glyphs have variation in horizontal"
@@ -5267,7 +5263,7 @@ def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont, GFAxisRegistry):
                   'family_metadata'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3051'
 )
-def com_google_fonts_check_metadata_consistent_axis_enumeration(family_metadata, ttFont):
+def com_google_fonts_check_metadata_consistent_axis_enumeration(family_metadata, ttFont, config):
     """ Validate VF axes match the ones declared on METADATA.pb. """
     from fontbakery.utils import pretty_print_list
 
@@ -5281,7 +5277,7 @@ def com_google_fonts_check_metadata_consistent_axis_enumeration(family_metadata,
         passed = False
         yield FAIL,\
               Message('missing-axes',
-                      f"The font variation axes {pretty_print_list(missing)}"
+                      f"The font variation axes {pretty_print_list(config, missing)}"
                       f" are present in the font's fvar table but are not"
                       f" declared on the METADATA.pb file.")
     if extra:
@@ -5289,7 +5285,7 @@ def com_google_fonts_check_metadata_consistent_axis_enumeration(family_metadata,
         yield FAIL,\
               Message('extra-axes',
                       f"The METADATA.pb file lists font variation axes that"
-                      f" are not supported but this family: {pretty_print_list(extra)}")
+                      f" are not supported but this family: {pretty_print_list(config, extra)}")
     if passed:
         yield PASS, "OK"
 
@@ -5763,7 +5759,7 @@ def com_google_fonts_check_render_own_name(ttFont):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2898',
 )
-def com_google_fonts_check_repo_sample_image(readme_contents, readme_directory):
+def com_google_fonts_check_repo_sample_image(readme_contents, readme_directory, config):
     """Check README.md has a sample image."""
     import re
     from fontbakery.utils import bullet_list
@@ -5818,7 +5814,7 @@ def com_google_fonts_check_repo_sample_image(readme_contents, readme_directory):
                   Message("image-not-displayed",
                           f'Even though the README.md file does not display'
                           f' a font sample image, a few image files were found:\n'
-                          f'{bullet_list(local_image_files)}\n'
+                          f'{bullet_list(config, local_image_files)}\n'
                           f'\n'
                           f'Please consider including one of those images on the README.\n'
                           f'{MARKDOWN_IMAGE_SYNTAX_TIP}\n')

--- a/Lib/fontbakery/profiles/outline.py
+++ b/Lib/fontbakery/profiles/outline.py
@@ -43,7 +43,7 @@ def close_but_not_on(yExpected, yTrue, tolerance):
     conditions = ["outlines_dict"],
     proposal = 'https://github.com/googlefonts/fontbakery/pull/3088'
 )
-def com_google_fonts_check_outline_alignment_miss(ttFont, outlines_dict):
+def com_google_fonts_check_outline_alignment_miss(ttFont, outlines_dict, config):
     """Are there any misaligned on-curve points?"""
     alignments = {
         "baseline": 0,
@@ -76,7 +76,9 @@ def com_google_fonts_check_outline_alignment_miss(ttFont, outlines_dict):
             return
 
     if warnings:
-        formatted_list = "\t* " + pretty_print_list(warnings, sep="\n\t* ")
+        formatted_list = "\t* " + pretty_print_list(config,
+                                                    warnings,
+                                                    sep="\n\t* ")
         yield WARN,\
               Message("found-misalignments",
                       f"The following glyphs have on-curve points which"
@@ -97,7 +99,7 @@ def com_google_fonts_check_outline_alignment_miss(ttFont, outlines_dict):
                   "is_not_variable_font"],
     proposal = 'https://github.com/googlefonts/fontbakery/pull/3088'
 )
-def com_google_fonts_check_outline_short_segments(ttFont, outlines_dict):
+def com_google_fonts_check_outline_short_segments(ttFont, outlines_dict, config):
     """Are any segments inordinately short?"""
     warnings = []
     for glyph, outlines in outlines_dict.items():
@@ -125,7 +127,9 @@ def com_google_fonts_check_outline_short_segments(ttFont, outlines_dict):
             return
 
     if warnings:
-        formatted_list = "\t* " + pretty_print_list(warnings, sep="\n\t* ")
+        formatted_list = "\t* " + pretty_print_list(config,
+                                                    warnings,
+                                                    sep="\n\t* ")
         yield WARN,\
               Message("found-short-segments",
                       f"The following glyphs have segments which seem very short:\n"
@@ -145,7 +149,7 @@ def com_google_fonts_check_outline_short_segments(ttFont, outlines_dict):
                   "is_not_variable_font"],
     proposal = 'https://github.com/googlefonts/fontbakery/pull/3088'
 )
-def com_google_fonts_check_outline_colinear_vectors(ttFont, outlines_dict):
+def com_google_fonts_check_outline_colinear_vectors(ttFont, outlines_dict, config):
     """Do any segments have colinear vectors?"""
     warnings = []
     for glyph, outlines in outlines_dict.items():
@@ -170,7 +174,9 @@ def com_google_fonts_check_outline_colinear_vectors(ttFont, outlines_dict):
             return
 
     if warnings:
-        formatted_list = "\t* " + pretty_print_list(sorted(set(warnings)), sep="\n\t* ")
+        formatted_list = "\t* " + pretty_print_list(config,
+                                                    sorted(set(warnings)),
+                                                    sep="\n\t* ")
         yield WARN,\
               Message("found-colinear-vectors",
                       f"The following glyphs have colinear vectors:\n"
@@ -188,7 +194,7 @@ def com_google_fonts_check_outline_colinear_vectors(ttFont, outlines_dict):
                   "is_not_variable_font"],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3064'
 )
-def com_google_fonts_check_outline_jaggy_segments(ttFont, outlines_dict):
+def com_google_fonts_check_outline_jaggy_segments(ttFont, outlines_dict, config):
     """Do outlines contain any jaggy segments?"""
     warnings = []
     for glyph, outlines in outlines_dict.items():
@@ -216,7 +222,9 @@ def com_google_fonts_check_outline_jaggy_segments(ttFont, outlines_dict):
                                 f" {prev}/{this} = {math.degrees(jag_angle)}")
 
     if warnings:
-        formatted_list = "\t* " + pretty_print_list(sorted(warnings), sep="\n\t* ")
+        formatted_list = "\t* " + pretty_print_list(config,
+                                                    sorted(warnings),
+                                                    sep="\n\t* ")
         yield WARN,\
               Message("found-jaggy-segments",
                       f"The following glyphs have jaggy segments:\n"
@@ -237,7 +245,7 @@ def com_google_fonts_check_outline_jaggy_segments(ttFont, outlines_dict):
                   "is_not_italic"],
     proposal = 'https://github.com/googlefonts/fontbakery/pull/3088'
 )
-def com_google_fonts_check_outline_semi_vertical(ttFont, outlines_dict):
+def com_google_fonts_check_outline_semi_vertical(ttFont, outlines_dict, config):
     """Do outlines contain any semi-vertical or semi-horizontal lines?"""
     warnings = []
     for glyph, outlines in outlines_dict.items():
@@ -255,7 +263,9 @@ def com_google_fonts_check_outline_semi_vertical(ttFont, outlines_dict):
                         warnings.append(f"{glyphname} (U+{codepoint:04X}): {s}")
 
     if warnings:
-        formatted_list = " * " + pretty_print_list(sorted(warnings), sep="\n * ")
+        formatted_list = " * " + pretty_print_list(config,
+                                                   sorted(warnings),
+                                                   sep="\n * ")
         yield WARN,\
              Message("found-semi-vertical",
                      f"The following glyphs have semi-vertical/semi-horizontal lines:\n"

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -505,7 +505,7 @@ def com_google_fonts_check_whitespace_ink(ttFont):
     # We may want to improve it and/or rephrase it.
     proposal = 'legacy:check/052'
 )
-def com_google_fonts_check_required_tables(ttFont):
+def com_google_fonts_check_required_tables(ttFont, config):
     """Font contains all required tables?"""
     from .shared_conditions import is_variable_font
     from fontbakery.utils import bullet_list
@@ -533,7 +533,7 @@ def com_google_fonts_check_required_tables(ttFont):
         yield INFO, \
               Message("optional-tables",
                       f"This font contains the following optional tables:\n"
-                      f"{bullet_list(optional_tables)}")
+                      f"{bullet_list(config, optional_tables)}")
 
     if is_variable_font(ttFont):
         # According to https://github.com/googlefonts/fontbakery/issues/1671
@@ -549,7 +549,7 @@ def com_google_fonts_check_required_tables(ttFont):
         yield FAIL, \
               Message("required-tables",
                       f"This font is missing the following required tables:\n"
-                      f"{bullet_list(missing_tables)}")
+                      f"{bullet_list(config, missing_tables)}")
     else:
         yield PASS, "Font contains all required tables."
 
@@ -663,7 +663,7 @@ def com_google_fonts_check_STAT_strings(ttFont):
                 'https://github.com/googlefonts/fontbakery/issues/2832'] # increase limit
                                                                          # to 63 chars
 )
-def com_google_fonts_check_valid_glyphnames(ttFont):
+def com_google_fonts_check_valid_glyphnames(ttFont, config):
     """Glyph names are all valid?"""
     from fontbakery.utils import pretty_print_list
 
@@ -695,7 +695,7 @@ def com_google_fonts_check_valid_glyphnames(ttFont):
                               f"The following glyph names may be too"
                               f" long for some legacy systems which may"
                               f" expect a maximum 31-char length limit:\n"
-                              f"{pretty_print_list(warn_names)}")
+                              f"{pretty_print_list(config, warn_names)}")
         else:
             yield FAIL,\
                   Message('found-invalid-names',
@@ -711,7 +711,8 @@ def com_google_fonts_check_valid_glyphnames(ttFont):
                            " The glyph names \"twocents\", \"a1\", and \"_\""
                            " are all valid, while \"2cents\""
                            " and \".twocents\" are not."
-                           "").format(pretty_print_list(bad_names)))
+                           "").format(pretty_print_list(config,
+                                                        bad_names)))
 
 
 @check(
@@ -1017,7 +1018,7 @@ def com_google_fonts_check_rupee(ttFont):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3160',
 )
-def com_google_fonts_check_unreachable_glyphs(ttFont):
+def com_google_fonts_check_unreachable_glyphs(ttFont, config):
     """Check font contains no unreachable glyphs"""
 
     def remove_lookup_outputs(all_glyphs, lookup):
@@ -1084,7 +1085,7 @@ def com_google_fonts_check_unreachable_glyphs(ttFont):
               Message("unreachable-glyphs",
                       f"The following glyphs could not be reached"
                       f" by codepoint or substitution rules:\n"
-                      f"{bullet_list(list(all_glyphs))}\n")
+                      f"{bullet_list(config, list(all_glyphs))}\n")
     else:
         yield PASS, "Font did not contain any unreachable glyphs"
 
@@ -1102,7 +1103,7 @@ def com_google_fonts_check_unreachable_glyphs(ttFont):
     """,
     proposal = 'legacy:check/153'
 )
-def com_google_fonts_check_contour_count(ttFont):
+def com_google_fonts_check_contour_count(ttFont, config):
     """Check if each glyph has the recommended amount of contours.
 
     This check is useful to assure glyphs aren't incorrectly constructed.
@@ -1201,10 +1202,10 @@ def com_google_fonts_check_contour_count(ttFont):
             bad_glyphs_name = [
                 f"Glyph name: {_glyph_name(cmap, name)}\t"
                 f"Contours detected: {count}\t"
-                f"Expected: {pretty_print_list(expected, shorten=None, glue='or')}"
+                f"Expected: {pretty_print_list(config, expected, glue='or')}"
                 for name, count, expected in bad_glyphs
             ]
-            bad_glyphs_name = bullet_list(bad_glyphs_name)
+            bad_glyphs_name = bullet_list(config, bad_glyphs_name)
             yield WARN,\
                   Message("contour-count",
                           f"This check inspects the glyph outlines and detects the"

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -144,23 +144,29 @@ def suffix(font):
     return '-'.join(s)
 
 
-def pretty_print_list(values, shorten=10, sep=", ", glue="and"):
+def pretty_print_list(config, values, shorten=10, sep=", ", glue="and"):
     if len(values) == 1:
         return str(values[0])
 
+    if config['full_lists']:
+        shorten = None
+
     if shorten and len(values) > shorten + 2:
         sep = sep.join(map(str, values[:shorten]))
-        return (f"{sep} {glue} {len(values) - shorten} more.")
+        return (f"{sep} {glue} {len(values) - shorten} more.\n"
+                f"\n"
+                f"Use -F or --full-lists to disable shortening of long lists.")
     else:
         sep = sep.join(map(str, values[:-1]))
         return f"{sep} {glue} {str(values[-1])}"
 
 
-def bullet_list(values, bullet="-"):
-    return f" {bullet} " + pretty_print_list(values,
-                                             shorten=False,
+def bullet_list(config, values, bullet="-", shorten=10):
+    return f" {bullet} " + pretty_print_list(config,
+                                             values,
+                                             shorten=shorten,
                                              sep=f"\n {bullet} ",
-                                             glue=f"\n {bullet}")
+                                             glue=f"\n {bullet} And")
 
 def get_regular(fonts):
     # TODO: Maybe also support getting a regular instance from a variable font?


### PR DESCRIPTION
New command line flag: `-F, --full-list` to print full lists (`pretty_print_list` and `bullet_list` methods) even when the total number of items exceeds a certain threashold.
(issues #3173 and #3512)