### PR TITLE
Support soft-return (U+2029) in rationale strings

### DIFF
--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -174,8 +174,7 @@ def com_google_fonts_check_family_win_ascent_and_descent(ttFont, vmetrics):
         OS/2 and hhea vertical metric values should match. This will produce the
         same linespacing on Mac, GNU+Linux and Windows.
 
-        - Mac OS X uses the hhea values.
-        
+        - Mac OS X uses the hhea values. 
         - Windows uses OS/2 or Win, depending on the OS or fsSelection bit value.
 
         When OS/2 and hhea vertical metrics match, the same linespacing results on

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -429,7 +429,7 @@ class TerminalReporter(TerminalProgress):
 
                 if check.rationale:
                     from fontbakery.utils import text_flow, unindent_and_unwrap_rationale
-                    content = unindent_and_unwrap_rationale(check.rationale).strip()
+                    content = unindent_and_unwrap_rationale(check.rationale)
                     print('    ' + self.theme["rationale-title"]("  Rationale:" + " " * 64) + '\n'
                           + text_flow(content,
                                       width=76,

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -114,24 +114,25 @@ def unindent_and_unwrap_rationale(rationale, checkid=None):
     """Takes the 'rationale' docstring of a check and removes indents and hard line
     breaks that were added to long lines."""
     content = ""
-    new_paragraph = True
 
     for line in rationale.split("\n"):
+        soft_return = line.endswith("\u2029")
         stripped_line = line.strip()
+        new_paragraph = len(stripped_line) == 0
 
-        if not stripped_line:
+        if new_paragraph:
+            content = content.rstrip()
             content += "\n\n"
-            new_paragraph = True
 
         else:
-            if not new_paragraph:
-                content += " "
-            else:
-                new_paragraph = False
-
             content += stripped_line
 
-    return content
+            if soft_return:
+                content += "\n"
+            else:
+                content += " "
+
+    return content.strip()
 
 
 def html5_collapsible(summary, details) -> str:

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -132,7 +132,7 @@ def unindent_and_unwrap_rationale(rationale, checkid=None):
             else:
                 content += " "
 
-    return content.strip()
+    return f"\n{content.strip()}\n"
 
 
 def html5_collapsible(summary, details) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,6 +76,7 @@ def test_unindent_and_unwrap_rationale():
         This is the last paragraph.
     """
     expected_rationale = (
+        "\n"
         "This is a line that is very long, so long in fact that it must be hard wrapped"
         " because it is longer than 88 lines, including the two 4-space indents.\n"
         "\n"
@@ -87,5 +88,6 @@ def test_unindent_and_unwrap_rationale():
         " means that it will not be appendend to the end of the previous line.\n"
         "\n"
         "This is the last paragraph."
+        "\n"
     )
     assert unindent_and_unwrap_rationale(rationale) == expected_rationale

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,8 @@
-import pytest
-from fontbakery.utils import text_flow, can_shape
+from fontbakery.utils import (
+    can_shape,
+    text_flow,
+    unindent_and_unwrap_rationale,
+)
 from fontTools.ttLib import TTFont
 from fontbakery.codetesting import portable_path
 
@@ -49,9 +52,40 @@ def test_text_flow():
 #                                             "      Two   \n"
 #                                             "      Three ")
 
+
 def test_can_shape():
     font = TTFont(portable_path(
         "data/test/source-sans-pro/OTF/SourceSansPro-Regular.otf"
     ))
     assert can_shape(font, "ABC")
     assert not can_shape(font, "こんにちは")
+
+
+def test_unindent_and_unwrap_rationale():
+    rationale = """
+        This is a line that is very long, so long in fact that it must be hard wrapped
+        because it is longer than 88 lines, including the two 4-space indents.
+
+        This is a new paragraph. This paragraph is also too long to fit within the
+        maximum width, so it must be hard wrapped.
+        This is a new line that was NOT soft-wrapped, so it will end up appendend to
+        the previous line. 
+        This is yet another line, but this one was soft-wrapped (Shift+Return), which
+        means that it will not be appendend to the end of the previous line.
+
+        This is the last paragraph.
+    """
+    expected_rationale = (
+        "This is a line that is very long, so long in fact that it must be hard wrapped"
+        " because it is longer than 88 lines, including the two 4-space indents.\n"
+        "\n"
+        "This is a new paragraph. This paragraph is also too long to fit within the"
+        " maximum width, so it must be hard wrapped."
+        " This is a new line that was NOT soft-wrapped, so it will end up appendend to"
+        " the previous line.\n"
+        "This is yet another line, but this one was soft-wrapped (Shift+Return), which"
+        " means that it will not be appendend to the end of the previous line.\n"
+        "\n"
+        "This is the last paragraph."
+    )
+    assert unindent_and_unwrap_rationale(rationale) == expected_rationale


### PR DESCRIPTION
- Adds support for soft-return (U+2029) in rationale strings.
- Adds a unit test for the `unindent_and_unwrap_rationale` method.
- Uses the soft-return in the rationale of **com.google.fonts/check/os2_metrics_match_hhea** (Universal profile).