### PR TITLE
don't FAIL on check/name/rfn with full OFL text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/designspace_has_consistent_glyphset]:** Check that non-default masters do not contain glyphs not found in the default master. (PR #3168)
   - **[com.google.fonts/check/designspace_has_consistent_codepoints]:** Check that Unicode assignments are consistent between masters. (PR #3168)
 
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/name/rfn]:** If the OFL text is included in a name table entry, the check should not FAIL, as the full license text contains the term 'Reserved Font Name', which in this case is OK. (issue #3542)
+
 
 ## 0.8.5 (2022-Jan-13)
 ### Noteworthy code-changes

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4323,6 +4323,12 @@ def com_google_fonts_check_name_rfn(ttFont):
     failed = False
     for entry in ttFont["name"].names:
         string = entry.toUnicode()
+        if "This license is copied below, and is also available with a FAQ" in string:
+            # This is the OFL text in a name table entry.
+            # It contains the term 'Reserved Font Name' in one of its clauses,
+            # so we will ignore this here.
+            continue
+
         if "reserved font name" in string.lower():
             yield FAIL,\
                   Message("rfn",

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -17,7 +17,8 @@ from fontbakery.constants import (NameID,
                                   WindowsEncodingID,
                                   WindowsLanguageID,
                                   MacintoshEncodingID,
-                                  MacintoshLanguageID)
+                                  MacintoshLanguageID,
+                                  OFL_BODY_TEXT)
 from fontbakery.profiles import googlefonts as googlefonts_profile
 import math
 
@@ -477,7 +478,19 @@ def test_check_name_rfn():
     ttFont = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
     assert_PASS(check(ttFont))
 
-    ttFont["name"].setName("Bla Reserved Font Name", 5, 3, 1, 0x409)
+    # The OFL text contains the term 'Reserved Font Name',
+    # which should to cause a FAIL:
+    ttFont["name"].setName(OFL_BODY_TEXT,
+                           NameID.LICENSE_DESCRIPTION,
+                           PlatformID.WINDOWS, WindowsEncodingID.UNICODE_BMP,
+                           WindowsLanguageID.ENGLISH_USA)
+    assert_PASS(check(ttFont),
+                "with the OFL full text...")
+
+    ttFont["name"].setName("Bla Reserved Font Name",
+                           NameID.VERSION_STRING,
+                           PlatformID.WINDOWS, WindowsEncodingID.UNICODE_BMP,
+                           WindowsLanguageID.ENGLISH_USA)
     assert_results_contain(check(ttFont),
                            FAIL, 'rfn',
                            'with "Reserved Font Name" on a name table entry...')


### PR DESCRIPTION
If the OFL text is included in a name table entry, the check should not FAIL, as the full license text contains the term 'Reserved Font Name', which in this case is OK (even if really not ideal regarding file size).

**com.google.fonts/check/name/rfn**
(issue #3542)