### PR TITLE
Freeze `collidoscope` dependency to version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.8.6 (2022-Feb-??)
+### Noteworthy code-changes
+  - Freeze `collidoscope` dependency to version 0.3.0 because v0.4.0 has a bug that fails to detect an `ïï` collision on Nunito Black. (issue #3554)
+
 ### New Profile
   - Olli Meier (@moontypespace) contributed a new profile for Fontwerk, https://fontwerk.com/
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setup(
         'beautifulsoup4',
         'beziers',
         'cmarkgfm',
-        'collidoscope',
+        'collidoscope==0.3.0', # v0.4.0 bug fails to detect an ïï collision on Nunito Black.
+                               # (see https://github.com/googlefonts/fontbakery/issues/3554)
         'defcon',
         'dehinter>=3.1.0', # 3.1.0 added dehinter.font.hint function
         'fontTools[ufo,lxml,unicode]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds


### PR DESCRIPTION
...because v0.4.0 has a bug that fails to detect an `ïï` collision on Nunito Black.
(issue #3554)