### PR TITLE
Update post table format version checks in post profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/metadata/category_hints]:** Check if category on METADATA.pb matches what can be inferred from keywords in the family name. (issue #3624)
 
 ### Changes to existing checks
+#### On the OpenType Profile
+  - **[com.google.fonts/check/post_table_version]:** Updated policy on acceptable post table version. Downgraded the check from FAIL to WARN-level (according to discussions at issue #3635)
+
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/metadata/can_render_samples]:** Check that the fonts can render the sample texts for all languages specified on METADATA.pb, by using the new `gflanguages` module (issue #3605)
 

--- a/Lib/fontbakery/profiles/post.py
+++ b/Lib/fontbakery/profiles/post.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS
+from fontbakery.status import FAIL, PASS, WARN
 from fontbakery.message import Message
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import
@@ -55,32 +55,43 @@ def com_google_fonts_check_family_underline_thickness(ttFonts):
 @check(
     id = 'com.google.fonts/check/post_table_version',
     rationale = """
-        Apple recommends against using 'post' table format 3 under most circumstances, as it can create problems with some printer drivers and PDF documents. The savings in disk space usually does not justify the potential loss in functionality.
-        Source: https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6post.html
+        post format 2.5 was deprecated in OpenType 1.3 and should not be used.
 
-        The CFF2 table does not contain glyph names, so variable OTFs should be allowed to use post table version 2.
+        According to Thomas Phinney, the possible problem with post format 3 is that under the right combination of 
+        circumstances, one can generate PDF from a font with a post format 3 table, and not have accurate backing store
+        for any text that has non-default glyphs for a given codepoint. It will look fine but not be searchable. This
+        can affect Latin text with high-end typography, and some complex script writing systems, especially with
+        higher-quality fonts. Those circumstances generally involve creating a PDF by first printing a PostScript stream
+        to disk, and then creating a PDF from that stream without reference to the original source document.  There are
+        some workflows where this applies,but these are not common use cases.
 
-        This check expects:
-        - Version 2 for TTF or OTF CFF2 Variable fonts
-        - Version 3 for OTF
+        Apple recommends against use of post format version 4 as "no longer necessary and should be avoided". Please
+        see the Apple TrueType reference documentation for additional details. 
+        https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6post.html
+
+        Acceptable post format versions are 2 and 3 for TTF and OTF (CFF and CFF2) builds.
     """,
     proposal = ['legacy:check/015',
                 'https://github.com/google/fonts/issues/215',
                 'https://github.com/googlefonts/fontbakery/issues/2638']
 )
-def com_google_fonts_check_post_table_version(ttFont, is_ttf):
+def com_google_fonts_check_post_table_version(ttFont):
     """Font has correct post table version?"""
     formatType = ttFont['post'].formatType
-    is_var = "fvar" in ttFont.keys()
-    is_cff2 = "CFF2" in ttFont.keys()
-    if is_ttf or (is_var and is_cff2):
-        expected = 2
-    else:
-        expected = 3
-    if formatType != expected:
+    if formatType == 3:
+        yield WARN, \
+              Message("post-table-version",
+                      "Post table format 3 use has niche use case problems."
+                      "Please review the check rationale for additional details.")
+    elif formatType == 2.5:
         yield FAIL, \
               Message("post-table-version",
-                      f"Post table should be version {expected}"
-                      f" instead of {formatType}.")
+                      "Post format 2.5 was deprecated in OpenType 1.3 and should" 
+                      "not be used.")
+    elif formatType == 4:
+        yield FAIL, \
+              Message("post-table-version",
+                      "According to Apple documentation, post format 4 tables are" 
+                      "no longer necessary and should not be used.")
     else:
-        yield PASS, f"Font has post table version {expected}."
+        yield PASS, f"Font has an acceptable post format {formatType} table version."

--- a/Lib/fontbakery/profiles/post.py
+++ b/Lib/fontbakery/profiles/post.py
@@ -55,25 +55,20 @@ def com_google_fonts_check_family_underline_thickness(ttFonts):
 @check(
     id = 'com.google.fonts/check/post_table_version',
     rationale = """
-        post format 2.5 was deprecated in OpenType 1.3 and should not be used.
+        Format 2.5 of the 'post' table was deprecated in OpenType 1.3 and should not be used.
 
-        According to Thomas Phinney, the possible problem with post format 3 is that under the right combination of 
-        circumstances, one can generate PDF from a font with a post format 3 table, and not have accurate backing store
-        for any text that has non-default glyphs for a given codepoint. It will look fine but not be searchable. This
-        can affect Latin text with high-end typography, and some complex script writing systems, especially with
-        higher-quality fonts. Those circumstances generally involve creating a PDF by first printing a PostScript stream
-        to disk, and then creating a PDF from that stream without reference to the original source document.  There are
-        some workflows where this applies,but these are not common use cases.
+        According to Thomas Phinney, the possible problem with post format 3 is that under the right combination of circumstances, one can generate PDF from a font with a post format 3 table, and not have accurate backing store for any text that has non-default glyphs for a given codepoint. It will look fine but not be searchable. This can affect Latin text with high-end typography, and some complex script writing systems, especially with
+        higher-quality fonts. Those circumstances generally involve creating a PDF by first printing a PostScript stream to disk, and then creating a PDF from that stream without reference to the original source document. There are some workflows where this applies,but these are not common use cases.
 
-        Apple recommends against use of post format version 4 as "no longer necessary and should be avoided". Please
-        see the Apple TrueType reference documentation for additional details. 
+        Apple recommends against use of post format version 4 as "no longer necessary and should be avoided". Please see the Apple TrueType reference documentation for additional details. 
         https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6post.html
 
         Acceptable post format versions are 2 and 3 for TTF and OTF CFF2 builds, and post format 3 for CFF builds.
     """,
     proposal = ['legacy:check/015',
                 'https://github.com/google/fonts/issues/215',
-                'https://github.com/googlefonts/fontbakery/issues/2638']
+                'https://github.com/googlefonts/fontbakery/issues/2638',
+                'https://github.com/googlefonts/fontbakery/issues/3635']
 )
 def com_google_fonts_check_post_table_version(ttFont):
     """Font has correct post table version?"""

--- a/Lib/fontbakery/profiles/post.py
+++ b/Lib/fontbakery/profiles/post.py
@@ -75,7 +75,7 @@ def com_google_fonts_check_family_underline_thickness(ttFonts):
                 'https://github.com/google/fonts/issues/215',
                 'https://github.com/googlefonts/fontbakery/issues/2638']
 )
-def com_google_fonts_check_post_table_version(ttFont, is_cff):
+def com_google_fonts_check_post_table_version(ttFont):
     """Font has correct post table version?"""
     formatType = ttFont['post'].formatType
     is_cff = "CFF " in ttFont

--- a/Lib/fontbakery/profiles/post.py
+++ b/Lib/fontbakery/profiles/post.py
@@ -69,16 +69,22 @@ def com_google_fonts_check_family_underline_thickness(ttFonts):
         see the Apple TrueType reference documentation for additional details. 
         https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6post.html
 
-        Acceptable post format versions are 2 and 3 for TTF and OTF (CFF and CFF2) builds.
+        Acceptable post format versions are 2 and 3 for TTF and OTF CFF2 builds, and post format 3 for CFF builds.
     """,
     proposal = ['legacy:check/015',
                 'https://github.com/google/fonts/issues/215',
                 'https://github.com/googlefonts/fontbakery/issues/2638']
 )
-def com_google_fonts_check_post_table_version(ttFont):
+def com_google_fonts_check_post_table_version(ttFont, is_cff):
     """Font has correct post table version?"""
     formatType = ttFont['post'].formatType
-    if formatType == 3:
+    is_cff = "CFF " in ttFont
+
+    if is_cff and formatType != 3:
+        yield FAIL, \
+              Message("post-table-version",
+                      "CFF fonts must contain post format 3 table.")
+    elif not is_cff and formatType == 3:
         yield WARN, \
               Message("post-table-version",
                       "Post table format 3 use has niche use case problems."

--- a/tests/profiles/post_test.py
+++ b/tests/profiles/post_test.py
@@ -70,7 +70,7 @@ def test_check_post_table_version():
     mock_post_2["post"].formatType = 2
     mock_post_2.reader.file.name = "post 2 mock font"
 
-    assert_PASS(check(mock_post_2))
+    assert_PASS(check(mock_post_2), reason="with a post 2 mock font")
 
     #
     # post format 2.5 mock font test
@@ -107,4 +107,24 @@ def test_check_post_table_version():
     assert_results_contain(check(mock_post_4),
                            FAIL, "post-table-version",
                            'with a font that has post format 4 table')
+
+
+    #
+    # post format 2/3 OTF CFF mock font test
+    #
+    mock_cff_post_2 = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Regular.otf"))
+
+    mock_cff_post_2["post"].formatType = 2
+    assert("CFF " in mock_cff_post_2)
+    assert("CFF2" not in mock_cff_post_2)
+    mock_cff_post_2.reader.file.name = "post 2 CFF mock font"
+
+    assert_results_contain(check(mock_cff_post_2),
+                           FAIL, "post-table-version",
+                           'with a CFF font that has post format 2 table')
+
+    mock_cff_post_3 = mock_cff_post_2
+    mock_cff_post_3["post"].formatType = 3
+
+    assert_PASS(check(mock_cff_post_3), reason="with a post 3 CFF mock font.")
 

--- a/tests/profiles/post_test.py
+++ b/tests/profiles/post_test.py
@@ -54,19 +54,57 @@ def test_check_family_underline_thickness(mada_ttFonts):
 
 
 def test_check_post_table_version():
-    """ Font has correct post table version (2 for TTF, 3 for OTF)? """
+    """ Font has acceptable post format version table? """
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/post_table_version")
 
-    # our reference Mada family is know to be good here.
-    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-    assert_PASS(check(ttFont),
-                'with good font.')
+    # create mock fonts for post format testing
 
-    # modify the post table version
-    ttFont['post'].formatType = 3
+    base_tt_font = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
 
-    assert_results_contain(check(ttFont),
+    #
+    # post format 2 mock font test
+    #
+    mock_post_2 = base_tt_font
+
+    mock_post_2["post"].formatType = 2
+    mock_post_2.reader.file.name = "post 2 mock font"
+
+    assert_PASS(check(mock_post_2))
+
+    #
+    # post format 2.5 mock font test
+    #
+    mock_post_2_5 = base_tt_font
+
+    mock_post_2_5["post"].formatType = 2.5
+    mock_post_2_5.reader.file.name = "post 2.5 mock font"
+
+    assert_results_contain(check(mock_post_2_5),
                            FAIL, "post-table-version",
-                           'with fonts that diverge on the fontRevision field value.')
+                           'with a font that has post format 2.5 table')
+
+    #
+    # post format 3 mock font test
+    #
+    mock_post_3 = base_tt_font
+
+    mock_post_3["post"].formatType = 3
+    mock_post_3.reader.file.name = "post 3  mock font"
+
+    assert_results_contain(check(mock_post_3),
+                           WARN, "post-table-version",
+                           'with a font that has post format 3 table')
+
+    #
+    # post format 4 mock font test
+    #
+    mock_post_4 = base_tt_font
+
+    mock_post_4["post"].formatType = 4
+    mock_post_4.reader.file.name = "post 4 mock font"
+
+    assert_results_contain(check(mock_post_4),
+                           FAIL, "post-table-version",
+                           'with a font that has post format 4 table')
 


### PR DESCRIPTION
Closes #3635

- Downgrades TT and CFF2 post format 3 FAIL to a WARN
- Keeps mandatory presence of OTF CFF post format 3 with FAIL status
- Adds post format 2.5 check as FAIL in all build formats
- Adds post format 4 check as FAIL in all build formats

---

### TODO

- [x] replace CFF format (only) check for post format 3 (https://github.com/googlefonts/fontbakery/pull/3637/commits/ec7a514440a10397706440df474cd35230adfa6e)
- [ ] update changelog if this is accepted