### PR TITLE
Move constants from profiles into constants module

### DIFF
--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -21,10 +21,7 @@ import enum
 # These variable font naming rules will soon change.
 # For more detail, see:
 # https://github.com/googlefonts/fontbakery/issues/2396#issuecomment-473250089
-VARFONT_SUFFIXES = [
-    "VF",
-    "Italic-VF",
-    "Roman-VF"]
+VARFONT_SUFFIXES = ["VF", "Italic-VF", "Roman-VF"]
 
 STATIC_STYLE_NAMES = [
     "Thin",
@@ -44,35 +41,27 @@ STATIC_STYLE_NAMES = [
     "SemiBold Italic",
     "Bold Italic",
     "ExtraBold Italic",
-    "Black Italic"]
+    "Black Italic",
+]
 
 RIBBI_STYLE_NAMES = [
     "Regular",
     "Italic",
     "Bold",
     "BoldItalic",
-    "Bold Italic"]  # <-- Do we really need this one?
-
-RIBBI_SPACED = [
-    "Regular",
-    "Italic",
-    "Bold",
-    "Bold Italic"
+    "Bold Italic",  # <-- Do we really need this one?
 ]
 
-RIBBI_UNSPACED = [
-    "Regular",
-    "Italic",
-    "Bold",
-    "BoldItalic"
-]
+RIBBI_SPACED = ["Regular", "Italic", "Bold", "Bold Italic"]
+
+RIBBI_UNSPACED = ["Regular", "Italic", "Bold", "BoldItalic"]
 
 PLACEHOLDER_LICENSING_TEXT = {
-    'UFL.txt': 'Licensed under the Ubuntu Font Licence 1.0.',
-    'OFL.txt': 'This Font Software is licensed under the SIL Open Font '
-               'License, Version 1.1. This license is available with a FAQ '
-               'at: https://scripts.sil.org/OFL',
-    'LICENSE.txt': 'Licensed under the Apache License, Version 2.0'
+    "UFL.txt": "Licensed under the Ubuntu Font Licence 1.0.",
+    "OFL.txt": "This Font Software is licensed under the SIL Open Font "
+    "License, Version 1.1. This license is available with a FAQ "
+    "at: https://scripts.sil.org/OFL",
+    "LICENSE.txt": "Licensed under the Apache License, Version 2.0",
 }
 
 SHOW_GF_DOCS_MSG = (
@@ -913,48 +902,58 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
 LATEST_TTFAUTOHINT_VERSION = "1.8.4"
 
 FSTYPE_RESTRICTIONS = {
-   0x0002: ("* The font must not be modified, embedded or exchanged in"
-            " any manner without first obtaining permission of"
-            " the legal owner."),
-   0x0004: ("The font may be embedded, and temporarily loaded on the"
-            " remote system, but documents that use it must"
-            " not be editable."),
-   0x0008: ("The font may be embedded but must only be installed"
-            " temporarily on other systems."),
-   0x0100: ("The font may not be subsetted prior to embedding."),
-   0x0200: ("Only bitmaps contained in the font may be embedded."
-            " No outline data may be embedded.")
+    0x0002: (
+        "* The font must not be modified, embedded or exchanged in"
+        " any manner without first obtaining permission of"
+        " the legal owner."
+    ),
+    0x0004: (
+        "The font may be embedded, and temporarily loaded on the"
+        " remote system, but documents that use it must"
+        " not be editable."
+    ),
+    0x0008: (
+        "The font may be embedded but must only be installed"
+        " temporarily on other systems."
+    ),
+    0x0100: ("The font may not be subsetted prior to embedding."),
+    0x0200: (
+        "Only bitmaps contained in the font may be embedded."
+        " No outline data may be embedded."
+    ),
 }
 
 LICENSE_URL = {
-    'OFL.txt': 'https://scripts.sil.org/OFL',
-    'LICENSE.txt': 'https://www.apache.org/licenses/LICENSE-2.0',
-    'UFL.txt': 'https://www.ubuntu.com/legal/terms-and-policies/font-licence'
+    "OFL.txt": "https://scripts.sil.org/OFL",
+    "LICENSE.txt": "https://www.apache.org/licenses/LICENSE-2.0",
+    "UFL.txt": "https://www.ubuntu.com/legal/terms-and-policies/font-licence",
 }
 LICENSE_NAME = {
-    'OFL.txt': 'Open Font',
-    'LICENSE.txt': 'Apache',
-    'UFL.txt': 'Ubuntu Font License'
+    "OFL.txt": "Open Font",
+    "LICENSE.txt": "Apache",
+    "UFL.txt": "Ubuntu Font License",
 }
 
 GASP_MEANING = {
     0x01: "- Use grid-fitting",
     0x02: "- Use grayscale rendering",
     0x04: "- Use gridfitting with ClearType symmetric smoothing",
-    0x08: "- Use smoothing along multiple axes with ClearType®"
+    0x08: "- Use smoothing along multiple axes with ClearType®",
 }
 
-GF_API_WEIGHT_NAMES = {100: "Thin",
-                       200: "ExtraLight",
-                       250: "Thin", # Legacy. Pre-vf epoch
-                       275: "ExtraLight", # Legacy. Pre-vf epoch
-                       300: "Light",
-                       400: "Regular",
-                       500: "Medium",
-                       600: "SemiBold",
-                       700: "Bold",
-                       800: "ExtraBold",
-                       900: "Black"}
+GF_API_WEIGHT_NAMES = {
+    100: "Thin",
+    200: "ExtraLight",
+    250: "Thin",  # Legacy. Pre-vf epoch
+    275: "ExtraLight",  # Legacy. Pre-vf epoch
+    300: "Light",
+    400: "Regular",
+    500: "Medium",
+    600: "SemiBold",
+    700: "Bold",
+    800: "ExtraBold",
+    900: "Black",
+}
 
 CSS_WEIGHT_NAMES = {
     100: "Thin",
@@ -965,7 +964,7 @@ CSS_WEIGHT_NAMES = {
     600: "SemiBold",
     700: "Bold",
     800: "ExtraBold",
-    900: "Black"
+    900: "Black",
 }
 
 POSTSCRIPT_NAME_WEIGHTS = {
@@ -986,44 +985,77 @@ POSTSCRIPT_NAME_WEIGHTS = {
     "ExtraBold": 800,
     "ExtraBoldItalic": 800,
     "Black": 900,
-    "BlackItalic": 900
+    "BlackItalic": 900,
 }
 
-OPTIMAL_UPEM = {
-  16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 1000, 2000
-}
+OPTIMAL_UPEM = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 1000, 2000}
 
-GF_ACCEPTABLE_UPEM = {
-  16, 32, 64, 128, 256, 500, 512, 1024, 2048, 4096, 1000, 2000
-}
+GF_ACCEPTABLE_UPEM = {16, 32, 64, 128, 256, 500, 512, 1024, 2048, 4096, 1000, 2000}
 
-REQUIRED_TABLES = ["cmap", "head", "hhea", "hmtx",
-                   "maxp", "name", "OS/2", "post"]
+REQUIRED_TABLES = ["cmap", "head", "hhea", "hmtx", "maxp", "name", "OS/2", "post"]
 
-OPTIONAL_TABLES = ["cvt ", "fpgm", "loca", "prep",
-                   "VORG", "EBDT", "EBLC", "EBSC",
-                   "BASE", "GPOS", "GSUB", "JSTF",
-                   "gasp", "hdmx", "LTSH", "PCLT",
-                   "VDMX", "vhea", "vmtx", "kern"]
+OPTIONAL_TABLES = [
+    "cvt ",
+    "fpgm",
+    "loca",
+    "prep",
+    "VORG",
+    "EBDT",
+    "EBLC",
+    "EBSC",
+    "BASE",
+    "GPOS",
+    "GSUB",
+    "JSTF",
+    "gasp",
+    "hdmx",
+    "LTSH",
+    "PCLT",
+    "VDMX",
+    "vhea",
+    "vmtx",
+    "kern",
+]
 
 UNWANTED_AAT_TABLES = {
-    'EBSC', 'Zaph', 'acnt', 'ankr', 'bdat', 'bhed', 'bloc',
-    'bmap', 'bsln', 'fdsc', 'feat', 'fond', 'gcid', 'just',
-    'kerx', 'lcar', 'ltag', 'mort', 'morx', 'opbd', 'prop',
-    'trak', 'xref'
+    "EBSC",
+    "Zaph",
+    "acnt",
+    "ankr",
+    "bdat",
+    "bhed",
+    "bloc",
+    "bmap",
+    "bsln",
+    "fdsc",
+    "feat",
+    "fond",
+    "gcid",
+    "just",
+    "kerx",
+    "lcar",
+    "ltag",
+    "mort",
+    "morx",
+    "opbd",
+    "prop",
+    "trak",
+    "xref",
 }
 
 UNWANTED_TABLES = {
-    'FFTM': 'Table contains redundant FontForge timestamp info',
-    'TTFA': 'Redundant TTFAutohint table',
-    'TSI0': 'Table contains data only used in VTT',
-    'TSI1': 'Table contains data only used in VTT',
-    'TSI2': 'Table contains data only used in VTT',
-    'TSI3': 'Table contains data only used in VTT',
-    'TSI5': 'Table contains data only used in VTT',
-    'prop': ('Table used on AAT, Apple\'s OS X specific technology.'
-             ' Although Harfbuzz now has optional AAT support,'
-             ' new fonts should not be using that.'),
+    "FFTM": "Table contains redundant FontForge timestamp info",
+    "TTFA": "Redundant TTFAutohint table",
+    "TSI0": "Table contains data only used in VTT",
+    "TSI1": "Table contains data only used in VTT",
+    "TSI2": "Table contains data only used in VTT",
+    "TSI3": "Table contains data only used in VTT",
+    "TSI5": "Table contains data only used in VTT",
+    "prop": (
+        "Table used on AAT, Apple's OS X specific technology."
+        " Although Harfbuzz now has optional AAT support,"
+        " new fonts should not be using that."
+    ),
 }
 DEBUGGING_TABLES = ["Debg", "FFTM"]
 
@@ -1058,70 +1090,89 @@ UNACCEPTABLE_CONTROL_CHARACTERS = [
     "uni001C",
     "uni001D",
     "uni001E",
-    "uni001F"
+    "uni001F",
 ]
 
 AVERAGE_WIDTH_CALCULATION_FACTORS = {
-    'a': 64,
-    'b': 14,
-    'c': 27,
-    'd': 35,
-    'e': 100,
-    'f': 20,
-    'g': 14,
-    'h': 42,
-    'i': 63,
-    'j': 3,
-    'k': 6,
-    'l': 35,
-    'm': 20,
-    'n': 56,
-    'o': 56,
-    'p': 17,
-    'q': 4,
-    'r': 49,
-    's': 56,
-    't': 71,
-    'u': 31,
-    'v': 10,
-    'w': 18,
-    'x': 3,
-    'y': 18,
-    'z': 2,
-    'space': 166
+    "a": 64,
+    "b": 14,
+    "c": 27,
+    "d": 35,
+    "e": 100,
+    "f": 20,
+    "g": 14,
+    "h": 42,
+    "i": 63,
+    "j": 3,
+    "k": 6,
+    "l": 35,
+    "m": 20,
+    "n": 56,
+    "o": 56,
+    "p": 17,
+    "q": 4,
+    "r": 49,
+    "s": 56,
+    "t": 71,
+    "u": 31,
+    "v": 10,
+    "w": 18,
+    "x": 3,
+    "y": 18,
+    "z": 2,
+    "space": 166,
 }
 
 # AGL recommended names, according to Adobe Glyph List for new fonts:
-AGL_RECOMMENDED_0020 = {'space'}
+AGL_RECOMMENDED_0020 = {"space"}
 AGL_RECOMMENDED_00A0 = {"uni00A0", "space"}  # "space" is in this set because some fonts
-                                             # use the same glyph for U+0020 and U+00A0
-                                             # Including it here also removes a warning
-                                             # when U+0020 is wrong, but U+00A0 is okay.
+# use the same glyph for U+0020 and U+00A0
+# Including it here also removes a warning
+# when U+0020 is wrong, but U+00A0 is okay.
 
 # AGL compliant names, but not recommended for new fonts:
-AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020 = {'uni0020',
-                                          'u0020',
-                                          'u00020',
-                                          'u000020'}
-AGL_COMPLIANT_BUT_NOT_RECOMMENDED_00A0 = {'nonbreakingspace',
-                                          'nbspace',
-                                          'u00A0',
-                                          'u000A0',
-                                          'u0000A0'}
+AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020 = {"uni0020", "u0020", "u00020", "u000020"}
+AGL_COMPLIANT_BUT_NOT_RECOMMENDED_00A0 = {
+    "nonbreakingspace",
+    "nbspace",
+    "u00A0",
+    "u000A0",
+    "u0000A0",
+}
 
 # code-points for all Unicode whitespace chars
 # (according to Unicode 11.0 property list):
 WHITESPACE_CHARACTERS = {
-  0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x0020, 0x0085, 0x00A0, 0x1680,
-  0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008,
-  0x2009, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000
+    0x0009,
+    0x000A,
+    0x000B,
+    0x000C,
+    0x000D,
+    0x0020,
+    0x0085,
+    0x00A0,
+    0x1680,
+    0x2000,
+    0x2001,
+    0x2002,
+    0x2003,
+    0x2004,
+    0x2005,
+    0x2006,
+    0x2007,
+    0x2008,
+    0x2009,
+    0x200A,
+    0x2028,
+    0x2029,
+    0x202F,
+    0x205F,
+    0x3000,
 }
 
 # Code-points that do not have whitespace property, but
 # should not have a drawing.
-EXTRA_NON_DRAWING = {
-  0x180E, 0x200B, 0x2060, 0xFEFF
-}
+EXTRA_NON_DRAWING = {0x180E, 0x200B, 0x2060, 0xFEFF}
 
 # Make the set of non drawing characters.
 # OGHAM SPACE MARK U+1680 is removed as it is

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -53,6 +53,20 @@ RIBBI_STYLE_NAMES = [
     "BoldItalic",
     "Bold Italic"]  # <-- Do we really need this one?
 
+RIBBI_SPACED = [
+    "Regular",
+    "Italic",
+    "Bold",
+    "Bold Italic"
+]
+
+RIBBI_UNSPACED = [
+    "Regular",
+    "Italic",
+    "Bold",
+    "BoldItalic"
+]
+
 PLACEHOLDER_LICENSING_TEXT = {
     'UFL.txt': 'Licensed under the Ubuntu Font Licence 1.0.',
     'OFL.txt': 'This Font Software is licensed under the SIL Open Font '
@@ -897,3 +911,219 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
 """
 
 LATEST_TTFAUTOHINT_VERSION = "1.8.4"
+
+FSTYPE_RESTRICTIONS = {
+   0x0002: ("* The font must not be modified, embedded or exchanged in"
+            " any manner without first obtaining permission of"
+            " the legal owner."),
+   0x0004: ("The font may be embedded, and temporarily loaded on the"
+            " remote system, but documents that use it must"
+            " not be editable."),
+   0x0008: ("The font may be embedded but must only be installed"
+            " temporarily on other systems."),
+   0x0100: ("The font may not be subsetted prior to embedding."),
+   0x0200: ("Only bitmaps contained in the font may be embedded."
+            " No outline data may be embedded.")
+}
+
+LICENSE_URL = {
+    'OFL.txt': 'https://scripts.sil.org/OFL',
+    'LICENSE.txt': 'https://www.apache.org/licenses/LICENSE-2.0',
+    'UFL.txt': 'https://www.ubuntu.com/legal/terms-and-policies/font-licence'
+}
+LICENSE_NAME = {
+    'OFL.txt': 'Open Font',
+    'LICENSE.txt': 'Apache',
+    'UFL.txt': 'Ubuntu Font License'
+}
+
+GASP_MEANING = {
+    0x01: "- Use grid-fitting",
+    0x02: "- Use grayscale rendering",
+    0x04: "- Use gridfitting with ClearType symmetric smoothing",
+    0x08: "- Use smoothing along multiple axes with ClearType®"
+}
+
+GF_API_WEIGHT_NAMES = {100: "Thin",
+                       200: "ExtraLight",
+                       250: "Thin", # Legacy. Pre-vf epoch
+                       275: "ExtraLight", # Legacy. Pre-vf epoch
+                       300: "Light",
+                       400: "Regular",
+                       500: "Medium",
+                       600: "SemiBold",
+                       700: "Bold",
+                       800: "ExtraBold",
+                       900: "Black"}
+
+CSS_WEIGHT_NAMES = {
+    100: "Thin",
+    200: "ExtraLight",
+    300: "Light",
+    400: "Regular",
+    500: "Medium",
+    600: "SemiBold",
+    700: "Bold",
+    800: "ExtraBold",
+    900: "Black"
+}
+
+POSTSCRIPT_NAME_WEIGHTS = {
+    "Thin": 100,
+    "ThinItalic": 100,
+    "ExtraLight": 200,
+    "ExtraLightItalic": 200,
+    "Light": 300,
+    "LightItalic": 300,
+    "Regular": 400,
+    "Italic": 400,
+    "Medium": 500,
+    "MediumItalic": 500,
+    "SemiBold": 600,
+    "SemiBoldItalic": 600,
+    "Bold": 700,
+    "BoldItalic": 700,
+    "ExtraBold": 800,
+    "ExtraBoldItalic": 800,
+    "Black": 900,
+    "BlackItalic": 900
+}
+
+OPTIMAL_UPEM = {
+  16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 1000, 2000
+}
+
+GF_ACCEPTABLE_UPEM = {
+  16, 32, 64, 128, 256, 500, 512, 1024, 2048, 4096, 1000, 2000
+}
+
+REQUIRED_TABLES = ["cmap", "head", "hhea", "hmtx",
+                   "maxp", "name", "OS/2", "post"]
+
+OPTIONAL_TABLES = ["cvt ", "fpgm", "loca", "prep",
+                   "VORG", "EBDT", "EBLC", "EBSC",
+                   "BASE", "GPOS", "GSUB", "JSTF",
+                   "gasp", "hdmx", "LTSH", "PCLT",
+                   "VDMX", "vhea", "vmtx", "kern"]
+
+UNWANTED_AAT_TABLES = {
+    'EBSC', 'Zaph', 'acnt', 'ankr', 'bdat', 'bhed', 'bloc',
+    'bmap', 'bsln', 'fdsc', 'feat', 'fond', 'gcid', 'just',
+    'kerx', 'lcar', 'ltag', 'mort', 'morx', 'opbd', 'prop',
+    'trak', 'xref'
+}
+
+UNWANTED_TABLES = {
+    'FFTM': 'Table contains redundant FontForge timestamp info',
+    'TTFA': 'Redundant TTFAutohint table',
+    'TSI0': 'Table contains data only used in VTT',
+    'TSI1': 'Table contains data only used in VTT',
+    'TSI2': 'Table contains data only used in VTT',
+    'TSI3': 'Table contains data only used in VTT',
+    'TSI5': 'Table contains data only used in VTT',
+    'prop': ('Table used on AAT, Apple\'s OS X specific technology.'
+             ' Although Harfbuzz now has optional AAT support,'
+             ' new fonts should not be using that.'),
+}
+DEBUGGING_TABLES = ["Debg", "FFTM"]
+
+
+UNACCEPTABLE_CONTROL_CHARACTERS = [
+    "uni0001",
+    "uni0002",
+    "uni0003",
+    "uni0004",
+    "uni0005",
+    "uni0006",
+    "uni0007",
+    "uni0008",
+    "uni0009",
+    "uni000A",
+    "uni000B",
+    "uni000C",
+    "uni000E",
+    "uni000F",
+    "uni0010",
+    "uni0011",
+    "uni0012",
+    "uni0013",
+    "uni0014",
+    "uni0015",
+    "uni0016",
+    "uni0017",
+    "uni0018",
+    "uni0019",
+    "uni001A",
+    "uni001B",
+    "uni001C",
+    "uni001D",
+    "uni001E",
+    "uni001F"
+]
+
+AVERAGE_WIDTH_CALCULATION_FACTORS = {
+    'a': 64,
+    'b': 14,
+    'c': 27,
+    'd': 35,
+    'e': 100,
+    'f': 20,
+    'g': 14,
+    'h': 42,
+    'i': 63,
+    'j': 3,
+    'k': 6,
+    'l': 35,
+    'm': 20,
+    'n': 56,
+    'o': 56,
+    'p': 17,
+    'q': 4,
+    'r': 49,
+    's': 56,
+    't': 71,
+    'u': 31,
+    'v': 10,
+    'w': 18,
+    'x': 3,
+    'y': 18,
+    'z': 2,
+    'space': 166
+}
+
+# AGL recommended names, according to Adobe Glyph List for new fonts:
+AGL_RECOMMENDED_0020 = {'space'}
+AGL_RECOMMENDED_00A0 = {"uni00A0", "space"}  # "space" is in this set because some fonts
+                                             # use the same glyph for U+0020 and U+00A0
+                                             # Including it here also removes a warning
+                                             # when U+0020 is wrong, but U+00A0 is okay.
+
+# AGL compliant names, but not recommended for new fonts:
+AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020 = {'uni0020',
+                                          'u0020',
+                                          'u00020',
+                                          'u000020'}
+AGL_COMPLIANT_BUT_NOT_RECOMMENDED_00A0 = {'nonbreakingspace',
+                                          'nbspace',
+                                          'u00A0',
+                                          'u000A0',
+                                          'u0000A0'}
+
+# code-points for all Unicode whitespace chars
+# (according to Unicode 11.0 property list):
+WHITESPACE_CHARACTERS = {
+  0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x0020, 0x0085, 0x00A0, 0x1680,
+  0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008,
+  0x2009, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000
+}
+
+# Code-points that do not have whitespace property, but
+# should not have a drawing.
+EXTRA_NON_DRAWING = {
+  0x180E, 0x200B, 0x2060, 0xFEFF
+}
+
+# Make the set of non drawing characters.
+# OGHAM SPACE MARK U+1680 is removed as it is
+# a whitespace that should have a drawing.
+NON_DRAWING = (WHITESPACE_CHARACTERS | EXTRA_NON_DRAWING) - {0x1680}

--- a/Lib/fontbakery/profiles/head.py
+++ b/Lib/fontbakery/profiles/head.py
@@ -52,16 +52,14 @@ def com_google_fonts_check_family_equal_font_versions(ttFonts):
 def com_google_fonts_check_unitsperem(ttFont):
     """Checking unitsPerEm value is reasonable."""
     upem = ttFont['head'].unitsPerEm
-    target_upem = [2**i for i in range(4, 15)]
-    target_upem.append(1000)
-    target_upem.append(2000)
+    from fontbakery.constants import OPTIMAL_UPEM
     if upem < 16 or upem > 16384:
         yield FAIL,\
               Message("out-of-range",
                       f"The value of unitsPerEm at the head table"
                       f" must be a value between 16 and 16384."
                       f" Got {upem} instead.")
-    elif upem not in target_upem:
+    elif upem not in OPTIMAL_UPEM:
         yield WARN,\
               Message("suboptimal",
                       f"In order to optimize performance on some"

--- a/Lib/fontbakery/profiles/os2.py
+++ b/Lib/fontbakery/profiles/os2.py
@@ -118,39 +118,11 @@ def com_google_fonts_check_xavgcharwidth(ttFont):
 
         expected_value = int(round(width_sum / count))
     else:  # Version 2 and below only consider lowercase latin glyphs and space.
+        from fontbakery.constants import AVERAGE_WIDTH_CALCULATION_FACTORS
         calculation_rule = ("the weighted average of the widths of the latin"
                             " lowercase glyphs in the font")
-        weightFactors = {
-            'a': 64,
-            'b': 14,
-            'c': 27,
-            'd': 35,
-            'e': 100,
-            'f': 20,
-            'g': 14,
-            'h': 42,
-            'i': 63,
-            'j': 3,
-            'k': 6,
-            'l': 35,
-            'm': 20,
-            'n': 56,
-            'o': 56,
-            'p': 17,
-            'q': 4,
-            'r': 49,
-            's': 56,
-            't': 71,
-            'u': 31,
-            'v': 10,
-            'w': 18,
-            'x': 3,
-            'y': 18,
-            'z': 2,
-            'space': 166
-        }
         glyph_order = ttFont.getGlyphOrder()
-        if not all(character in glyph_order for character in weightFactors):
+        if not all(character in glyph_order for character in AVERAGE_WIDTH_CALCULATION_FACTORS.keys()):
             yield FAIL,\
                   Message("missing-glyphs",
                           "Font is missing the required"
@@ -158,9 +130,9 @@ def com_google_fonts_check_xavgcharwidth(ttFont):
             return
 
         width_sum = 0
-        for glyph_id in weightFactors:
+        for glyph_id, weight in AVERAGE_WIDTH_CALCULATION_FACTORS.items():
             width = ttFont['hmtx'].metrics[glyph_id][0]
-            width_sum += (width * weightFactors[glyph_id])
+            width_sum += (width * weight)
 
         expected_value = int(width_sum / 1000.0 + 0.5)  # round to closest int
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -372,10 +372,10 @@ def com_google_fonts_check_whitespace_glyphnames(ttFont):
     """Font has **proper** whitespace glyph names?"""
     from fontbakery.utils import get_glyph_name
     from fontbakery.constants import (
-      AGL_RECOMMENDED_0020,
-      AGL_RECOMMENDED_00A0,
-      AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020,
-      AGL_COMPLIANT_BUT_NOT_RECOMMENDED_00A0
+        AGL_RECOMMENDED_0020,
+        AGL_RECOMMENDED_00A0,
+        AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020,
+        AGL_COMPLIANT_BUT_NOT_RECOMMENDED_00A0
     )
 
     if ttFont['post'].formatType == 3.0:

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -371,24 +371,12 @@ def com_google_fonts_check_whitespace_glyphs(ttFont, missing_whitespace_chars):
 def com_google_fonts_check_whitespace_glyphnames(ttFont):
     """Font has **proper** whitespace glyph names?"""
     from fontbakery.utils import get_glyph_name
-
-    # AGL recommended names, according to Adobe Glyph List for new fonts:
-    AGL_RECOMMENDED_0020 = {'space'}
-    AGL_RECOMMENDED_00A0 = {"uni00A0", "space"}  # "space" is in this set because some fonts
-                                                 # use the same glyph for U+0020 and U+00A0
-                                                 # Including it here also removes a warning
-                                                 # when U+0020 is wrong, but U+00A0 is okay.
-
-    # AGL compliant names, but not recommended for new fonts:
-    AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020 = {'uni0020',
-                                              'u0020',
-                                              'u00020',
-                                              'u000020'}
-    AGL_COMPLIANT_BUT_NOT_RECOMMENDED_00A0 = {'nonbreakingspace',
-                                              'nbspace',
-                                              'u00A0',
-                                              'u000A0',
-                                              'u0000A0'}
+    from fontbakery.constants import (
+      AGL_RECOMMENDED_0020,
+      AGL_RECOMMENDED_00A0,
+      AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020,
+      AGL_COMPLIANT_BUT_NOT_RECOMMENDED_00A0
+    )
 
     if ttFont['post'].formatType == 3.0:
         yield SKIP, "Font has version 3 post table."
@@ -462,25 +450,7 @@ def com_google_fonts_check_whitespace_ink(ttFont):
     # This checks that certain glyphs are empty.
     # Some, but not all, are Unicode whitespace.
 
-    # code-points for all Unicode whitespace chars
-    # (according to Unicode 11.0 property list):
-    WHITESPACE_CHARACTERS = {
-        0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x0020, 0x0085, 0x00A0, 0x1680,
-        0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008,
-        0x2009, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000
-    }
-
-    # Code-points that do not have whitespace property, but
-    # should not have a drawing.
-    EXTRA_NON_DRAWING = {
-        0x180E, 0x200B, 0x2060, 0xFEFF
-    }
-
-    # Make the set of non drawing characters.
-    # OGHAM SPACE MARK U+1680 is removed as it is
-    # a whitespace that should have a drawing.
-    NON_DRAWING = (WHITESPACE_CHARACTERS | EXTRA_NON_DRAWING) - {0x1680}
-
+    from fontbakery.constants import NON_DRAWING
     passed = True
     for codepoint in sorted(NON_DRAWING):
         g = get_glyph_name(ttFont, codepoint)
@@ -509,15 +479,8 @@ def com_google_fonts_check_required_tables(ttFont, config):
     """Font contains all required tables?"""
     from .shared_conditions import is_variable_font
     from fontbakery.utils import bullet_list
+    from fontbakery.constants import REQUIRED_TABLES, OPTIONAL_TABLES
 
-    REQUIRED_TABLES = ["cmap", "head", "hhea", "hmtx",
-                       "maxp", "name", "OS/2", "post"]
-
-    OPTIONAL_TABLES = ["cvt ", "fpgm", "loca", "prep",
-                       "VORG", "EBDT", "EBLC", "EBSC",
-                       "BASE", "GPOS", "GSUB", "JSTF",
-                       "gasp", "hdmx", "LTSH", "PCLT",
-                       "VDMX", "vhea", "vmtx", "kern"]
     # See https://github.com/googlefonts/fontbakery/issues/617
     #
     # We should collect the rationale behind the need for each of the
@@ -563,18 +526,7 @@ def com_google_fonts_check_required_tables(ttFont, config):
 )
 def com_google_fonts_check_unwanted_tables(ttFont):
     """Are there unwanted tables?"""
-    UNWANTED_TABLES = {
-        'FFTM': 'Table contains redundant FontForge timestamp info',
-        'TTFA': 'Redundant TTFAutohint table',
-        'TSI0': 'Table contains data only used in VTT',
-        'TSI1': 'Table contains data only used in VTT',
-        'TSI2': 'Table contains data only used in VTT',
-        'TSI3': 'Table contains data only used in VTT',
-        'TSI5': 'Table contains data only used in VTT',
-        'prop': ('Table used on AAT, Apple\'s OS X specific technology.'
-                 ' Although Harfbuzz now has optional AAT support,'
-                 ' new fonts should not be using that.'),
-    }
+    from fontbakery.constants import UNWANTED_TABLES
     unwanted_tables_found = []
     for table in ttFont.keys():
         if table in UNWANTED_TABLES.keys():


### PR DESCRIPTION
## Description

We have a constants module, but there are lots of font-related constants dotted around the profiles. This moves them all to the constants module. (The next stage in my evil plan is to unify the fontbakery.constants and gftools.constants into a parent library.)

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

