### PR TITLE
Support setting right-side margin in `text_flow` method

### DIFF
--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -435,6 +435,7 @@ class TerminalReporter(TerminalProgress):
                                       width=76,
                                       indent=4,
                                       left_margin=2,
+                                      right_margin=1,
                                       space_padding=True,
                                       text_color=self.theme["rationale-text"]))
 

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -43,7 +43,7 @@ def colorless_len(str):
 
 def text_flow(content, width=80, indent=0, left_margin=0, right_margin=0,
               first_line_indent=0, space_padding=False,
-              text_color="{}".format): # pylint: disable=consider-using-f-string
+              text_color="{}".format):  # pylint: disable=consider-using-f-string
     result = []
     line_num = 0
     for line in content.split("\n"):
@@ -76,7 +76,8 @@ def text_flow(content, width=80, indent=0, left_margin=0, right_margin=0,
                     new_line = chunks.pop(0)
                     while chunks:
                         next_len = colorless_len(new_line) + 1 + colorless_len(chunks[0])
-                        if next_len >= _width: break
+                        if next_len >= _width:
+                            break
                         new_line += "/" + chunks.pop(0)
                     this_line = new_line
                     words.insert(0, "/" + "/".join(chunks))

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -41,18 +41,18 @@ def colorless_len(str):
     return len(re.sub('\x1b(\\[[0-9;]+|\\].+)m', '', str))
 
 
-def text_flow(content, width=80, indent=0, left_margin=0,
+def text_flow(content, width=80, indent=0, left_margin=0, right_margin=0,
               first_line_indent=0, space_padding=False,
               text_color="{}".format): # pylint: disable=consider-using-f-string
     result = []
     line_num = 0
     for line in content.split("\n"):
         _indent = indent
-        _width = width
+        _width = width - right_margin
 
         if line.strip() == "":
             if space_padding:
-                result.append(" " * _indent + text_color(" " * _width))
+                result.append(" " * _indent + text_color(" " * width))
             continue
 
         words = line.split(" ")
@@ -83,15 +83,15 @@ def text_flow(content, width=80, indent=0, left_margin=0,
                 else:
                     # not sure what else to do,
                     # so we'll simply cut the long word
-                    words.insert(0, this_line[_width:])
-                    this_line = this_line[:_width]
+                    words.insert(0, this_line[_width:])  # word overflow chunk
+                    this_line = this_line[:_width]  # line with chopped word leftover
 
-            while words and (colorless_len(this_line) + 1 + colorless_len(words[0]) <= width):
+            while words and (colorless_len(this_line) + 1 + colorless_len(words[0]) <= _width):
                 this_line += " " + words.pop(0)
 
             if space_padding:
                 # pad the line with spaces to fit the block width:
-                this_line += " " * (_width - colorless_len(this_line))
+                this_line += " " * (width - colorless_len(this_line))
             result.append(" " * _indent + text_color(this_line))
     return "\n".join(result)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,6 +43,40 @@ def test_text_flow():
                                              " Two   \n"
                                              " Three ")
 
+    assert text_flow("One Two Three",
+                     width=9,
+                     left_margin=1,
+                     right_margin=1,
+                     space_padding=True) == (" One Two \n"
+                                             " Three   ")
+
+    assert text_flow("One Two Three",
+                     width=8,
+                     left_margin=1,
+                     right_margin=1,
+                     space_padding=True) == (" One    \n"
+                                             " Two    \n"
+                                             " Three  ")
+
+    assert text_flow("One Two Three Four",
+                     width=7,
+                     left_margin=1,
+                     right_margin=1,
+                     space_padding=True) == (" One   \n"
+                                             " Two   \n"
+                                             " Three \n"
+                                             " Four  ")
+
+    assert text_flow("One Two Three Four",
+                     width=6,
+                     left_margin=1,
+                     right_margin=1,
+                     space_padding=True) == (" One  \n"
+                                             " Two  \n"
+                                             " Thre \n"
+                                             " e    \n"
+                                             " Four ")
+
 # FIXME!
 #    assert text_flow("One Two Three",
 #                     width=12,


### PR DESCRIPTION
- Adds support for setting the right-side margin in `text_flow` method
- Sets the right-side margin terminal reporter to `1`

Before this change:

<img width="763" alt="Screen Shot 2022-04-18 at 14 23 09" src="https://user-images.githubusercontent.com/2119742/163880258-afaa3ab5-2bf6-4765-8bae-c85cb01817dd.png">

After this change:

<img width="761" alt="Screen Shot 2022-04-18 at 14 23 50" src="https://user-images.githubusercontent.com/2119742/163880275-4a4d90e9-b627-4b46-ad31-25110c250ced.png">
