### PR TITLE
Updates to shaping profile

### DIFF
--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -65,12 +65,16 @@ def create_report_item(vharfbuzz,
                        buf1=None,
                        buf2=None,
                        type="item",
+                       note=None,
                        extra_data=None):
     if text:
         message += f': <span class="tf">{text}</span>'
 
     if type == "item":
-        message = f"<li>{message}</li>\n"
+        message = f"<li>{message}"
+        if note:
+            message += f" ({note})"
+        message += "</li>\n"
     elif type == "header":
         message = get_stylesheet(vharfbuzz) + f"\n<h4>{message}</h4>\n"
 
@@ -265,6 +269,7 @@ def gereate_shaping_regression_report(vharfbuzz, shaping_file, failed_shaping_te
                                          text=test["input"],
                                          buf1=output_buf,
                                          buf2=buf2,
+                                         note=test.get("note"),
                                          extra_data=extra_data)
         report_items.append(report_item)
 

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -82,10 +82,6 @@ def create_report_item(vharfbuzz,
         message += f"\n\n<pre>{extra_data}</pre>\n\n"
 
     serialized_buf1 = None
-    if buf1:
-        serialized_buf1 = vharfbuzz.serialize_buf(buf1,
-                                                  glyphsonly=(buf2 and isinstance(buf2, str)))
-        message += f"\n\n<pre>Got     : {serialized_buf1}</pre>\n\n"
     if buf2:
         if isinstance(buf2, FakeBuffer):
             try:
@@ -98,11 +94,16 @@ def create_report_item(vharfbuzz,
             serialized_buf2 = buf2
         message += f"\n\n<pre>Expected: {serialized_buf2}</pre>\n\n"
 
-        # Report a diff table
-        if serialized_buf1 and serialized_buf2:
-            diff = list(ndiff([serialized_buf1], [serialized_buf2]))
-            if diff and diff[-1][0] == "?":
-                message += f"\n\n<pre>         {diff[-1][1:]}</pre>\n\n"
+    if buf1:
+        serialized_buf1 = vharfbuzz.serialize_buf(buf1,
+                                                  glyphsonly=(buf2 and isinstance(buf2, str)))
+        message += f"\n\n<pre>Got     : {serialized_buf1}</pre>\n\n"
+
+    # Report a diff table
+    if serialized_buf1 and serialized_buf2:
+        diff = list(ndiff([serialized_buf1], [serialized_buf2]))
+        if diff and diff[-1][0] == "?":
+            message += f"\n\n<pre>         {diff[-1][1:]}</pre>\n\n"
 
     # Now draw it as SVG
     if buf1:

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -88,13 +88,18 @@ def create_report_item(vharfbuzz,
         message += f"\n\n<pre>Got     : {serialized_buf1}</pre>\n\n"
     if buf2:
         if isinstance(buf2, FakeBuffer):
-            serialized_buf2 = vharfbuzz.serialize_buf(buf2)
+            try:
+              serialized_buf2 = vharfbuzz.serialize_buf(buf2)
+            except Exception:
+              # This may fail if the glyphs are not found in the font
+              serialized_buf2 = None
+              buf2 = None  # Don't try to draw it either
         else:
             serialized_buf2 = buf2
         message += f"\n\n<pre>Expected: {serialized_buf2}</pre>\n\n"
 
         # Report a diff table
-        if serialized_buf1:
+        if serialized_buf1 and serialized_buf2:
             diff = list(ndiff([serialized_buf1], [serialized_buf2]))
             if diff and diff[-1][0] == "?":
                 message += f"\n\n<pre>         {diff[-1][1:]}</pre>\n\n"

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -82,6 +82,7 @@ def create_report_item(vharfbuzz,
         message += f"\n\n<pre>{extra_data}</pre>\n\n"
 
     serialized_buf1 = None
+    serialized_buf2 = None
     if buf2:
         if isinstance(buf2, FakeBuffer):
             try:


### PR DESCRIPTION
This improves the user experience for the shaping profile:

- Pass “note” from test to output

Individual JSON test cases can now contain a `"note": ...` key which is displayed in the output to help identify the test case.

- Be more robust when the glyphs are not present

When the test expectation contains glyphs which are no longer present in the font (i.e. which have been removed or renamed), fontbakery would previously error. This handles the exception gracefully.

- Reverse output order: expectation before got

In the test report, it's more natural to see the output in the order "what we wanted", "what we got". This reverses the order to help the reader interpret the output.