### PR TITLE
Apply --succinct to other reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## 0.8.7 (2022-Feb-??)
+### Noteworthy code-changes
+  - The `--succinct` flag now generates succinct HTML and MD reports.
+
 ### New Checks
 #### Added to the Fontwerk Profile
   - Include most of the `googlefonts` profile checks. (PR #3579)

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -129,7 +129,7 @@ def ArgumentParser(profile, profile_arg=True):
     argument_parser.add_argument('--succinct',
                                  action='store_true',
                                  help='This is a slightly more compact and succint'
-                                      ' output layout for the text terminal.')
+                                      ' output layout.')
 
     if sys.platform != "win32":
         argument_parser.add_argument('-n', '--no-progress',
@@ -334,6 +334,7 @@ def main(profile=None, values=None):
     for reporter_class, output_file in args.reporters:
         reporters.append(reporter_class(loglevels=args.loglevels,
                              runner=runner,
+                             succinct=args.succinct,
                              collect_results_by=args.gather_by,
                              output_file=output_file
                          ))

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -8,8 +8,11 @@ LOGLEVELS=["ERROR","FAIL","WARN","SKIP","INFO","PASS","DEBUG"]
 
 class GHMarkdownReporter(SerializeReporter):
 
-    def __init__(self, loglevels, **kwd):
+    def __init__(self, loglevels,
+                     succinct=None,
+                     **kwd):
         super().__init__(**kwd)
+        self.succinct = succinct
         self.loglevels = loglevels
 
     def write(self):
@@ -49,7 +52,7 @@ class GHMarkdownReporter(SerializeReporter):
 
 
     def render_rationale(self, check, checkid):
-        if not "rationale" in check:
+        if self.succinct or not "rationale" in check:
             return ""
 
         # Ideally we'll at some point invoke a proper markdown

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -8,13 +8,6 @@ LOGLEVELS=["ERROR","FAIL","WARN","SKIP","INFO","PASS","DEBUG"]
 
 class GHMarkdownReporter(SerializeReporter):
 
-    def __init__(self, loglevels,
-                     succinct=None,
-                     **kwd):
-        super().__init__(**kwd)
-        self.succinct = succinct
-        self.loglevels = loglevels
-
     def write(self):
         with open(self.output_file, "w") as fh:
             fh.write(self.get_markdown())
@@ -81,10 +74,6 @@ class GHMarkdownReporter(SerializeReporter):
                                                                 check["result"],
                                                                 check["description"]),
                                       f"\n* {github_search_url}\n{rationale}\n{logs}")
-
-    def omit_loglevel(self, msg):
-        return self.loglevels and (self.loglevels[0] > Status(msg))
-
 
     def deduce_profile_from_section_name(self, section):
         # This is very hacky!

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -1,5 +1,6 @@
 import os
 from fontbakery.reporters.serialize import SerializeReporter
+from fontbakery.utils import html5_collapsible
 from fontbakery.checkrunner import Status
 from fontbakery import __version__ as version
 
@@ -26,13 +27,6 @@ class GHMarkdownReporter(SerializeReporter):
             'PASS':  "\U0001F35E", # 🍞  :bread
             'DEBUG': "\U0001F50E", # 🔎 :mag_right:
         }[name]
-
-
-    def html5_collapsible(self, summary, details):
-        return (f"<details>\n"
-                f"<summary>{summary}</summary>\n"
-                f"{details}\n"
-                f"</details>\n")
 
 
     def log_md(self, log):
@@ -70,7 +64,7 @@ class GHMarkdownReporter(SerializeReporter):
 
         rationale = self.render_rationale(check, checkid)
 
-        return self.html5_collapsible("{} <b>{}:</b> {}".format(self.emoticon(check["result"]),
+        return html5_collapsible("{} <b>{}:</b> {}".format(self.emoticon(check["result"]),
                                                                 check["result"],
                                                                 check["description"]),
                                       f"\n* {github_search_url}\n{rationale}\n{logs}")
@@ -119,12 +113,12 @@ class GHMarkdownReporter(SerializeReporter):
 
         if family_checks:
             family_checks.sort(key=lambda c: c["result"])
-            md += self.html5_collapsible("<b>[{}] Family checks</b>".format(len(family_checks)),
+            md += html5_collapsible("<b>[{}] Family checks</b>".format(len(family_checks)),
                                          "".join(map(self.check_md, family_checks)) + "<br>")
 
         for filename in checks.keys():
             checks[filename].sort(key=lambda c: LOGLEVELS.index(c["result"]))
-            md += self.html5_collapsible("<b>[{}] {}</b>".format(len(checks[filename]),
+            md += html5_collapsible("<b>[{}] {}</b>".format(len(checks[filename]),
                                                                  filename),
                                          "".join(map(self.check_md, checks[filename])) + "<br>")
 

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -121,7 +121,7 @@ class HTMLReporter(SerializeReporter):
         content = unindent_rationale(check['rationale'], checkid)
         return cmarkgfm.markdown_to_html(
                 content, options=cmarkgfmOptions.CMARK_OPT_UNSAFE
-            )
+        )
 
     def log_html(self, log) -> str:
         """Return single check sub-result string as HTML or not if below log

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -8,8 +8,8 @@ from cmarkgfm.cmark import Options as cmarkgfmOptions
 
 
 import fontbakery.checkrunner
-import fontbakery.reporters.serialize
-from fontbakery.utils import unindent_rationale
+from fontbakery.reporters.serialize import SerializeReporter
+from fontbakery.utils import unindent_rationale, html5_collapsible
 
 LOGLEVELS = ["ERROR", "FAIL", "WARN", "SKIP", "INFO", "PASS", "DEBUG"]
 EMOTICON = {
@@ -24,7 +24,7 @@ EMOTICON = {
 ISSUE_URL = "https://github.com/googlefonts/fontbakery/issues"
 
 
-class HTMLReporter(fontbakery.reporters.serialize.SerializeReporter):
+class HTMLReporter(SerializeReporter):
     """Renders a report as a HTML document."""
 
     def write(self):
@@ -210,13 +210,6 @@ def html5_document(body_elements) -> str:
                     {body}
                     </body>
                 </html>"""
-
-
-def html5_collapsible(summary, details) -> str:
-    """Return nestable, collapsible <detail> tag for check grouping and sub-
-    results."""
-
-    return f"<details><summary>{summary}</summary><div>{details}</div></details>"
 
 
 def summary_table(

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -27,13 +27,6 @@ ISSUE_URL = "https://github.com/googlefonts/fontbakery/issues"
 class HTMLReporter(fontbakery.reporters.serialize.SerializeReporter):
     """Renders a report as a HTML document."""
 
-    def __init__(self, loglevels,
-                     succinct=None,
-                     **kwd):
-        super().__init__(**kwd)
-        self.succinct = succinct
-        self.loglevels = loglevels
-
     def write(self):
         with open(self.output_file, "w", encoding="utf-8") as fh:
             fh.write(self.get_html())
@@ -115,12 +108,6 @@ class HTMLReporter(fontbakery.reporters.serialize.SerializeReporter):
 
         body_elements[0:0] = body_top
         return html5_document(body_elements)
-
-    def omit_loglevel(self, msg) -> bool:
-        """Determine if message is below log level."""
-        return self.loglevels and (
-            self.loglevels[0] > fontbakery.checkrunner.Status(msg)
-        )
 
     def html_for_check(self, check) -> str:
         """Return HTML string for complete single check."""

--- a/Lib/fontbakery/reporters/serialize.py
+++ b/Lib/fontbakery/reporters/serialize.py
@@ -18,6 +18,7 @@ from fontbakery.checkrunner import (
             , END
             )
 from fontbakery.reporters import FontbakeryReporter
+from fontbakery.checkrunner import Status
 
 class SerializeReporter(FontbakeryReporter):
     """
@@ -29,9 +30,13 @@ class SerializeReporter(FontbakeryReporter):
     """
 
 
-    def __init__(self, collect_results_by=None
-                     , **kwd):
+    def __init__(self, loglevels,
+                     succinct=None,
+                     collect_results_by=None,
+                     **kwd):
         super().__init__(**kwd)
+        self.succinct = succinct
+        self.loglevels = loglevels
         self._results_by = collect_results_by
         self._items = {}
         self._doc = None
@@ -47,6 +52,12 @@ class SerializeReporter(FontbakeryReporter):
         # If check is None this is `section`
         # otherwise this `check`
         pass
+
+    def omit_loglevel(self, msg) -> bool:
+        """Determine if message is below log level."""
+        return self.loglevels and (
+            self.loglevels[0] > Status(msg)
+        )
 
     def _register(self, event):
         super()._register(event)

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -122,6 +122,13 @@ def unindent_rationale(rationale, checkid=None):
     return content
 
 
+def html5_collapsible(summary, details) -> str:
+    """Return nestable, collapsible <detail> tag for check grouping and sub-
+    results."""
+
+    return f"<details><summary>{summary}</summary><div>{details}</div></details>"
+
+
 def split_camel_case(camelcase):
     result = []
     word = ""

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -117,7 +117,7 @@ Here's the output of `fontbakery check-googlefonts -h`:
                             Messages are all status lines within a check.
                             One of: DEBUG, PASS, SKIP, INFO, WARN, FAIL, ERROR.
                             (default: LOGLEVEL)
-      --succinct            This is a slightly more compact and succint output layout for the text terminal.
+      --succinct            This is a slightly more compact and succint output layout.
       -n, --no-progress     In a tty as stdout, don't render the progress indicators.
       -C, --no-colors       No colors for tty output.
       -S, --show-sections   Show section summaries.


### PR DESCRIPTION
## Description

Currently the `--succinct` flag only affects terminal output, and the HTML reporter does not output rationale text.

With this PR, the HTML and MD reporters both output rationale text unless the `--succinct` flag is used, in which case rationales are suppressed.

## To Do
- [X] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [x] request a review

