### PR TITLE
upstream_yaml_has_required_fields: rm repository_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Univeresal Profile
   - **[com.google.fonts/check/dotted_circle]:** Fix ERROR by adding safeguard conditional on `is_complex_shaper_font` function. (issue #3640)
+  - **[com.google.fonts/check/repo/upstream_yaml_has_required_fields]:** Remove repository_url field check since METADATA.pb files now include the source field. (issue #3618)
 
 #### On the OpenType Profile
   - **[com.google.fonts/check/post_table_version]:** Updated policy on acceptable post table version. Downgraded the check from FAIL to WARN-level (according to discussions at issue #3635)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4582,7 +4582,7 @@ def com_google_fonts_check_repo_fb_report(family_directory):
 )
 def com_google_fonts_check_repo_upstream_yaml_has_required_fields(upstream_yaml):
     """Check upstream.yaml file contains all required fields"""
-    required_fields = set(["branch", "files", "repository_url"])
+    required_fields = set(["branch", "files"])
     upstream_fields = set(upstream_yaml.keys())
 
     missing_fields = required_fields - upstream_fields

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3248,7 +3248,6 @@ def test_check_repo_upstream_yaml_has_required_fields():
                         "com.google.fonts/check/repo/upstream_yaml_has_required_fields")
     upstream_yaml = {
         "branch": "main",
-        "repository_url": "https://www.github.com/googlefonts/testFamily",
         "files": {"TestFamily-Regular.ttf": "TestFamily-Regular.ttf"}
     }
     # Pass if upstream.yaml file contains all fields
@@ -3256,7 +3255,7 @@ def test_check_repo_upstream_yaml_has_required_fields():
                 'for an upstream.yaml which contains all fields')
 
     # Fail if it doesn't
-    upstream_yaml.pop("repository_url")
+    upstream_yaml.pop("files")
     assert_results_contain(check([], {"upstream_yaml": upstream_yaml}),
                            FAIL, "missing-fields",
                            "for an upsream.yaml which doesn't contain all fields")


### PR DESCRIPTION
## Description

Remove repository_url field check since our METADATA.pb files now include the source field. Will fix false positives such as https://github.com/google/fonts/pull/4365#issuecomment-1065179253

(Closes #3618)

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

