### PR TITLE
Start of a check database website

### DIFF
--- a/snippets/dump-all-the-checks.py
+++ b/snippets/dump-all-the-checks.py
@@ -1,0 +1,49 @@
+import pkgutil
+import fontbakery
+from fontbakery.utils import get_theme
+from importlib import import_module
+from fontbakery.profile import get_module_profile
+import json
+import cmarkgfm
+from cmarkgfm.cmark import Options as cmarkgfmOptions
+import re
+
+
+def md2html(x):
+    return cmarkgfm.markdown_to_html_with_extensions(x, options=cmarkgfmOptions.CMARK_OPT_UNSAFE, extensions=["autolink"])
+
+
+checks = {}
+profiles_modules = [
+    x.name
+    for x in pkgutil.walk_packages(fontbakery.__path__, "fontbakery.")
+    if x.name.startswith("fontbakery.profiles")
+]
+for profile_name in profiles_modules:
+    imported = import_module(profile_name, package=None)
+    profile = get_module_profile(imported)
+    if not profile:
+        continue
+    profile_name = profile_name[20:]
+    for section in profile._sections.values():
+        for check in section._checks:
+            if check.id not in checks:
+                checks[check.id] = {
+                    "sections": set(),
+                    "profiles": set(),
+                }
+            checks[check.id]["sections"].add(section.name)
+            checks[check.id]["profiles"].add(profile_name)
+            for attr in ["proposal", "rationale", "severity", "description"]:
+                if getattr(check, attr):
+                    md = getattr(check, attr)
+                    if attr == "rationale":
+                        md = re.sub(r"(?m)^\s+", "", md)
+                        checks[check.id][attr] = md2html(md)
+                    else:
+                        checks[check.id][attr] = md
+
+for ck in checks.values():
+    ck["sections"] = list(ck["sections"])
+    ck["profiles"] = list(ck["profiles"])
+print("window.fbchecks=" + json.dumps(checks, indent=4, sort_keys=True))


### PR DESCRIPTION
I created a website to hold all the fontbakery check descriptions, similar to Rust's [ALL the Clippy Lints](https://rust-lang.github.io/rust-clippy/master/) page.

You can see what it looks like at https://simoncozens.github.io/fontbakery/

Or here:

<img width="993" alt="Screenshot 2022-01-27 at 16 00 05" src="https://user-images.githubusercontent.com/106728/151395782-5cc53950-a4c8-45db-99dd-7d13fd30d3ca.png">

The idea is that we have a GitHub action which dumps the metadata about the checks into a JSON file and then checks it in to the gh-pages branch. The Python code to dump the metadata is in the snippet in this patch. If you like the idea, I will set up the gh-pages branch with the relevant files and then provide another PR for the GitHub action.
