### PR TITLE
`com.google.fonts/check/cjk_vertical_metrics_regressions`: Round expected sTypoAscender and sTypoDescender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the GoogleFonts Profile
   - **[com.google.fonts/check/license/OFL_copyright]:** Improve wording of log message to clarify its meaning. It was too easy to think that the displayed copyright string (read from the font binary and reported for reference) was an example of the actually expected string format. (issue #3674)
+  - **[com.google.fonts/check/cjk_vertical_metrics_regressions]:** Round calculation of expected sTypoAscender and sTypoDescender values (issue #3645)
+
 #### On the Universal Profile
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4971,8 +4971,8 @@ def com_google_fonts_check_cjk_vertical_metrics(ttFont):
         'OS/2.usWinDescent': ttFont['OS/2'].usWinDescent
     }
     expected_metrics = {
-        'OS/2.sTypoAscender': font_upm * 0.88,
-        'OS/2.sTypoDescender': font_upm * -0.12,
+        'OS/2.sTypoAscender': round(font_upm * 0.88),
+        'OS/2.sTypoDescender': round(font_upm * -0.12),
         'OS/2.sTypoLineGap': 0,
         'hhea.lineGap': 0,
     }


### PR DESCRIPTION
(issue #3645)