### PR TITLE
Add missing semicolon in html.py

### DIFF
--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -164,7 +164,7 @@ def html5_document(body_elements) -> str:
             th,
             td {
                 border: 1px solid #ddd;
-                padding: 0.5em
+                padding: 0.5em;
             }
 
             tr:nth-child(even) {


### PR DESCRIPTION
## Description
This minor pull request adds a missing semicolon in a CSS declaration for consistency with all other style declarations. Doing so is generally considered a [best practice](https://teamtreehouse.com/community/does-the-semicolon-have-to-be-added-after-each-declaration-in-a-rule-or-is-it-optional).