### PR TITLE
Add "full_lists" to the list of required arguments

### DIFF
--- a/Lib/fontbakery/configuration.py
+++ b/Lib/fontbakery/configuration.py
@@ -5,7 +5,8 @@ import yaml
 class Configuration(dict):
     def __init__(self, **kwargs):
         super().__init__(kwargs)
-        for required_arg in ["custom_order", "explicit_checks", "exclude_checks"]:
+        for required_arg in ["custom_order", "explicit_checks",
+                             "exclude_checks", "full_lists"]:
             if required_arg not in self:
                 self[required_arg] = None
 

--- a/Lib/fontbakery/configuration.py
+++ b/Lib/fontbakery/configuration.py
@@ -5,8 +5,10 @@ import yaml
 class Configuration(dict):
     def __init__(self, **kwargs):
         super().__init__(kwargs)
-        for required_arg in ["custom_order", "explicit_checks",
-                             "exclude_checks", "full_lists"]:
+        for required_arg in ["custom_order",
+                             "explicit_checks",
+                             "exclude_checks",
+                             "full_lists"]:
             if required_arg not in self:
                 self[required_arg] = None
 


### PR DESCRIPTION
In #3517 `full_lists` was [added to the set of arguments that can be overridden](https://github.com/googlefonts/fontbakery/blob/a42692596729ef0dcb1ced765f4285cded07c25d/Lib/fontbakery/commands/check_profile.py#L308), but [it's missing from the list of required arguments](https://github.com/googlefonts/fontbakery/blob/a42692596729ef0dcb1ced765f4285cded07c25d/Lib/fontbakery/configuration.py#L8) and so it's not getting initialized, which causes a KeyError when [this line is hit](https://github.com/googlefonts/fontbakery/blob/a42692596729ef0dcb1ced765f4285cded07c25d/Lib/fontbakery/utils.py#L160).

Fixes #3631

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

