### PR TITLE
Use pretty_print_list in production_glyphs_similarity

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2971,8 +2971,9 @@ def com_google_fonts_check_version_bump(ttFont,
     conditions = ['api_gfonts_ttFont'],
     proposal = 'legacy:check/118'
 )
-def com_google_fonts_check_production_glyphs_similarity(ttFont, api_gfonts_ttFont):
+def com_google_fonts_check_production_glyphs_similarity(ttFont, api_gfonts_ttFont, config):
     """Glyphs are similiar to Google Fonts version?"""
+    from fontbakery.utils import pretty_print_list
 
     def glyphs_surface_area(ttFont):
         """Calculate the surface area of a glyph's ink"""
@@ -3007,8 +3008,12 @@ def com_google_fonts_check_production_glyphs_similarity(ttFont, api_gfonts_ttFon
             bad_glyphs.append(glyph)
 
     if bad_glyphs:
+        formatted_list = "\t* " + pretty_print_list(config,
+                                            bad_glyphs,
+                                            sep="\n\t* ")
+
         yield WARN, ("Following glyphs differ greatly from"
-                     " Google Fonts version: [{}]").format(", ".join(sorted(bad_glyphs)))
+                     f" Google Fonts version:\n{formatted_list}")
     else:
         yield PASS, ("Glyphs are similar in"
                      " comparison to the Google Fonts version.")


### PR DESCRIPTION
## Description

Currently the similarity check produces output like this:

```
ollowing glyphs differ greatly from Google Fonts version: [Aring, Lambda,
Omegatonos, Phi, Xi, backslash, beta, braceright, copyright, dollar, eight,
emdash, multiply, numbersign, parenleft, parenright, percent, phi, quotedbl,
registered, sigma, slash, three, two, uni0191, uni01B2, uni01B7, uni01C0,
uni01C1, uni01C2, uni01EE, uni021C, uni021D, uni0221, uni0224, uni0245,
uni0251, uni0252, uni0258, uni025D, uni0281, uni0282, uni0295, uni02B0,
uni02B1, uni02B2, uni02B3, uni02B4, uni02B5, uni02B6, uni02B7, uni02B8,
uni02C1, uni02C2, uni02C3, uni02C4, uni02C5, uni02C8, uni02CC, uni02DE,
uni02E0, uni02E1, uni02E2, uni02E3, uni02E4, uni02EA, uni02EB, uni02F9,
uni02FA, uni02FB, uni02FC, uni0320, uni0335, uni033B, uni035E, uni035F,
uni0363, uni0364, uni0365, uni0366, uni0367, uni0368, uni0369, uni036A,
uni036B, uni036C, uni036D, uni036E, uni036F, uni0394, uni03A9, uni03BC,
uni03D7, uni03DB, uni03DD, uni0461, uni0488, uni0489, uni049C, uni049E,
uni049F, uni04BB, uni1D0A, uni1D20, uni1D21, uni1D22, uni1D2C, uni1D2E,
uni1D30, uni1D31, uni1D33, uni1D34, uni1D35, uni1D36, uni1D37, uni1D38,
uni1D39, uni1D3A, uni1D3C, uni1D3D, uni1D3E, uni1D3F, uni1D40, uni1D41,
uni1D42, uni1D43, uni1D45, uni1D47, uni1D48, uni1D49, uni1D4A, uni1D4D,
uni1D4F, uni1D50, uni1D51, uni1D52, uni1D56, uni1D57, uni1D58, uni1D5B,
uni1D5C, uni1D5D, uni1D5E, uni1D5F, uni1D60, uni1D61, uni1D62, uni1D63,
uni1D64, uni1D65, uni1D66, uni1D67, uni1D68, uni1D69, uni1D6A, uni1D78,
uni1D7E, uni1D9B, uni1D9C, uni1D9D, uni1D9E, uni1DA0, uni1DA1, uni1DA2,
uni1DA3, uni1DA4, uni1DA5, uni1DA8, uni1DA9, uni1DAA, uni1DAB, uni1DAC,
uni1DAD, uni1DAE, uni1DAF, uni1DB0, uni1DB1, uni1DB3, uni1DB4, uni1DB5,
uni1DB6, uni1DB7, uni1DB8, uni1DB9, uni1DBA, uni1DBB, uni1DBC, uni1DBD,
uni1DBE, uni1DBF, uni1DCA, uni1E10, uni1E11, uni1F02, uni1F03, uni1F04,
uni1F05, uni1F06, uni1F07, uni1F0A, uni1F0B, uni1F0C, uni1F0D, uni1F0E,
uni1F0F, uni1F1A, uni1F1B, uni1F1C, uni1F1D, uni1F22, uni1F23, uni1F24,
uni1F25, uni1F26, uni1F27, uni1F2A, uni1F2B, uni1F2C, uni1F2D, uni1F2E,
uni1F2F, uni1F32, uni1F33, uni1F34, uni1F35, uni1F36, uni1F37, uni1F3A,
uni1F3B, uni1F3C, uni1F3D, uni1F3E, uni1F3F, uni1F42, uni1F43, uni1F44,
uni1F45, uni1F4A, uni1F4B, uni1F4C, uni1F4D, uni1F52, uni1F53, uni1F54,
uni1F55, uni1F56, uni1F57, uni1F5B, uni1F5D, uni1F5F, uni1F62, uni1F63,
uni1F64, uni1F65, uni1F66, uni1F67, uni1F82, uni1F83, uni1F84, uni1F85,
uni1F86, uni1F87, uni1F88, uni1F89, uni1F8A, uni1F8B, uni1F8C, uni1F8D,
uni1F8E, uni1F8F, uni1F92, uni1F93, uni1F94, uni1F95, uni1F96, uni1F97,
uni1F98, uni1F99, uni1F9A, uni1F9B, uni1F9C, uni1F9D, uni1F9E, uni1F9F,
uni1FA2, uni1FA3, uni1FA4, uni1FA5, uni1FA6, uni1FA7, uni1FA8, uni1FA9,
uni1FAA, uni1FAB, uni1FAC, uni1FAD, uni1FAE, uni1FAF, uni1FBC, uni1FBE,
uni1FCC, uni1FCD, uni1FCE, uni1FCF, uni1FDD, uni1FDE, uni1FDF, uni1FFC,
uni200C, uni200D, uni207F, uni2090, uni2091, uni2092, uni2093, uni2094,
uni20A9, uni2117, uni25CC, uniA720, uniA721]
```

We have a list formatting function to stop this kind of thing from happening, and so we should use it...

## To Do
- [ ] update `CHANGELOG.md` - this is a small cosmetic change. Do we need to?
- [ ] wait for all checks to pass
- [ ] request a review

