### PR TITLE
Migrate check/transformed_components to Universal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/name/familyname]:** Consider camel-case exceptions (issue #3584)
   - **[com.google.fonts/check/name/fullfontname]:** Consider camel-case exceptions (issue #3584)
 
+#### Migrations
+  - **[com.google.fonts/check/transformed_components]:** moved from `Google Fonts` profile to `Universal` profile. It is not strictly a Google Fonts related check as transformed components cause problems in various rendering environments. (issue #3588)
+
 
 ## 0.8.6 (2022-Jan-29)
 ### Noteworthy code-changes

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -174,7 +174,6 @@ FONT_FILE_CHECKS = [
     'com.google.fonts/check/smart_dropout',
     'com.google.fonts/check/integer_ppem_if_hinted',
     'com.google.fonts/check/unitsperem_strict',
-    'com.google.fonts/check/transformed_components',
     'com.google.fonts/check/vertical_metrics_regressions',
     'com.google.fonts/check/cjk_vertical_metrics',
     'com.google.fonts/check/cjk_vertical_metrics_regressions',
@@ -3135,41 +3134,6 @@ def com_google_fonts_check_mac_style(ttFont, style):
                           expected,
                           bitmask=MacStyle.BOLD,
                           bitname="BOLD")
-
-
-@check(
-    id = 'com.google.fonts/check/transformed_components',
-    conditions = ['is_ttf'],
-    rationale = """
-        Some families have glyphs which have been constructed by using transformed components e.g the 'u' being constructed from a flipped 'n'.
-
-        From a designers point of view, this sounds like a win (less work). However, such approaches can lead to rasterization issues, such as having the 'u' not sitting on the baseline at certain sizes after running the font through ttfautohint.
-
-        As of July 2019, Marc Foley observed that ttfautohint assigns cvt values to transformed glyphs as if they are not transformed and the result is they render very badly, and that vttLib does not support flipped components.
-
-        When building the font with fontmake, this problem can be fixed by using the "Decompose Transformed Components" filter.
-    """,
-    proposal = 'https://github.com/googlefonts/fontbakery/issues/2011',
-)
-def com_google_fonts_check_transformed_components(ttFont):
-    """Ensure component transforms do not perform scaling or rotation."""
-    failures = ""
-    for glyph_name in ttFont.getGlyphOrder():
-        glyf = ttFont["glyf"][glyph_name]
-        if not glyf.isComposite():
-            continue
-        for component in glyf.components:
-            comp_name, transform = component.getComponentInfo()
-            if transform[0:4] != (1, 0, 0, 1):
-                failures += f"* {glyph_name} (component {comp_name})\n"
-    if failures:
-        yield FAIL,\
-              Message("transformed-components",
-                      f"The following glyphs had components with scaling or rotation:\n"
-                      f"\n"
-                      f"{failures}")
-    else:
-        yield PASS, "No glyphs had components with scaling or rotation"
 
 
 # FIXME!

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -61,7 +61,8 @@ UNIVERSAL_PROFILE_CHECKS = \
         'com.google.fonts/check/rupee',
         'com.google.fonts/check/unreachable_glyphs',
         'com.google.fonts/check/contour_count',
-        'com.google.fonts/check/cjk_chws_feature'
+        'com.google.fonts/check/cjk_chws_feature',
+        'com.google.fonts/check/transformed_components'
     ]
 
 
@@ -1374,6 +1375,42 @@ def com_google_fonts_check_cjk_chws_feature(ttFont):
                       FEATURE_NOT_FOUND.format("vchw"))
     if passed:
         yield PASS, "Font contains chws and vchw features"
+
+
+@check(
+    id = 'com.google.fonts/check/transformed_components',
+    conditions = ['is_ttf'],
+    rationale = """
+        Some families have glyphs which have been constructed by using transformed components e.g the 'u' being constructed from a flipped 'n'.
+
+        From a designers point of view, this sounds like a win (less work). However, such approaches can lead to rasterization issues, such as having the 'u' not sitting on the baseline at certain sizes after running the font through ttfautohint.
+
+        As of July 2019, Marc Foley observed that ttfautohint assigns cvt values to transformed glyphs as if they are not transformed and the result is they render very badly, and that vttLib does not support flipped components.
+
+        When building the font with fontmake, the problem can be fixed by adding this to the command line:
+        --filter DecomposeTransformedComponentsFilter
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/2011',
+)
+def com_google_fonts_check_transformed_components(ttFont):
+    """Ensure component transforms do not perform scaling or rotation."""
+    failures = ""
+    for glyph_name in ttFont.getGlyphOrder():
+        glyf = ttFont["glyf"][glyph_name]
+        if not glyf.isComposite():
+            continue
+        for component in glyf.components:
+            comp_name, transform = component.getComponentInfo()
+            if transform[0:4] != (1, 0, 0, 1):
+                failures += f"* {glyph_name} (component {comp_name})\n"
+    if failures:
+        yield FAIL,\
+              Message("transformed-components",
+                      f"The following glyphs had components with scaling or rotation:\n"
+                      f"\n"
+                      f"{failures}")
+    else:
+        yield PASS, "No glyphs had components with scaling or rotation"
 
 
 profile.auto_register(globals())

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2331,21 +2331,6 @@ def test_check_production_encoded_glyphs(cabin_ttFonts):
                                FAIL, 'lost-glyphs')
 
 
-def test_check_transformed_components():
-    """Ensure component transforms do not perform scaling or rotation."""
-    check = CheckTester(googlefonts_profile,
-                        "com.google.fonts/check/transformed_components")
-
-    font = TEST_FILE("cabin/Cabin-Regular.ttf")
-    assert_PASS(check(font),
-                "with a good font...")
-
-    # DM Sans v1.100 had some transformed components
-    font = TEST_FILE("dm-sans-v1.100/DMSans-Regular.ttf")
-    assert_results_contain(check(font),
-                           FAIL, 'transformed-components')
-
-
 def test_check_metadata_nameid_copyright():
     """ Copyright field for this font on METADATA.pb matches
         all copyright notice entries on the name table? """

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -890,3 +890,18 @@ def test_check_designspace_has_consistent_codepoints():
                            FAIL, 'inconsistent-codepoints')
 
     # TODO: Fix it and ensure it passes the check
+
+
+def test_check_transformed_components():
+    """Ensure component transforms do not perform scaling or rotation."""
+    check = CheckTester(universal_profile,
+                        "com.google.fonts/check/transformed_components")
+
+    font = TEST_FILE("cabin/Cabin-Regular.ttf")
+    assert_PASS(check(font),
+                "with a good font...")
+
+    # DM Sans v1.100 had some transformed components
+    font = TEST_FILE("dm-sans-v1.100/DMSans-Regular.ttf")
+    assert_results_contain(check(font),
+                           FAIL, 'transformed-components')


### PR DESCRIPTION
It is not strictly a Google Fonts related check as transformed components cause problems in various rendering environments.

com.google.fonts/check/transformed_components
(issue #3588)

Also add the fontmake DecomposeTransformedComponentsFilter flag to the rationale text.
(issue #3587)