### PR TITLE
New Check: com.google.fonts/check/metadata/category_hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Noteworthy code-changes
   - On the GitHub Markdown reporter, checks which produce all the same output for a range of fonts are now automatically clustered into a family check result. (PR #3610)
 
+### New Checks
+#### Added to the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/category_hints]:** Check if category on METADATA.pb matches what can be inferred from keywords in the family name. (issue #3624)
+
 ### Changes to existing checks
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/metadata/can_render_samples]:** Check that the fonts can render the sample texts for all languages specified on METADATA.pb, by using the new `gflanguages` module (issue #3605)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -79,7 +79,8 @@ METADATA_CHECKS = [
     'com.google.fonts/check/metadata/designer_profiles',
     'com.google.fonts/check/metadata/family_directory_name',
     'com.google.fonts/check/metadata/can_render_samples',
-    'com.google.fonts/check/metadata/unsupported_subsets'
+    'com.google.fonts/check/metadata/unsupported_subsets',
+    'com.google.fonts/check/metadata/category_hints'
 ]
 
 DESCRIPTION_CHECKS = [
@@ -5938,6 +5939,45 @@ def com_google_fonts_check_metadata_can_render_samples(ttFont, family_metadata):
                               f'"{sample_text}"\n')
 
     if passed:
+       yield PASS, "OK."
+
+
+@check(
+    id = "com.google.fonts/check/metadata/category_hints",
+    rationale = """
+        Sometimes the font familyname contains words that hint at which is the most likely correct category to be declared on METADATA.pb
+    """,
+    conditions = ["family_metadata"],
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/3624'
+)
+def com_google_fonts_check_metadata_category_hint(family_metadata):
+    """Check if category on METADATA.pb matches what can be inferred from the family name."""
+
+    HINTS = {
+        "SANS_SERIF": ["Grotesk",
+                       "Grotesque"],
+        "SERIF": ["Old Style",
+                  "Transitional",
+                  "Garamond"],
+        "DISPLAY": ["Display"],
+        "HANDWRITING": ["Hand",
+                        "Script"]
+    }
+
+    inferred_category = None
+    for category, hints in HINTS.items():
+        for hint in hints:
+            if hint in family_metadata.name:
+                inferred_category = category
+                break
+
+    if (inferred_category is not None and
+        not family_metadata.category == inferred_category):
+       yield WARN,\
+             Message('inferred-category',
+                     f'Familyname seems to hint at "{inferred_category}" but'
+                     f' METADATA.pb declares it as "{family_metadata.category}".')
+    else:
        yield PASS, "OK."
 
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4104,3 +4104,36 @@ def test_check_metadata_unsupported_subsets():
     md.subsets.extend(["cyrillic"])
     assert_results_contain(check(font, {"family_metadata": md}),
                            WARN, 'unsupported-subset')
+
+
+def test_check_metadata_category_hints():
+    """ Check if category on METADATA.pb matches what can be inferred from the family name. """
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/metadata/category_hints")
+
+    font = TEST_FILE("cabin/Cabin-Regular.ttf")
+    assert_PASS(check(font),
+                "with a familyname without any of the keyword hints...")
+
+    md = check["family_metadata"]
+    md.name = "SeaweedScript"
+    md.category = "DISPLAY"
+    assert_results_contain(check(font, {"family_metadata": md}),
+                           WARN, 'inferred-category',
+                           f'with a bad category "{md.category}" for familyname "{md.name}"...')
+
+    md.name = "RedHatDisplay"
+    md.category = "SANS_SERIF"
+    assert_results_contain(check(font, {"family_metadata": md}),
+                           WARN, 'inferred-category',
+                           f'with a bad category "{md.category}" for familyname "{md.name}"...')
+
+    md.name = "SeaweedScript"
+    md.category = "HANDWRITING"
+    assert_PASS(check(font, {"family_metadata": md}),
+                f'with a good category "{md.category}" for familyname "{md.name}"...')
+
+    md.name = "RedHatDisplay"
+    md.category = "DISPLAY"
+    assert_PASS(check(font, {"family_metadata": md}),
+                f'with a good category "{md.category}" for familyname "{md.name}"...')


### PR DESCRIPTION
Check if category on METADATA.pb matches what can be inferred from keywords in the family name.

Added to the Google Fonts Profile
**com.google.fonts/check/metadata/category_hints**
(issue #3624)
