### PR TITLE
Copyright exceptions for Noto fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/name/familyname]:** Consider camel-case exceptions (issue #3584)
   - **[com.google.fonts/check/name/fullfontname]:** Consider camel-case exceptions (issue #3584)
   - **[com.google.fonts/check/glyph_coverage]:** Use the correct nam-file for checking coverage of the GF-latin-core glyphset (issue #3583)
+  - **[com.google.fonts/check/font_copyright]:** Allow Google LLC copyright.
+  - **[com.google.fonts/check/license/OFL_copyright]:** Re-use expected copyright format.
 
 #### Migrations
   - **[com.google.fonts/check/transformed_components]:** moved from `Google Fonts` profile to `Universal` profile. It is not strictly a Google Fonts related check as transformed components cause problems in various rendering environments. (issue #3588)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2369,7 +2369,7 @@ def com_google_fonts_check_metadata_valid_post_script_name_values(font_metadata,
 
 
 EXPECTED_COPYRIGHT_PATTERN = \
-r'copyright [0-9]{4}(\-[0-9]{4})? the .* project authors \([^\@]*\)'
+r'copyright [0-9]{4}(\-[0-9]{4})? (the .* project authors \([^\@]*\)|google llc. all rights reserved)'
 
 @check(
     id = 'com.google.fonts/check/metadata/valid_copyright',

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1196,7 +1196,7 @@ def com_google_fonts_check_license_OFL_copyright(license_contents):
     """Check license file has good copyright string."""
     import re
     string = license_contents.strip().split('\n')[0].lower()
-    does_match = re.search(r'copyright [0-9]{4}(\-[0-9]{4})? the .* project authors \([^\@]*\)', string)
+    does_match = re.search(EXPECTED_COPYRIGHT_PATTERN, string)
     if does_match:
         yield PASS, "looks good"
     else:


### PR DESCRIPTION
## Description

Noto fonts are produced by Google, so have a copyright notice of the form `Copyright XXXX-XXXX Google LLC. All Rights Reserved`. This should be an allowable copyright notice; this PR updates the `EXPECTED_COPYRIGHT_PATTERN` to allow it.

I also noticed that the `OFL_copyright` check used its own regular expression; it should share `EXPECTED_COPYRIGHT_PATTERN`. So I fixed that too.

## To Do
- [X] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

