### PR TITLE
Fix `assert_results_contain` method

### DIFF
--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -198,7 +198,8 @@ def assert_results_contain(check_results,
     if not reason:
         reason = f"[{expected_msgcode}]"
     if not expected_msgcode:
-      raise Exception("Test must expect a message code")
+        raise Exception(
+            "Test must provide the expected message code (e.g. PASS or FAIL or ...)")
 
     print(f"Test {expected_status} {reason}")
     check_results = list(check_results)
@@ -210,21 +211,20 @@ def assert_results_contain(check_results,
 
     for status, msg in check_results:
         if status not in [PASS, DEBUG] and not isinstance(msg, Message):
-            raise Exception(f"Bare Python strings no longer supported in result values.\n"
+            raise Exception(
+                f"Bare Python strings are no longer supported in result values.\n"
                 f"Please use the Message class to wrap strings and to give them"
-                f" a keyword useful for identifying them (on bug reports as well as"
-                f" in the implementation of reliable code-tests).\n"
-                f"(Bare string: '{msg}')")
+                f" a keyword useful for identifying them (in bug reports as well as"
+                f" in the implementation of reliable unit tests).\n"
+                f"(Bare string: {msg!r})")
 
-        if (status == expected_status and
-            expected_msgcode == None or
-            (isinstance(msg, Message) and msg.code == expected_msgcode)):
+        if status == expected_status:
             if isinstance(msg, Message):
                 return msg.message
             else:
-                return msg # It is probably a plain python string
+                return msg  # It is probably a plain python string
 
-    #if not found:
+    # if no match was found
     raise Exception(f"Expected to find {expected_status}, [code: {expected_msgcode}]\n"
                     f"But did not find it in:\n"
                     f"{check_results}")

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -218,7 +218,10 @@ def assert_results_contain(check_results,
                 f" in the implementation of reliable unit tests).\n"
                 f"(Bare string: {msg!r})")
 
-        if status == expected_status:
+        if status == expected_status and (
+            expected_msgcode is None
+            or (isinstance(msg, Message) and msg.code == expected_msgcode)
+        ):
             if isinstance(msg, Message):
                 return msg.message
             else:

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -199,7 +199,7 @@ def assert_results_contain(check_results,
         reason = f"[{expected_msgcode}]"
     if not expected_msgcode:
         raise Exception(
-            "Test must provide the expected message code (e.g. PASS or FAIL or ...)")
+            "Test must provide the expected message code")
 
     print(f"Test {expected_status} {reason}")
     check_results = list(check_results)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3832,7 +3832,7 @@ def test_check_STAT_axis_order():
     # This clearly is not a TTF, but is good enough for testing:
     fonts = [TEST_FILE("merriweather/METADATA.pb")]
     assert_results_contain(check(fonts),
-                           ERROR, "bad-font")
+                           INFO, "bad-font")
 
 
 def test_check_metadata_escaped_strings():
@@ -3900,7 +3900,7 @@ def test_check_description_family_update():
     import requests
     desc = requests.get(ABEEZEE_DESC).text
     assert_results_contain(check(font, {'description': desc}),
-                           FAIL, "description-not-updated")
+                           WARN, "description-not-updated")
 
     assert_PASS(check(font, {'description': desc + '\nSomething else...'}))
 
@@ -4116,12 +4116,12 @@ def test_check_metadata_unsupported_subsets():
     md = check["family_metadata"]
     md.subsets.extend(["foo"])
     assert_results_contain(check(font, {"family_metadata": md}),
-                           WARN, 'unknown-subset')
+                           FAIL, 'unknown-subset')
 
     del md.subsets[:]
     md.subsets.extend(["cyrillic"])
     assert_results_contain(check(font, {"family_metadata": md}),
-                           WARN, 'unsupported-subset')
+                           FAIL, 'unsupported-subset')
 
 
 def test_check_metadata_category_hints():

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -828,11 +828,11 @@ def test_check_cjk_chws_feature():
     cjk_font = TEST_FILE("cjk/SourceHanSans-Regular.otf")
     ttFont = TTFont(cjk_font)
     assert_results_contain(check(ttFont),
-                           FAIL, "missing-chws-feature",
+                           WARN, "missing-chws-feature",
                            'for Source Han Sans')
 
     assert_results_contain(check(ttFont),
-                           FAIL, "missing-vchw-feature",
+                           WARN, "missing-vchw-feature",
                            'for Source Han Sans')
 
     # Insert them.
@@ -937,7 +937,7 @@ def test_check_gpos7():
 
     font = TEST_FILE("notosanskhudawadi/NotoSansKhudawadi-Regular.ttf")
     assert_results_contain(check(font),
-                           FAIL, "has-gpos7")
+                           WARN, "has-gpos7")
 
 
 def test_freetype_rasterizer():


### PR DESCRIPTION
Before, the method incorrectly matched status codes that were not included in the `check_results` list.