### PR TITLE
Fix glyph_coverage check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/contour_count]:** Four fifths glyph can also be drawn with only 3 contours if the four is open-ended. (issue #3511)
+  - **[com.google.fonts/check/glyph_coverage]:** Use the new glyphsets python module. (issue #3533)
 
 
 ## 0.8.4 (2021-Nov-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/name/familyname]:** Consider camel-case exceptions (issue #3584)
   - **[com.google.fonts/check/name/fullfontname]:** Consider camel-case exceptions (issue #3584)
+  - **[com.google.fonts/check/glyph_coverage]:** Use the correct nam-file for checking coverage of the GF-latin-core glyphset (issue #3583)
 
 #### Migrations
   - **[com.google.fonts/check/transformed_components]:** moved from `Google Fonts` profile to `Universal` profile. It is not strictly a Google Fonts related check as transformed components cause problems in various rendering environments. (issue #3588)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -990,10 +990,13 @@ def font_codepoints(ttFont):
 def com_google_fonts_check_glyph_coverage(ttFont, font_codepoints, config):
     """Check `Google Fonts Latin Core` glyph coverage."""
     from fontbakery.utils import bullet_list
-    from glyphsets.codepoints import CodepointsInSubset
+    from glyphsets import codepoints
     import unicodedata2
 
-    required_codepoints = CodepointsInSubset("latin")
+    gf_glyphsets = codepoints.nam_dir + "/GF Glyph Sets"
+    codepoints.set_encoding_path(gf_glyphsets)
+
+    required_codepoints = codepoints.CodepointsInSubset("GF-latin-core")
     diff = required_codepoints - font_codepoints
     missing = []
     for c in sorted(diff):


### PR DESCRIPTION
Use the correct nam-file for checking coverage of the `GF-latin-core` glyphset.

**com.google.fonts/check/glyph_coverage**
(issue #3583)