### PR TITLE
Fixes to Sphinx auto-generated documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+
 ## 0.8.7 (2022-Feb-??)
+### New Checks
+#### Added to the Fontwerk Profile
+  - Include most of the `googlefonts` profile checks. (PR #3579)
+  - **[com.fontwerk/check/vendor_id]:** Vendor ID must for 'WERK' on FontWerk fonts. (PR #3579)
+  - **[com.fontwerk/check/weight_class_fvar]:** usWeightclass must match fvar default value. (PR #3579)
+
 ### Changes to existing checks
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/name/familyname]:** Consider camel-case exceptions (issue #3584)

--- a/Lib/fontbakery/sphinx_extensions/profile.py
+++ b/Lib/fontbakery/sphinx_extensions/profile.py
@@ -58,6 +58,11 @@ class FontBakeryCallableDocumenter(ModuleLevelDocumenter):
         # type: () -> str
         # We use the original signature from the wrapped _function
         has_retval = isinstance(self.object, FontBakeryCondition)
+
+        if not hasattr(self.object, '_func'):
+            # FIXME! I don't know what's this.
+            return None
+
         sig = Signature(self.object._func, bound_method=False, has_retval=has_retval)
         args = stringify_signature(sig)
         # escape backslashes for reST

--- a/docs/source/fontbakery/profiles/fontwerk.rst
+++ b/docs/source/fontbakery/profiles/fontwerk.rst
@@ -1,0 +1,12 @@
+########
+fontwerk
+########
+
+All vendor-specific profiles such as the `fontwerk` one also include the checks from the :doc:`universal` profile. Fontwerk also includes most checks from the :doc:`googlefonts` profile, except these:
+
+.. literalinclude:: ../../../../Lib/fontbakery/profiles/fontwerk.py
+   :pyobject: leave_this_one_out
+
+.. automodule:: fontbakery.profiles.fontwerk
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/googlefonts_conditions.rst
+++ b/docs/source/fontbakery/profiles/googlefonts_conditions.rst
@@ -1,0 +1,7 @@
+######################
+googlefonts_conditions
+######################
+
+.. automodule:: fontbakery.profiles.googlefonts_conditions
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/index.rst
+++ b/docs/source/fontbakery/profiles/index.rst
@@ -10,13 +10,14 @@ profiles
    adobefonts
    googlefonts
    notofonts
+   typenetwork
+   fontwerk
    fontval
    ufo_sources
    iso15008
    layout
    outline
    shaping
-   typenetwork
    shared_conditions
    googlefonts_conditions
 

--- a/docs/source/fontbakery/profiles/iso15008.rst
+++ b/docs/source/fontbakery/profiles/iso15008.rst
@@ -1,0 +1,7 @@
+########
+iso15008
+########
+
+.. automodule:: fontbakery.profiles.iso15008
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/notofonts.rst
+++ b/docs/source/fontbakery/profiles/notofonts.rst
@@ -1,0 +1,9 @@
+#########
+notofonts
+#########
+
+All vendor-specific profiles such as the `notofonts` one also include the checks from the :doc:`universal` profile.
+
+.. automodule:: fontbakery.profiles.notofonts
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/outline.rst
+++ b/docs/source/fontbakery/profiles/outline.rst
@@ -1,0 +1,7 @@
+#######
+outline
+#######
+
+.. automodule:: fontbakery.profiles.outline
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/shaping.rst
+++ b/docs/source/fontbakery/profiles/shaping.rst
@@ -1,0 +1,7 @@
+#######
+shaping
+#######
+
+.. automodule:: fontbakery.profiles.shaping
+   :members:
+   :undoc-members:

--- a/docs/source/fontbakery/profiles/typenetwork.rst
+++ b/docs/source/fontbakery/profiles/typenetwork.rst
@@ -1,0 +1,9 @@
+###########
+typenetwork
+###########
+
+All vendor-specific profiles such as the `typenetwork` one also include the checks from the :doc:`universal` profile.
+
+.. automodule:: fontbakery.profiles.typenetwork
+   :members:
+   :undoc-members:


### PR DESCRIPTION
While adding a docs page for the new Fontwerk profile (PR #3579) I ended up
noticing a few others were also missing.