### PR TITLE
Do not accept more than a single dash on filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Noteworthy code-changes
   - New command line flag: `-F, --full-list` to print full lists (`pretty_print_list` method) even when the total number of items exceeds a certain threashold. (issues #3173 and #3512)
   - Included a few of the more recently added profiles that were still missing on our online docs (issue #3518)
+  - Do not accept more than a single dash on font filenames. This ensures FontBakery won't miscomputed expected style values use on checks such as `com.google.fonts/check/usweightclass`. (issue #3524)
 
 ### New Checks
 #### Added to the Universal Profile

--- a/Lib/fontbakery/parse.py
+++ b/Lib/fontbakery/parse.py
@@ -139,10 +139,13 @@ def style_parse(ttFont):
     import os
     filename = os.path.basename(ttFont.reader.file.name)
     if len(filename.split("-")) != 2:
-        style = "Regular"
+        # Google Fonts policy on font file naming scheme
+        # requires that only a single dash is used
+        # to separate family name from style.
+        return None
     else:
         style = filename.split("-")[1].split(".")[0]
-    return _style_parse(style)
+        return _style_parse(style)
 
 
 def instance_parse(string):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -24,6 +24,7 @@ def test_name():
     style = _style_parse("Bold Oblique")
     assert style.name == "Bold Italic"
 
+
 def test_fvar_coordinates():
     style = instance_parse("Regular")
     assert style.coordinates == {"wght": 400.0}
@@ -51,4 +52,3 @@ def test_token_order():
     style = instance_parse("Italic Black")
     assert style.raw_token_order == ["ital", "wght"]
     assert style.expected_token_order == ["wght", "ital"]
-


### PR DESCRIPTION
This ensures FontBakery won't miscomputed expected style values use on
checks such as `check/usweightclass`
(issue #3524)