### PR TITLE
New check: com.adobe.fonts/check/nameid_1_win_english

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)
 
 ### New Checks
+#### Added to the Adobe Fonts Profile
+  - **[com.adobe.fonts/check/nameid_1_win_english]:** Validates that the font has a good nameID 1, Windows/Unicode/US-English `name` table record. (issue #3714)
+
 #### Added to the Noto Fonts Profile
   - The majority of checks from the Google Fonts profile have been added. (PR #3681)
   - **[com.google.fonts/check/name/noto_manufacturer]:** Checks for a known manufacturer name and correct designer URL in the name table. (PR #3681)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -134,9 +134,11 @@ profile.auto_register(globals())
 profile.check_log_override(
     # from `universal` profile:
     "com.google.fonts/check/whitespace_glyphs",
-    reason="For Adobe, this is not as severe "
-    + "as assessed in the original check for 0x00A0.",
     overrides=(("missing-whitespace-glyph-0x00A0", WARN, KEEP_ORIGINAL_MESSAGE),),
+    reason=(
+        "For Adobe, this is not as severe "
+        "as assessed in the original check for 0x00A0."
+    ),
 )
 
 

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -81,7 +81,7 @@ def test_check_find_empty_letters():
     assert message == "U+0042 should be visible, but its glyph ('B') is empty."
 
 
-def test_check_missing_whitespace():
+def test_check_whitespace_glyphs_adobefonts_override():
     """Check that overridden test for nbsp yields WARN rather than FAIL."""
     check = CheckTester(
         adobefonts_profile, "com.google.fonts/check/whitespace_glyphs:adobefonts"

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -16,6 +16,29 @@ from fontbakery.profiles import adobefonts as adobefonts_profile
 from fontbakery.profiles.adobefonts import profile
 
 
+def test_get_family_checks():
+    """Validate the set of family checks."""
+    family_checks = profile.get_family_checks()
+    family_check_ids = {check.id for check in family_checks}
+    expected_family_check_ids = {
+        "com.adobe.fonts/check/family/bold_italic_unique_for_nameid1",
+        "com.adobe.fonts/check/family/consistent_upm",
+        "com.adobe.fonts/check/family/max_4_fonts_per_family_name",
+        "com.google.fonts/check/family/underline_thickness",
+        "com.google.fonts/check/family/panose_proportion",
+        "com.google.fonts/check/family/panose_familytype",
+        "com.google.fonts/check/family/equal_unicode_encodings",
+        "com.google.fonts/check/family/equal_font_versions",
+        "com.google.fonts/check/family/win_ascent_and_descent",
+        "com.google.fonts/check/family/vertical_metrics",
+        "com.google.fonts/check/family/single_directory",
+        # should it be included here? or should we have
+        # a get_superfamily_checks() method?
+        # 'com.google.fonts/check/superfamily/vertical_metrics',
+    }
+    assert family_check_ids == expected_family_check_ids
+
+
 def test_check_family_consistent_upm():
     """A group of fonts designed & produced as a family should have consistent
     units per em."""
@@ -41,29 +64,6 @@ def test_check_family_consistent_upm():
     # now try with one font with a different UPM (i.e. 2048)
     ttFonts[1]["head"].unitsPerEm = 2048
     assert_results_contain(check(ttFonts), FAIL, "inconsistent-upem")
-
-
-def test_get_family_checks():
-    """Validate the set of family checks."""
-    family_checks = profile.get_family_checks()
-    family_check_ids = {check.id for check in family_checks}
-    expected_family_check_ids = {
-        "com.adobe.fonts/check/family/bold_italic_unique_for_nameid1",
-        "com.adobe.fonts/check/family/consistent_upm",
-        "com.adobe.fonts/check/family/max_4_fonts_per_family_name",
-        "com.google.fonts/check/family/underline_thickness",
-        "com.google.fonts/check/family/panose_proportion",
-        "com.google.fonts/check/family/panose_familytype",
-        "com.google.fonts/check/family/equal_unicode_encodings",
-        "com.google.fonts/check/family/equal_font_versions",
-        "com.google.fonts/check/family/win_ascent_and_descent",
-        "com.google.fonts/check/family/vertical_metrics",
-        "com.google.fonts/check/family/single_directory",
-        # should it be included here? or should we have
-        # a get_superfamily_checks() method?
-        # 'com.google.fonts/check/superfamily/vertical_metrics',
-    }
-    assert family_check_ids == expected_family_check_ids
 
 
 def test_check_find_empty_letters():

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -95,3 +95,27 @@ def test_check_whitespace_glyphs_adobefonts_override():
     for subtable in ttFont["cmap"].tables:
         subtable.cmap.pop(0x00A0, None)
     assert_results_contain(check(ttFont), WARN, "missing-whitespace-glyph-0x00A0")
+
+
+def test_check_valid_glyphnames_adobefonts_override():
+    """Check that overridden test yields WARN rather than FAIL."""
+    check = CheckTester(
+        adobefonts_profile, "com.google.fonts/check/valid_glyphnames:adobefonts"
+    )
+
+    ttFont = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
+    assert_PASS(check(ttFont))
+
+    good_name = "b" * 63
+    bad_name1 = "a" * 64
+    bad_name2 = "3cents"
+    bad_name3 = ".threecents"
+    ttFont.glyphOrder[2] = bad_name1
+    ttFont.glyphOrder[3] = bad_name2
+    ttFont.glyphOrder[4] = bad_name3
+    ttFont.glyphOrder[5] = good_name
+    message = assert_results_contain(check(ttFont), WARN, "found-invalid-names")
+    assert good_name not in message
+    assert bad_name1 in message
+    assert bad_name2 in message
+    assert bad_name3 in message


### PR DESCRIPTION
Added to the Adobe Fonts Profile
Validates that the font has a good nameID 1, Windows/Unicode/US-English `name` table record
(issue #3714)

Includes a few other minor tweaks.