### PR TITLE
Consider CamelCase exceptions on name table checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.8.7 (2022-Feb-??)
-  - ...
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/name/familyname]:** Consider camel-case exceptions (issue #3584)
+  - **[com.google.fonts/check/name/fullfontname]:** Consider camel-case exceptions (issue #3584)
 
 
 ## 0.8.6 (2022-Jan-29)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3307,6 +3307,11 @@ def com_google_fonts_check_name_familyname(ttFont, style, familyname_with_spaces
                 continue
 
             string = name.string.decode(name.getEncoding()).strip()
+
+            if (camelcased_familyname_exception(string) and
+                string == expected_value.replace(" ", "")):
+                continue
+
             if string != expected_value:
                 failed = True
                 yield FAIL,\
@@ -3371,9 +3376,16 @@ def com_google_fonts_check_name_fullfontname(ttFont,
     failed = False
     for name in ttFont['name'].names:
         if name.nameID == NameID.FULL_FONT_NAME:
-            expected_value = "{} {}".format(familyname_with_spaces,
+            camelcased_name = familyname_with_spaces.replace(" ", "")
+            if camelcased_familyname_exception(camelcased_name):
+                familyname = camelcased_name
+            else:
+                familyname = familyname_with_spaces
+
+            expected_value = "{} {}".format(familyname,
                                             style_with_spaces)
             string = name.string.decode(name.getEncoding()).strip()
+
             if string != expected_value:
                 failed = True
                 # special case

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2482,7 +2482,9 @@ def test_check_name_familyname():
         (FAIL, "mismatch", TEST_FILE("overpassmono/OverpassMono-Regular.ttf"),     "Overpass Mono", "Foo"),
         (PASS, "ok",       TEST_FILE("merriweather/Merriweather-Black.ttf"),       "Merriweather",  "Merriweather Black"),
         (PASS, "ok",       TEST_FILE("merriweather/Merriweather-LightItalic.ttf"), "Merriweather",  "Merriweather Light"),
-        (FAIL, "mismatch", TEST_FILE("merriweather/Merriweather-LightItalic.ttf"), "Merriweather",  "Merriweather Light Italic")
+        (FAIL, "mismatch", TEST_FILE("merriweather/Merriweather-LightItalic.ttf"), "Merriweather",  "Merriweather Light Italic"),
+        (PASS, "ok",       TEST_FILE("abeezee/ABeeZee-Regular.ttf"), "ABeeZee",  "ABeeZee"),
+        # Note: ABeeZee is a good camel-cased name exception.
     ]
 
     for expected, keyword, filename, mac_value, win_value in test_cases:
@@ -2615,6 +2617,12 @@ def test_check_name_fullfontname():
                                    'with a bad FULL_FONT_NAME entry...')
             # restore it:
             ttFont["name"].names[index].string = backup
+
+    # And we should also accept a few camel-cased familyname exceptions,
+    # so this one should also be fine:
+    ttFont = TTFont(TEST_FILE("abeezee/ABeeZee-Regular.ttf"))
+    assert_PASS(check(ttFont),
+                "with a good camel-cased fontname...")
 
 
 def NOT_IMPLEMENTED_test_check_name_postscriptname():


### PR DESCRIPTION
* com.google.fonts/check/name/familyname
* com.google.fonts/check/name/fullfontname
(issue #3584)