### PR TITLE
New Fontwerk profile <https://fontwerk.com/>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.8.6 (2022-Feb-??)
+### New Profile
+  - Olli Meier (@moontypespace) contributed a new profile for Fontwerk, https://fontwerk.com/
+
 ### New Checks
+#### Added to the Fontwerk Profile
+  - **[com.fontwerk/check/no_mac_entries]:** Check if font has Mac name table entries (platform=1) (PR #3545)
+
 #### Added to the Universal Profile
   - **[com.google.fonts/check/designspace_has_sources]:** Check that all sources in a designspace can be loaded successfully. (PR #3168)
   - **[com.google.fonts/check/designspace_has_default_master]:** Check that a default master is defined. (PR #3168)

--- a/Lib/fontbakery/cli.py
+++ b/Lib/fontbakery/cli.py
@@ -10,6 +10,7 @@ from fontbakery.commands.check_profile import main as check_profile_main
 CLI_PROFILES = [
     "adobefonts",
     "fontval",
+    "fontwerk",
     "googlefonts",
     "notofonts",
     "opentype",

--- a/Lib/fontbakery/profiles/fontwerk.py
+++ b/Lib/fontbakery/profiles/fontwerk.py
@@ -1,0 +1,49 @@
+"""
+Checks for Fontwerk <https://fontwerk.com/>
+"""
+
+from fontbakery.callable import check
+from fontbakery.section import Section
+from fontbakery.status import PASS, FAIL
+from fontbakery.fonts_profile import profile_factory
+from fontbakery.message import Message
+from fontbakery.profiles.universal import UNIVERSAL_PROFILE_CHECKS
+
+profile_imports = ('fontbakery.profiles.universal',)
+profile = profile_factory(default_section=Section("Fontwerk"))
+
+FONTWERK_PROFILE_CHECKS = \
+    UNIVERSAL_PROFILE_CHECKS + [
+        'com.fontwerk/check/no_mac_entries'
+    ]
+
+
+@check(
+    id = 'com.fontwerk/check/no_mac_entries',
+    rationale = """
+        Mac name table entries are not needed anymore.
+        Even Apple stopped producing name tables with platform 1.
+        Please see for example the following system font:
+        /System/Library/Fonts/SFCompact.ttf
+        
+        Also, Dave Opstad, who developed Apple's TrueType specifications, told Olli Meier a couple years ago (as of January/2022) that these entries are outdated and should not be produced anymore.
+    """,
+    proposal = 'https://github.com/googlefonts/gftools/issues/469'
+)
+def com_fontwerk_check_name_no_mac_entries(ttFont):
+    """Check if font has Mac name table entries (platform=1)"""
+
+    passed = True
+    for rec in ttFont["name"].names:
+        if rec.platformID == 1:
+            yield FAIL, \
+                  Message("mac-names",
+                          f'Please remove name ID {rec.nameID}')
+            passed = False
+
+    if passed:
+        yield PASS, 'No Mac name table entries.'
+
+
+profile.auto_register(globals())
+profile.test_expected_checks(FONTWERK_PROFILE_CHECKS, exclusive=True)

--- a/tests/profiles/fontwerk_test.py
+++ b/tests/profiles/fontwerk_test.py
@@ -1,0 +1,22 @@
+from fontbakery.message import Message
+from fontbakery.checkrunner import FAIL
+from fontbakery.codetesting import (assert_PASS,
+                                    assert_results_contain,
+                                    CheckTester,
+                                    TEST_FILE)
+from fontbakery.profiles import fontwerk as fontwerk_profile
+
+
+def test_check_name_no_mac_entries():
+    check = CheckTester(fontwerk_profile,
+                        'com.fontwerk/check/no_mac_entries')
+
+    font = TEST_FILE('abeezee/ABeeZee-Italic.ttf')
+    assert_results_contain(check(font),
+                           FAIL, 'mac-names',
+                           'with a font containing Mac names')
+
+    font = TEST_FILE('source-sans-pro/OTF/SourceSansPro-Regular.otf')
+    assert_PASS(check(font),
+                'with a font without Mac names')
+


### PR DESCRIPTION
And an initial check:
**com.fontwerk/check/no_mac_entries**
`"Check if font has Mac name table entries (platform=1)"`
(followup to PR #3545)