### PR TITLE
Add 6 new `fvar` checks to OpenType profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/varfont/valid_axis_nameid]:** Validates that the value of axisNameID used by each VariationAxisRecord is greater than 255 and less than 32768. (issue #3702)
   - **[com.adobe.fonts/check/varfont/valid_subfamily_nameid]:** Validates that the value of subfamilyNameID used by each InstanceRecord is 2, 17, or greater than 255 and less than 32768. (issue #3703)
   - **[com.adobe.fonts/check/varfont/valid_postscript_nameid]:** Validates that the value of postScriptNameID used by each InstanceRecord is 6, 0xFFFF, or greater than 255 and less than 32768. (issue #3704)
+  - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Validates that when an instance record is included for the default instance, its subfamilyNameID value is set to either 2 or 17, and its postScriptNameID value is set to 6. (issue #3708)
 
 #### Added to the Universal Profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Checks that the font can be rasterized by FreeType. (issue #3642)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### Added to the OpenType Profile
   - **[com.adobe.fonts/check/varfont/valid_axis_nameid]:** Validates that the value of axisNameID used by each VariationAxisRecord is greater than 255 and less than 32768. (issue #3702)
+  - **[com.adobe.fonts/check/varfont/valid_subfamily_nameid]:** Validates that the value of subfamilyNameID used by each InstanceRecord is 2, 17, or greater than 255 and less than 32768. (issue #3703)
 
 #### Added to the Universal Profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Checks that the font can be rasterized by FreeType. (issue #3642)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the OpenType Profile
   - **[com.adobe.fonts/check/varfont/valid_axis_nameid]:** Validates that the value of axisNameID used by each VariationAxisRecord is greater than 255 and less than 32768. (issue #3702)
   - **[com.adobe.fonts/check/varfont/valid_subfamily_nameid]:** Validates that the value of subfamilyNameID used by each InstanceRecord is 2, 17, or greater than 255 and less than 32768. (issue #3703)
+  - **[com.adobe.fonts/check/varfont/valid_postscript_nameid]:** Validates that the value of postScriptNameID used by each InstanceRecord is 6, 0xFFFF, or greater than 255 and less than 32768. (issue #3704)
 
 #### Added to the Universal Profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Checks that the font can be rasterized by FreeType. (issue #3642)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/hmtx/whitespace_advances]:** Checks that whitespace glyphs have expected advance widths. (PR #3681)
   - **[com.google.fonts/check/cmap/alien_codepoints]:** Checks that there are no surrogate pair or private use area codepoints encoded in the cmap table. (PR #3681)
 
+#### Added to the OpenType Profile
+  - **[com.adobe.fonts/check/varfont/valid_axis_nameid]:** Validates that the value of axisNameID used by each VariationAxisRecord is greater than 255 and less than 32768. (issue #3702)
+
 #### Added to the Universal Profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Checks that the font can be rasterized by FreeType. (issue #3642)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/varfont/valid_postscript_nameid]:** Validates that the value of postScriptNameID used by each InstanceRecord is 6, 0xFFFF, or greater than 255 and less than 32768. (issue #3704)
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Validates that when an instance record is included for the default instance, its subfamilyNameID value is set to either 2 or 17, and its postScriptNameID value is set to 6. (issue #3708)
   - **[com.adobe.fonts/check/varfont/same_size_instance_records]:** Validates that all of the instance records in a given font have the same size, with all either including or omitting the postScriptNameID field. (issue #3705)
+  - **[com.adobe.fonts/check/varfont/distinct_instance_records]:** Validates that all of the instance records in a given font have distinct data. (issue #3706)
 
 #### Added to the Universal Profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Checks that the font can be rasterized by FreeType. (issue #3642)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/varfont/valid_subfamily_nameid]:** Validates that the value of subfamilyNameID used by each InstanceRecord is 2, 17, or greater than 255 and less than 32768. (issue #3703)
   - **[com.adobe.fonts/check/varfont/valid_postscript_nameid]:** Validates that the value of postScriptNameID used by each InstanceRecord is 6, 0xFFFF, or greater than 255 and less than 32768. (issue #3704)
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Validates that when an instance record is included for the default instance, its subfamilyNameID value is set to either 2 or 17, and its postScriptNameID value is set to 6. (issue #3708)
+  - **[com.adobe.fonts/check/varfont/same_size_instance_records]:** Validates that all of the instance records in a given font have the same size, with all either including or omitting the postScriptNameID field. (issue #3705)
 
 #### Added to the Universal Profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Checks that the font can be rasterized by FreeType. (issue #3642)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -30,8 +30,9 @@ Felipe Correa da Silva Sanches <juca@members.fsf.org>
 Filip Zembowicz <fil@google.com>
 Lasse Fister <commander@graphicore.de>
 Marc Foley <m.foley.88@gmail.com>
+Miguel Sousa <miguel.sousa@adobe.com>
 Mikhail Kashkin <mkashkin@gmail.com>
 Raph Levien <raph.levien@gmail.com>
-Simon Cozens <simon@simon-cozens.org>
 Robert Martinez <mail@robertmartinez.de>
+Simon Cozens <simon@simon-cozens.org>
 Vitaly Volkov <hash.3g@gmail.com>

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -311,3 +311,42 @@ def com_adobe_fonts_check_varfont_valid_subfamily_nameid(ttFont):
         )
 
     yield PASS, "subfamilyNameID values are valid"
+
+
+@check(
+    id="com.adobe.fonts/check/varfont/valid_postscript_nameid",
+    rationale="""
+        According to the 'fvar' documentation in OpenType spec v1.9
+        https://docs.microsoft.com/en-us/typography/opentype/spec/fvar
+
+        The postScriptNameID field provides a name ID that can be used to obtain
+        strings from the 'name' table that can be treated as equivalent to name
+        ID 6 (PostScript name) strings for the given instance. Values of 6 and
+        0xFFFF can be used; otherwise, values must be greater than 255 and less
+        than 32768.
+    """,
+    conditions=["is_variable_font"],
+    proposal="https://github.com/googlefonts/fontbakery/issues/3704",
+)
+def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont):
+    """Validates that the value of postScriptNameID used by each InstanceRecord
+    is 6, 0xFFFF, or greater than 255 and less than 32768."""
+
+    font_postscript_nameids = [
+        inst.postscriptNameID for inst in ttFont["fvar"].instances
+    ]
+    invalid_postscript_nameids = [
+        val
+        for val in font_postscript_nameids
+        if not (255 < val < 32768) and val not in {6, 0xFFFF}
+    ]
+
+    if invalid_postscript_nameids:
+        yield FAIL, Message(
+            "invalid-postscript-nameid",
+            f"Found {len(invalid_postscript_nameids)} postScriptNameID value(s) that "
+            "are not 6, 0xFFFF, or greater than 255 and less than 32768: "
+            f"{', '.join(map(str, invalid_postscript_nameids))}",
+        )
+
+    yield PASS, "postScriptNameID values are valid"

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -243,3 +243,34 @@ def com_google_fonts_check_varfont_slnt_range(ttFont, slnt_axis):
                       f' which is rare. If that\'s not the case, then'
                       f' the "slant" axis should be a range of'
                       f' negative values instead.')
+
+
+@check(
+    id="com.adobe.fonts/check/varfont/valid_axis_nameid",
+    rationale="""
+        According to the 'fvar' documentation in OpenType spec v1.9
+        https://docs.microsoft.com/en-us/typography/opentype/spec/fvar
+
+        The axisNameID field provides a name ID that can be used to obtain strings
+        from the 'name' table that can be used to refer to the axis in application
+        user interfaces. The name ID must be greater than 255 and less than 32768.
+    """,
+    conditions=["is_variable_font"],
+    proposal="https://github.com/googlefonts/fontbakery/issues/3702",
+)
+def com_adobe_fonts_check_varfont_valid_axis_nameid(ttFont):
+    """Validates that the value of axisNameID used by each VariationAxisRecord
+    is greater than 255 and less than 32768."""
+
+    font_axis_nameids = [axis.axisNameID for axis in ttFont["fvar"].axes]
+    invalid_axis_nameids = [val for val in font_axis_nameids if not (255 < val < 32768)]
+
+    if invalid_axis_nameids:
+        yield FAIL, Message(
+            "invalid-axis-nameid",
+            f"Found {len(invalid_axis_nameids)} axisNameID value(s) that are not "
+            "greater than 255 and less than 32768: "
+            f"{', '.join(map(str, invalid_axis_nameids))}",
+        )
+
+    yield PASS, "axisNameID values are valid"

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -384,7 +384,7 @@ def com_adobe_fonts_check_varfont_valid_default_instance_nameids(ttFont):
     axes_dflt_coords = {axis.axisTag: axis.defaultValue for axis in fvar_table.axes}
 
     for i, inst in enumerate(fvar_table.instances, 1):
-        inst_coords = {key: val for key, val in inst.coordinates.items()}
+        inst_coords = dict(inst.coordinates.items())
 
         # The instance record has the same coordinates as the default instance
         if inst_coords == axes_dflt_coords:
@@ -430,7 +430,7 @@ def com_adobe_fonts_check_varfont_same_size_instance_records(ttFont):
     """Validates that all of the instance records in a given font have the same size."""
 
     font_ps_nameids_not_provided = set(
-        [inst.postscriptNameID == 0xFFFF for inst in ttFont["fvar"].instances]
+        inst.postscriptNameID == 0xFFFF for inst in ttFont["fvar"].instances
     )
 
     # 'font_ps_nameids_not_provided' is a set whose values can only be
@@ -465,10 +465,10 @@ def com_adobe_fonts_check_varfont_distinct_instance_records(ttFont, has_name_tab
     name_table = ttFont["name"] if has_name_table else None
 
     unique_inst_recs = set()
-    repeat_inst_recs = list()
+    repeat_inst_recs = []
 
     for i, inst in enumerate(ttFont["fvar"].instances, 1):
-        inst_coords = [(key, val) for key, val in inst.coordinates.items()]
+        inst_coords = list(inst.coordinates.items())
         inst_subfam_nameid = inst.subfamilyNameID
         inst_postscript_nameid = inst.postscriptNameID
         inst_data = (tuple(inst_coords), inst_subfam_nameid, inst_postscript_nameid)

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -410,3 +410,37 @@ def com_adobe_fonts_check_varfont_valid_default_instance_nameids(ttFont):
                 )
 
     yield PASS, "The default instance nameID values are valid"
+
+
+@check(
+    id="com.adobe.fonts/check/varfont/same_size_instance_records",
+    rationale="""
+        According to the 'fvar' documentation in OpenType spec v1.9
+        https://docs.microsoft.com/en-us/typography/opentype/spec/fvar
+
+        All of the instance records in a given font must be the same size, with
+        all either including or omitting the postScriptNameID field. [...]
+        If the value is 0xFFFF, then the value is ignored, and no PostScript name
+        equivalent is provided for the instance.
+    """,
+    conditions=["is_variable_font"],
+    proposal="https://github.com/googlefonts/fontbakery/issues/3705",
+)
+def com_adobe_fonts_check_varfont_same_size_instance_records(ttFont):
+    """Validates that all of the instance records in a given font have the same size."""
+
+    font_ps_nameids_not_provided = set(
+        [inst.postscriptNameID == 0xFFFF for inst in ttFont["fvar"].instances]
+    )
+
+    # 'font_ps_nameids_not_provided' is a set whose values can only be
+    # {True}, {False}, or {True, False}. So if the size of the set is not 1,
+    # it means that some instance records have postscriptNameID values while
+    # others do not.
+    if len(font_ps_nameids_not_provided) != 1:
+        yield FAIL, Message(
+            "different-size-instance-records",
+            "Instance records don't all have the same size.",
+        )
+
+    yield PASS, "All instance records have the same size"

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -274,3 +274,40 @@ def com_adobe_fonts_check_varfont_valid_axis_nameid(ttFont):
         )
 
     yield PASS, "axisNameID values are valid"
+
+
+@check(
+    id="com.adobe.fonts/check/varfont/valid_subfamily_nameid",
+    rationale="""
+        According to the 'fvar' documentation in OpenType spec v1.9
+        https://docs.microsoft.com/en-us/typography/opentype/spec/fvar
+
+        The subfamilyNameID field provides a name ID that can be used to obtain
+        strings from the 'name' table that can be treated as equivalent to name
+        ID 17 (typographic subfamily) strings for the given instance. Values of
+        2 or 17 can be used; otherwise, values must be greater than 255 and less
+        than 32768.
+    """,
+    conditions=["is_variable_font"],
+    proposal="https://github.com/googlefonts/fontbakery/issues/3703",
+)
+def com_adobe_fonts_check_varfont_valid_subfamily_nameid(ttFont):
+    """Validates that the value of subfamilyNameID used by each InstanceRecord
+    is 2, 17, or greater than 255 and less than 32768."""
+
+    font_subfam_nameids = [inst.subfamilyNameID for inst in ttFont["fvar"].instances]
+    invalid_subfam_nameids = [
+        val
+        for val in font_subfam_nameids
+        if not (255 < val < 32768) and val not in {2, 17}
+    ]
+
+    if invalid_subfam_nameids:
+        yield FAIL, Message(
+            "invalid-subfamily-nameid",
+            f"Found {len(invalid_subfam_nameids)} subfamilyNameID value(s) that are not "
+            "2, 17, or greater than 255 and less than 32768: "
+            f"{', '.join(map(str, invalid_subfam_nameids))}",
+        )
+
+    yield PASS, "subfamilyNameID values are valid"

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -79,6 +79,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/layout_valid_script_tags',
     'com.google.fonts/check/layout_valid_language_tags',
     'com.adobe.fonts/check/varfont/valid_axis_nameid',
+    'com.adobe.fonts/check/varfont/valid_subfamily_nameid',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -83,6 +83,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/varfont/valid_postscript_nameid',
     'com.adobe.fonts/check/varfont/valid_default_instance_nameids',
     'com.adobe.fonts/check/varfont/same_size_instance_records',
+    'com.adobe.fonts/check/varfont/distinct_instance_records',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -82,6 +82,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/varfont/valid_subfamily_nameid',
     'com.adobe.fonts/check/varfont/valid_postscript_nameid',
     'com.adobe.fonts/check/varfont/valid_default_instance_nameids',
+    'com.adobe.fonts/check/varfont/same_size_instance_records',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -78,6 +78,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/layout_valid_feature_tags',
     'com.google.fonts/check/layout_valid_script_tags',
     'com.google.fonts/check/layout_valid_language_tags',
+    'com.adobe.fonts/check/varfont/valid_axis_nameid',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -81,6 +81,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/varfont/valid_axis_nameid',
     'com.adobe.fonts/check/varfont/valid_subfamily_nameid',
     'com.adobe.fonts/check/varfont/valid_postscript_nameid',
+    'com.adobe.fonts/check/varfont/valid_default_instance_nameids',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -80,6 +80,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/layout_valid_language_tags',
     'com.adobe.fonts/check/varfont/valid_axis_nameid',
     'com.adobe.fonts/check/varfont/valid_subfamily_nameid',
+    'com.adobe.fonts/check/varfont/valid_postscript_nameid',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -37,6 +37,11 @@ def is_cff2(ttFont):
 
 
 @condition
+def has_name_table(ttFont):
+    return "name" in ttFont.keys()
+
+
+@condition
 def variable_font_filename(ttFont):
     from fontbakery.utils import get_name_entry_strings
     from fontbakery.constants import (MacStyle,

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -306,3 +306,43 @@ def test_check_varfont_valid_subfamily_nameid():
     inst_1.subfamilyNameID = 3
     inst_2.subfamilyNameID = 18
     assert_results_contain(check(ttFont), FAIL, "invalid-subfamily-nameid")
+
+
+def test_check_varfont_valid_postscript_nameid():
+    """The value of postScriptNameID used by each InstanceRecord must
+    be 6, 0xFFFF, or greater than 255 and less than 32768."""
+    check = CheckTester(
+        opentype_profile, "com.adobe.fonts/check/varfont/valid_postscript_nameid"
+    )
+
+    # The postScriptNameID values in the reference varfont are all valid
+    ttFont = TTFont("data/test/cabinvf/Cabin[wdth,wght].ttf")
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    fvar_table = ttFont["fvar"]
+    inst_1 = fvar_table.instances[0]
+    inst_2 = fvar_table.instances[1]
+    inst_3 = fvar_table.instances[2]
+    inst_4 = fvar_table.instances[3]
+
+    # Change the instances' postScriptNameID to
+    # 6, 0xFFFF and to the maximum and minimum allowed values
+    inst_1.postscriptNameID = 6
+    inst_2.postscriptNameID = 0xFFFF
+    inst_3.postscriptNameID = 256
+    inst_4.postscriptNameID = 32767
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    # Change two instances' postScriptNameID to invalid values
+    # (32768 is greater than the maximum, and 255 is less than the minimum)
+    inst_3.postscriptNameID = 255
+    inst_4.postscriptNameID = 32768
+    assert_results_contain(check(ttFont), FAIL, "invalid-postscript-nameid")
+
+    # Reset two postScriptNameID to valid values,
+    # then set two other postScriptNameID to invalid values
+    inst_3.postscriptNameID = 256  # valid
+    inst_4.postscriptNameID = 32767  # valid
+    inst_1.postscriptNameID = 3
+    inst_2.postscriptNameID = 18
+    assert_results_contain(check(ttFont), FAIL, "invalid-postscript-nameid")

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -404,3 +404,38 @@ def test_check_varfont_valid_default_instance_nameids():
     assert_results_contain(
         check(ttFont), FAIL, "invalid-default-instance-postscript-nameid"
     )
+
+
+def test_check_varfont_same_size_instance_records():
+    """All of the instance records in a given font must have the same size,
+    with all either including or omitting the postScriptNameID field. If the value
+    is 0xFFFF it means that no PostScript name is provided for the instance."""
+    check = CheckTester(
+        opentype_profile, "com.adobe.fonts/check/varfont/same_size_instance_records"
+    )
+
+    # The value of postScriptNameID is 0xFFFF for all the instance records in the
+    # reference varfont
+    ttFont = TTFont("data/test/cabinvf/Cabin[wdth,wght].ttf")
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    fvar_table = ttFont["fvar"]
+    inst_1 = fvar_table.instances[0]
+    inst_2 = fvar_table.instances[1]
+    inst_3 = fvar_table.instances[2]
+    inst_4 = fvar_table.instances[3]
+
+    # Change the postScriptNameID of one instance record
+    inst_1.postscriptNameID = 256
+    assert_results_contain(check(ttFont), FAIL, "different-size-instance-records")
+
+    # Change the postScriptNameID of the remaining instance records
+    inst_2.postscriptNameID = 356
+    inst_3.postscriptNameID = 456
+    inst_4.postscriptNameID = 556
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    # Change the postScriptNameID of two instance records
+    inst_1.postscriptNameID = 0xFFFF
+    inst_3.postscriptNameID = 0xFFFF
+    assert_results_contain(check(ttFont), FAIL, "different-size-instance-records")

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -235,3 +235,34 @@ def test_check_varfont_slnt_range():
     # And it must now be good ;-)
     assert_PASS(check(ttFont))
 
+
+def test_check_varfont_valid_axis_nameid():
+    """The value of axisNameID used by each VariationAxisRecord must
+    be greater than 255 and less than 32768."""
+    check = CheckTester(
+        opentype_profile, "com.adobe.fonts/check/varfont/valid_axis_nameid"
+    )
+
+    # The axisNameID values in the reference varfont are all valid
+    ttFont = TTFont("data/test/cabinvf/Cabin[wdth,wght].ttf")
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    fvar_table = ttFont["fvar"]
+    wght_axis = fvar_table.axes[0]
+    wdth_axis = fvar_table.axes[1]
+
+    # Change the axes' axisNameID to the maximum and minimum allowed values
+    wght_axis.axisNameID = 32767
+    wdth_axis.axisNameID = 256
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    # Change the axes' axisNameID to invalid values
+    # (32768 is greater than the maximum, and 255 is less than the minimum)
+    wght_axis.axisNameID = 32768
+    wdth_axis.axisNameID = 255
+    assert_results_contain(check(ttFont), FAIL, "invalid-axis-nameid")
+
+    # Another set of invalid values
+    wght_axis.axisNameID = 128
+    wdth_axis.axisNameID = 36000
+    assert_results_contain(check(ttFont), FAIL, "invalid-axis-nameid")

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -439,3 +439,24 @@ def test_check_varfont_same_size_instance_records():
     inst_1.postscriptNameID = 0xFFFF
     inst_3.postscriptNameID = 0xFFFF
     assert_results_contain(check(ttFont), FAIL, "different-size-instance-records")
+
+
+def test_check_varfont_distinct_instance_records():
+    """All of the instance records in a font should have distinct coordinates
+    and distinct subfamilyNameID and postScriptName ID values."""
+    check = CheckTester(
+        opentype_profile, "com.adobe.fonts/check/varfont/distinct_instance_records"
+    )
+
+    # All of the instance records in the reference varfont are unique
+    ttFont = TTFont("data/test/cabinvf/Cabin[wdth,wght].ttf")
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    fvar_table = ttFont["fvar"]
+    inst_1 = fvar_table.instances[0]
+    inst_2 = fvar_table.instances[1]
+
+    # Make instance 2 the same as instance 1
+    inst_2.subfamilyNameID = inst_1.subfamilyNameID
+    inst_2.coordinates["wght"] = inst_1.coordinates["wght"]
+    assert_results_contain(check(ttFont), WARN, "repeated-instance-records")

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -266,3 +266,43 @@ def test_check_varfont_valid_axis_nameid():
     wght_axis.axisNameID = 128
     wdth_axis.axisNameID = 36000
     assert_results_contain(check(ttFont), FAIL, "invalid-axis-nameid")
+
+
+def test_check_varfont_valid_subfamily_nameid():
+    """The value of subfamilyNameID used by each InstanceRecord must
+    be 2, 17, or greater than 255 and less than 32768."""
+    check = CheckTester(
+        opentype_profile, "com.adobe.fonts/check/varfont/valid_subfamily_nameid"
+    )
+
+    # The subfamilyNameID values in the reference varfont are all valid
+    ttFont = TTFont("data/test/cabinvf/Cabin[wdth,wght].ttf")
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    fvar_table = ttFont["fvar"]
+    inst_1 = fvar_table.instances[0]
+    inst_2 = fvar_table.instances[1]
+    inst_3 = fvar_table.instances[2]
+    inst_4 = fvar_table.instances[3]
+
+    # Change the instances' subfamilyNameID to
+    # 2, 17 and to the maximum and minimum allowed values
+    inst_1.subfamilyNameID = 2
+    inst_2.subfamilyNameID = 17
+    inst_3.subfamilyNameID = 256
+    inst_4.subfamilyNameID = 32767
+    assert_PASS(check(ttFont), "with a good varfont...")
+
+    # Change two instances' subfamilyNameID to invalid values
+    # (32768 is greater than the maximum, and 255 is less than the minimum)
+    inst_3.subfamilyNameID = 255
+    inst_4.subfamilyNameID = 32768
+    assert_results_contain(check(ttFont), FAIL, "invalid-subfamily-nameid")
+
+    # Reset two subfamilyNameID to valid values,
+    # then set two other subfamilyNameID to invalid values
+    inst_3.subfamilyNameID = 256  # valid
+    inst_4.subfamilyNameID = 32767  # valid
+    inst_1.subfamilyNameID = 3
+    inst_2.subfamilyNameID = 18
+    assert_results_contain(check(ttFont), FAIL, "invalid-subfamily-nameid")

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -1,4 +1,5 @@
 from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance
 
 from fontbakery.checkrunner import (FAIL, WARN)
 from fontbakery.codetesting import (assert_PASS,
@@ -57,7 +58,6 @@ def test_check_varfont_regular_slnt_coord():
     ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
 
     # So we add one:
-    from fontTools.ttLib.tables._f_v_a_r import Axis
     new_axis = Axis()
     new_axis.axisTag = "slnt"
     ttFont["fvar"].axes.append(new_axis)
@@ -82,7 +82,6 @@ def test_check_varfont_regular_ital_coord():
         must be zero on the 'Regular' instance. """
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/varfont/regular_ital_coord")
-    from fontTools.ttLib.tables._f_v_a_r import Axis
 
     # Our reference varfont, CabinVFBeta.ttf, lacks an 'ital' variation axis.
     ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
@@ -112,7 +111,6 @@ def test_check_varfont_regular_opsz_coord():
         should be between 10 and 16 on the 'Regular' instance. """
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/varfont/regular_opsz_coord")
-    from fontTools.ttLib.tables._f_v_a_r import Axis
 
     # Our reference varfont, CabinVFBeta.ttf, lacks an 'opsz' variation axis.
     ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
@@ -362,7 +360,6 @@ def test_check_varfont_valid_default_instance_nameids():
     assert_PASS(check(ttFont), "with a good varfont...")
 
     # Add an instance record for the default instance
-    from fontTools.ttLib.tables._f_v_a_r import NamedInstance
 
     fvar_table = ttFont["fvar"]
     dflt_inst = NamedInstance()


### PR DESCRIPTION
1. `com.adobe.fonts/check/varfont/valid_axis_nameid`
    Validates that the value of axisNameID used by each VariationAxisRecord is greater than 255 and less than 32768.
    #3702
1. `com.adobe.fonts/check/varfont/valid_subfamily_nameid`
    Validates that the value of subfamilyNameID used by each InstanceRecord is 2, 17, or greater than 255 and less than 32768.
    #3703
1. `com.adobe.fonts/check/varfont/valid_postscript_nameid`
    Validates that the value of postScriptNameID used by each InstanceRecord is 6, 0xFFFF, or greater than 255 and less than 32768.
    #3704
1. `com.adobe.fonts/check/varfont/valid_default_instance_nameids`
    Validates that when an instance record is included for the default instance, its subfamilyNameID value is set to either 2 or 17, and its postScriptNameID value is set to 6.
    #3708
1. `com.adobe.fonts/check/varfont/same_size_instance_records`
    Validates that all of the instance records in a given font have the same size, with all either including or omitting the postScriptNameID field.
    #3705
1. `com.adobe.fonts/check/varfont/distinct_instance_records`
    Validates that all of the instance records in a given font have distinct data.
    #3706
