### PR TITLE
fix typo and make rationale match the code

### DIFF
--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -101,8 +101,8 @@ def com_google_fonts_check_name_trailing_spaces(ttFont):
     conditions = ['vmetrics',
                   'not is_cjk_font'],
     rationale = """
-        A font's winAscent and winDescent values should be greater than the
-        head table's yMax, abs(yMin) values. If they are less than these values,
+        A font's winAscent and winDescent values should be greater than or equal to 
+        the head table's yMax, abs(yMin) values. If they are less than these values,
         clipping can occur on Windows platforms
         (https://github.com/RedHatBrand/Overpass/issues/33).
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -174,7 +174,7 @@ def com_google_fonts_check_family_win_ascent_and_descent(ttFont, vmetrics):
         OS/2 and hhea vertical metric values should match. This will produce the
         same linespacing on Mac, GNU+Linux and Windows.
 
-        - Mac OS X uses the hhea values. 
+        - Mac OS X uses the hhea values.
         - Windows uses OS/2 or Win, depending on the OS or fsSelection bit value.
 
         When OS/2 and hhea vertical metrics match, the same linespacing results on

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -174,7 +174,7 @@ def com_google_fonts_check_family_win_ascent_and_descent(ttFont, vmetrics):
         OS/2 and hhea vertical metric values should match. This will produce the
         same linespacing on Mac, GNU+Linux and Windows.
 
-        - Mac OS X uses the hhea values.
+        - Mac OS X uses the hhea values. 
         - Windows uses OS/2 or Win, depending on the OS or fsSelection bit value.
 
         When OS/2 and hhea vertical metrics match, the same linespacing results on


### PR DESCRIPTION
## Description
Remove unexpected Paragraph Separator and adjust `com.google.fonts/check/family/win_ascent_and_descent` test Rational to match what the test is doing

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

