### PR TITLE
Fix 'com.fontwerk/check/inconsistencies_between_fvar_stat'

### DIFF
--- a/Lib/fontbakery/profiles/fontwerk.py
+++ b/Lib/fontbakery/profiles/fontwerk.py
@@ -182,7 +182,7 @@ def com_fontwerk_check_inconsistencies_between_fvar_stat(ttFont):
         return FAIL,\
                Message("missing-stat-table",
                        "Missing STAT table in variable font.")
-
+    passed = True
     fvar = ttFont['fvar']
     name = ttFont['name']
 
@@ -193,6 +193,7 @@ def com_fontwerk_check_inconsistencies_between_fvar_stat(ttFont):
                   Message("missing-name-id",
                           f"The name ID {ins.subfamilyNameID} used in an"
                           f" fvar instance is missing in the name table.")
+            passed = False
             continue
 
         for axis_tag, value in ins.coordinates.items():
@@ -201,8 +202,13 @@ def com_fontwerk_check_inconsistencies_between_fvar_stat(ttFont):
                       Message("missing-fvar-instance-axis-value",
                               f"{instance_name}: '{axis_tag}' axis value '{value}'"
                               f" missing in STAT table.")
+                passed = False
 
         # TODO: Compare fvar instance name with constructed STAT table name.
+
+    if passed:
+        yield PASS, "STAT and fvar axis records are consistent."
+
 
 @check(
     id = 'com.fontwerk/check/style_linking',

--- a/tests/profiles/fontwerk_test.py
+++ b/tests/profiles/fontwerk_test.py
@@ -53,6 +53,10 @@ def test_check_inconsistencies_between_fvar_stat():
     check = CheckTester(fontwerk_profile,
                         'com.fontwerk/check/inconsistencies_between_fvar_stat')
 
+    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
+    msg = assert_PASS(check(ttFont), "with a good varfont...")
+    assert msg == "STAT and fvar axis records are consistent."
+
     ttFont = TTFont(TEST_FILE("bad_fonts/fvar_stat_differences/AxisLocationVAR.ttf"))
     ttFont['name'].removeNames(nameID=277)
     assert_results_contain(check(ttFont),


### PR DESCRIPTION
Fixes ERROR caused by lack of yield status when the font triggers no failures.
Screenshot of the error before this patch.

<img width="719" alt="Screen Shot 2022-04-25 at 01 53 04" src="https://user-images.githubusercontent.com/2119742/165057215-8febcd0b-cd37-4098-bd25-65ea3228c659.png">

/cc @moontypespace 