### PR TITLE
Use `gflanguages` module to check sample rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Noteworthy code-changes
   - On the GitHub Markdown reporter, checks which produce all the same output for a range of fonts are now automatically clustered into a family check result. (PR #3610)
 
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/can_render_samples]:** Check that the fonts can render the sample texts for all languages specified on METADATA.pb, by using the new `gflanguages` module (issue #3605)
+
 
 ## 0.8.7 (2022-Feb-17)
 ### Noteworthy code-changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ defcon==0.10.0
 dehinter==4.0.0
 fontTools[ufo,lxml,unicode]==4.29.1
 font-v==2.1.0
+gflanguages==0.2.0
 glyphsets==0.2.1
 lxml==4.8.0
 opentype-sanitizer==8.2.1

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'dehinter>=3.1.0', # 3.1.0 added dehinter.font.hint function
         'fontTools[ufo,lxml,unicode]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
         'font-v',
+        'gflanguages>=0.2.0', # 0.1.1 was under the GPLv3 (see: https://github.com/googlefonts/fontbakery/pull/3617#issuecomment-1044898812)
         'glyphsets',
         'lxml',
         'opentype-sanitizer>=7.1.9',  # 7.1.9 fixes caret value format = 3 bug

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4054,7 +4054,8 @@ def test_check_metadata_can_render_samples():
 
     # Cabin's METADATA.pb does not have sample_glyphs entry
     metadata_file = TEST_FILE("cabin/METADATA.pb")
-    assert_SKIP(check(metadata_file))
+    assert_results_contain(check(metadata_file),
+                           INFO, 'no-samples')
 
     # We add a small set of latin glyphs
     # that we're sure Cabin supports:
@@ -4068,8 +4069,6 @@ def test_check_metadata_can_render_samples():
                            FAIL, 'sample-glyphs')
 
     # TODO: expand the check to also validate sample_text fields
-    # TODO: maybe also fetch samples from the language textprotos
-    #       published on the google/fonts git repo
 
 
 def test_check_description_urls():


### PR DESCRIPTION
com.google.fonts/check/metadata/can_render_samples

Check that the fonts can render the sample texts for all languages specified on METADATA.pb, by using the new `gflanguages` module.
(issue #3605)