### PR TITLE
Use "stable" read-the-docs URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.8.9 (2022-Apr-??)
-  - ...
+### BugFixes
+  - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)
 
 
 ## Upcoming release: 0.8.8 (2022-Mar-23)

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -52,7 +52,7 @@ class GHMarkdownReporter(SerializeReporter):
 
         check["logs"].sort(key=lambda c: c["status"])
         logs = "".join(map(self.log_md, check["logs"]))
-        github_search_url = ( "<a href=\"https://font-bakery.readthedocs.io/en/latest"
+        github_search_url = ( "<a href=\"https://font-bakery.readthedocs.io/en/stable"
                              f"/fontbakery/profiles/{profile}.html#{checkid}\">"
                              f"{checkid}</a>" )
 

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -1,6 +1,6 @@
 ## Font Bakery Command Line Usage
 
-Install Font Bakery as a package with the instructions in the [Installation Guides](https://font-bakery.readthedocs.io/en/latest/user/installation/index.html), and you will have a `fontbakery` command in your `$PATH`.
+Install Font Bakery as a package with the instructions in the [Installation Guides](https://font-bakery.readthedocs.io/en/stable/user/installation/index.html), and you will have a `fontbakery` command in your `$PATH`.
 
 This has several subcommands, described in the help function:
 


### PR DESCRIPTION
Users reading markdown reports are now directed to the "stable" version of
our ReadTheDocs documentation instead of the "latest" (git dev) one.

(issue #3677)
