### PR TITLE
check/varfont/grade_reflow - Cleanup output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/glyph_coverage]:** Fix ERROR. (issue #3551)
   - **[com.google.fonts/check/repo/sample_image]:** Declare conditions so that font repos lacking a README.md file will skip this check. (issue #3559)
   - **[com.google.fonts/check/metadata/unsupported_subsets]:** Declare conditions so that font repos lacking a METADATA.pb file will skip this check. (issue #3564)
-  - **[com.google.fonts/check/varfont/grade_reflow]:** fix AttributeError: `'NoneType'` object has no attribute `'StartSize'` (issue #3561)
+  - **[com.google.fonts/check/varfont/grade_reflow]:** fix AttributeError: `'NoneType'` object has no attribute `'StartSize'` (issue #3566)
+  - **[com.google.fonts/check/varfont/grade_reflow]:** Cleanup log message output: use a set (instead of a list) in order to eliminate multiple reporting of the same glyphs (issue #3561)
 
 
 ## 0.8.5 (2022-Jan-13)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5066,18 +5066,18 @@ def com_google_fonts_check_varfont_grade_reflow(ttFont, config):
         return
 
     gvar = ttFont["gvar"]
-    bad_glyphs = []
+    bad_glyphs = set()
     for glyph, deltas in gvar.variations.items():
         for delta in deltas:
             if "GRAD" not in delta.axes:
                 continue
             if any(c is not None and c != (0, 0)
                    for c in delta.coordinates[-4:]):
-                bad_glyphs.append(glyph)
+                bad_glyphs.add(glyph)
 
     if bad_glyphs:
         bad_glyphs_list = pretty_print_list(config,
-                                            bad_glyphs)
+                                            list(bad_glyphs))
         yield FAIL,\
               Message("grad-causes-reflow",
                       f"The following glyphs have variation in horizontal"


### PR DESCRIPTION
Use a python set (instead of a python list) in order to eliminate multiple reporting of the same glyphs.
(issue #3561)

Also fix reference of the fix from the previous commit to the correct issue (#3566)
on the CHANGELOG file. (unfortunately the bad reference will remain incorrect in the git log message)