### PR TITLE
check/repo/sample_image: Declare conditions so that font repos lacking a README will skip this check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/name/rfn]:** If the OFL text is included in a name table entry, the check should not FAIL, as the full license text contains the term 'Reserved Font Name', which in this case is OK. (issue #3542)
   - **[com.google.fonts/check/layout_valid_feature_tags]:** Allow 'HARF' and 'BUZZ' tags. (issue #3368)
   - **[com.google.fonts/check/glyph_coverage]:** Fix ERROR. (issue #3551)
+  - **[com.google.fonts/check/repo/sample_image]:** Declare conditions so that font repos lacking a README will skip this check. (issue #3559)
 
 
 ## 0.8.5 (2022-Jan-13)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5818,6 +5818,8 @@ def com_google_fonts_check_render_own_name(ttFont):
     rationale = """
         In order to showcase what a font family looks like, the project's README.md file should ideally include a sample image and highlight it in the upper portion of the document, no more than 10 lines away from the top of the file.
     """,
+    conditions = ["readme_contents",
+                  "readme_directory"],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2898',
 )
 def com_google_fonts_check_repo_sample_image(readme_contents, readme_directory, config):


### PR DESCRIPTION
(issue #3559)