### PR TITLE
fix ERROR on check/metadata/unsupported_subsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/name/rfn]:** If the OFL text is included in a name table entry, the check should not FAIL, as the full license text contains the term 'Reserved Font Name', which in this case is OK. (issue #3542)
   - **[com.google.fonts/check/layout_valid_feature_tags]:** Allow 'HARF' and 'BUZZ' tags. (issue #3368)
   - **[com.google.fonts/check/glyph_coverage]:** Fix ERROR. (issue #3551)
-  - **[com.google.fonts/check/repo/sample_image]:** Declare conditions so that font repos lacking a README will skip this check. (issue #3559)
+  - **[com.google.fonts/check/repo/sample_image]:** Declare conditions so that font repos lacking a README.md file will skip this check. (issue #3559)
+  - **[com.google.fonts/check/metadata/unsupported_subsets]:** Declare conditions so that font repos lacking a METADATA.pb file will skip this check. (issue #3564)
 
 
 ## 0.8.5 (2022-Jan-13)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1018,6 +1018,7 @@ def com_google_fonts_check_glyph_coverage(ttFont, font_codepoints, config):
 
         Subsets for which none of the codepoints are supported will cause the check to FAIL.
     """,
+    conditions = ["family_metadata"],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3533',
     severity = 10, # max severity because this blocks font pushes to production.
 )


### PR DESCRIPTION
Declare conditions so that font repos lacking a METADATA.pb file will skip this check.
(issue #3564)