### PR TITLE
Update maintainer notes to include source releases

### DIFF
--- a/docs/source/maintainer/maintainer-notes.md
+++ b/docs/source/maintainer/maintainer-notes.md
@@ -88,7 +88,8 @@ git tag -a v0.8.2 -m "Font Bakery version 0.8.2 (2021-Sep-01)"
 git push upstream --tags
 
 # create the package
-python setup.py bdist_wheel --universal
+pip install build
+python -m build
 
 # and finally upload the new package to PyPI
 pip install twine


### PR DESCRIPTION
## Description
Fixes #3573 for future releases (unless a maintainer has sneakily automated this). This does not provide source archives for current releases. For that reason, I recommend leaving #3573 open until there has been discussion about uploading past source archives.
