### PR TITLE
Replace soft-return character. Fix bullet lists

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -6196,7 +6196,7 @@ def com_google_fonts_check_repo_sample_image(readme_contents, readme_directory, 
             yield WARN,\
                   Message("image-not-displayed",
                           f'Even though the README.md file does not display'
-                          f' a font sample image, a few image files were found:\n'
+                          f' a font sample image, a few image files were found:\n\n'
                           f'{bullet_list(config, local_image_files)}\n'
                           f'\n'
                           f'Please consider including one of those images on the README.\n'

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -585,7 +585,7 @@ def com_google_fonts_check_required_tables(ttFont, config):
     if optional_tables:
         yield INFO, \
               Message("optional-tables",
-                      f"This font contains the following optional tables:\n"
+                      f"This font contains the following optional tables:\n\n"
                       f"{bullet_list(config, optional_tables)}")
 
     if is_variable_font(ttFont):
@@ -601,7 +601,7 @@ def com_google_fonts_check_required_tables(ttFont, config):
     if missing_tables:
         yield FAIL, \
               Message("required-tables",
-                      f"This font is missing the following required tables:\n"
+                      f"This font is missing the following required tables:\n\n"
                       f"{bullet_list(config, missing_tables)}")
     else:
         yield PASS, "Font contains all required tables."
@@ -1147,7 +1147,7 @@ def com_google_fonts_check_designspace_has_consistent_glyphset(designSpace, conf
     if failures:
         yield FAIL,\
               Message("inconsistent-glyphset",
-                      f"Glyphsets were not consistent:\n"
+                      f"Glyphsets were not consistent:\n\n"
                       f"{bullet_list(config, failures)}")
     else:
         yield PASS, "Glyphsets were consistent."
@@ -1183,7 +1183,7 @@ def com_google_fonts_check_designspace_has_consistent_codepoints(designSpace, co
     if failures:
         yield FAIL,\
               Message("inconsistent-codepoints",
-                      f"Unicode assignments were not consistent:\n"
+                      f"Unicode assignments were not consistent:\n\n"
                       f"{bullet_list(config, failures)}")
     else:
         yield PASS, "Unicode assignments were consistent."
@@ -1271,7 +1271,7 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
         yield WARN,\
               Message("unreachable-glyphs",
                       f"The following glyphs could not be reached"
-                      f" by codepoint or substitution rules:\n"
+                      f" by codepoint or substitution rules:\n\n"
                       f"{bullet_list(config, list(all_glyphs))}\n")
     else:
         yield PASS, "Font did not contain any unreachable glyphs"
@@ -1578,7 +1578,7 @@ def com_google_fonts_check_dotted_circle(ttFont, config):
         yield FAIL,\
               Message("unattached-dotted-circle-marks",
                       f"The following glyphs could not be attached"
-                      f" to the dotted circle glyph:\n"
+                      f" to the dotted circle glyph:\n\n"
                       f"{bullet_list(config, unattached)}")
     else:
         yield PASS, "All marks were anchored to dotted circle"

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -174,7 +174,7 @@ def com_google_fonts_check_family_win_ascent_and_descent(ttFont, vmetrics):
         OS/2 and hhea vertical metric values should match. This will produce the
         same linespacing on Mac, GNU+Linux and Windows.
 
-        - Mac OS X uses the hhea values. 
+        - Mac OS X uses the hhea values.⏎
         - Windows uses OS/2 or Win, depending on the OS or fsSelection bit value.
 
         When OS/2 and hhea vertical metrics match, the same linespacing results on

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -197,7 +197,7 @@ def pretty_print_list(config, values, shorten=10, sep=", ", glue="and"):
     if len(values) == 1:
         return str(values[0])
 
-    if config['full_lists']:
+    if config.get('full_lists'):
         shorten = None
 
     if shorten and len(values) > shorten + 2:

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -201,13 +201,13 @@ def pretty_print_list(config, values, shorten=10, sep=", ", glue="and"):
         shorten = None
 
     if shorten and len(values) > shorten + 2:
-        sep = sep.join(map(str, values[:shorten]))
-        return (f"{sep} {glue} {len(values) - shorten} more.\n"
+        joined_items_str = sep.join(map(str, values[:shorten]))
+        return (f"{joined_items_str} {glue} {len(values) - shorten} more.\n"
                 f"\n"
                 f"Use -F or --full-lists to disable shortening of long lists.")
     else:
-        sep = sep.join(map(str, values[:-1]))
-        return f"{sep} {glue} {str(values[-1])}"
+        joined_items_str = sep.join(map(str, values[:-1]))
+        return f"{joined_items_str} {glue} {str(values[-1])}"
 
 
 def bullet_list(config, items, bullet="-", indentation="\t"):

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -143,7 +143,7 @@ def unindent_and_unwrap_rationale(rationale, checkid=None):
     content = ""
 
     for line in rationale.split("\n"):
-        soft_return = line.endswith("\u2029")
+        soft_return = line.endswith("⏎")  # U+23CE
         stripped_line = line.strip()
         new_paragraph = len(stripped_line) == 0
 
@@ -155,7 +155,7 @@ def unindent_and_unwrap_rationale(rationale, checkid=None):
             content += stripped_line
 
             if soft_return:
-                content += "\n"
+                content = f"{content[:-1]}\n"
             else:
                 content += " "
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,9 @@
+import pytest
+
 from fontbakery.utils import (
+    bullet_list,
     can_shape,
+    pretty_print_list,
     text_flow,
     unindent_and_unwrap_rationale,
 )
@@ -125,3 +129,96 @@ def test_unindent_and_unwrap_rationale():
         "\n"
     )
     assert unindent_and_unwrap_rationale(rationale) == expected_rationale
+
+
+def _make_values(count: int) -> list:
+    """Helper method that returns a list with 'count' number of items"""
+    return [f"item {i}" for i in range(1, count + 1)]
+
+
+@pytest.mark.parametrize('values, expected_str', [
+    # (_make_values(0), ""),  # causes IndexError
+    (_make_values(1), "item 1"),
+    (_make_values(2), "item 1 and item 2"),
+    (_make_values(3), "item 1, item 2 and item 3"),
+    (_make_values(4), "item 1, item 2, item 3 and item 4"),
+    (_make_values(12), ("item 1, item 2, item 3, item 4, item 5, item 6, item 7,"
+                        " item 8, item 9, item 10, item 11 and item 12")),
+])
+def test_pretty_print_list_full(values, expected_str):
+    config = {'full_lists': True}
+    assert pretty_print_list(config, values) == expected_str
+    assert pretty_print_list(config, values, shorten=3) == expected_str
+    assert pretty_print_list(
+        config, values, sep=" + ") == expected_str.replace(", ", " + ")
+    assert pretty_print_list(
+        config, values, glue="&") == expected_str.replace("and", "&")
+
+
+MORE_MSG = "\n\nUse -F or --full-lists to disable shortening of long lists."
+
+
+@pytest.mark.parametrize('values, shorten, expected_str', [
+    (_make_values(1), None, "item 1"),
+    (_make_values(1), 0, "item 1"),
+    (_make_values(1), 1, "item 1"),
+    (_make_values(1), 2, "item 1"),
+    (_make_values(2), None, "item 1 and item 2"),
+    (_make_values(2), 0, "item 1 and item 2"),
+    (_make_values(2), 1, "item 1 and item 2"),
+    (_make_values(2), 2, "item 1 and item 2"),
+    (_make_values(2), 3, "item 1 and item 2"),
+    (_make_values(3), None, "item 1, item 2 and item 3"),
+    (_make_values(3), 1, "item 1, item 2 and item 3"),
+    (_make_values(3), 2, "item 1, item 2 and item 3"),
+    (_make_values(3), 3, "item 1, item 2 and item 3"),
+    (_make_values(3), 4, "item 1, item 2 and item 3"),
+    (_make_values(4), None, "item 1, item 2, item 3 and item 4"),
+    (_make_values(4), 0, "item 1, item 2, item 3 and item 4"),
+    (_make_values(4), 1, f"item 1 and 3 more.{MORE_MSG}"),
+    (_make_values(4), 2, "item 1, item 2, item 3 and item 4"),
+    (_make_values(4), 3, "item 1, item 2, item 3 and item 4"),
+    (_make_values(4), 4, "item 1, item 2, item 3 and item 4"),
+    (_make_values(4), 5, "item 1, item 2, item 3 and item 4"),
+    (_make_values(5), None, "item 1, item 2, item 3, item 4 and item 5"),
+    (_make_values(5), 0, "item 1, item 2, item 3, item 4 and item 5"),
+    (_make_values(5), 1, f"item 1 and 4 more.{MORE_MSG}"),
+    (_make_values(5), 2, f"item 1, item 2 and 3 more.{MORE_MSG}"),
+    (_make_values(5), 3, "item 1, item 2, item 3, item 4 and item 5"),
+    (_make_values(5), 4, "item 1, item 2, item 3, item 4 and item 5"),
+    (_make_values(5), 5, "item 1, item 2, item 3, item 4 and item 5"),
+    (_make_values(5), 6, "item 1, item 2, item 3, item 4 and item 5"),
+    (_make_values(12), None, ("item 1, item 2, item 3, item 4, item 5, item 6, item 7,"
+                              " item 8, item 9, item 10, item 11 and item 12")),
+    (_make_values(12), 0, ("item 1, item 2, item 3, item 4, item 5, item 6, item 7,"
+                           " item 8, item 9, item 10, item 11 and item 12")),
+    (_make_values(12), 1, f"item 1 and 11 more.{MORE_MSG}"),
+    (_make_values(12), 6, ("item 1, item 2, item 3, item 4, item 5, item 6"
+                           f" and 6 more.{MORE_MSG}")),
+    (_make_values(13), None, ("item 1, item 2, item 3, item 4, item 5, item 6, item 7,"
+                              f" item 8, item 9, item 10 and 3 more.{MORE_MSG}")),
+    (_make_values(13), 0, ("item 1, item 2, item 3, item 4, item 5, item 6, item 7,"
+                           " item 8, item 9, item 10, item 11, item 12 and item 13")),
+    (_make_values(13), 1, f"item 1 and 12 more.{MORE_MSG}"),
+    (_make_values(13), 6, ("item 1, item 2, item 3, item 4, item 5, item 6"
+                           f" and 7 more.{MORE_MSG}")),
+])
+def test_pretty_print_list_shorten(values, shorten, expected_str):
+    config = {}
+    if shorten is not None:
+        assert pretty_print_list(config, values, shorten=shorten) == expected_str
+    else:
+        assert pretty_print_list(config, values) == expected_str
+
+
+@pytest.mark.parametrize('values, expected_str', [
+    (_make_values(1), "\t- item 1"),
+    (_make_values(2), "\t- item 1 \n\n\t- And item 2"),
+    (_make_values(3), "\t- item 1\n\n\t- item 2 \n\n\t- And item 3"),
+    (_make_values(4), "\t- item 1\n\n\t- item 2\n\n\t- item 3 \n\n\t- And item 4"),
+])
+def test_bullet_list(values, expected_str):
+    config = {'full_lists': True}
+    assert bullet_list(config, values) == expected_str
+    assert bullet_list(config, values, bullet="*") == expected_str.replace("-", "*")
+    assert bullet_list(config, values, indentation="") == expected_str.replace("\t", "")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,7 +103,7 @@ def test_unindent_and_unwrap_rationale():
         This is a new paragraph. This paragraph is also too long to fit within the
         maximum width, so it must be hard wrapped.
         This is a new line that was NOT soft-wrapped, so it will end up appendend to
-        the previous line. 
+        the previous line.⏎
         This is yet another line, but this one was soft-wrapped (Shift+Return), which
         means that it will not be appendend to the end of the previous line.
 


### PR DESCRIPTION
This PR changes the soft-return marker character from U+2029 (implemented in #3717) to U+23CE. The former was problematic because it's non-marking, and [some IDEs complain about it](https://github.com/googlefonts/fontbakery/pull/3735#discussion_r856666652).

The other (unrelated) change fixes several occurrences where `bullet_list()` was preceded by only one new line, instead of two; other places throughout the codebase where `bullet_list()` is use already employ 2 new lines.
Below are screen shots of terminal and HTML renditions before and after #3692, and with the changes in this PR.

## Before #3692
<img width="1769" alt="before_ 69bd7acce671b4feacc422f2b90f3d66c0d904e8" src="https://user-images.githubusercontent.com/2119742/165188145-99617a7c-c345-409b-ab9c-c70f01867401.png">
<img width="1184" alt="before" src="https://user-images.githubusercontent.com/2119742/165188172-bd719f2c-e1b8-4511-b24c-806ed10b523e.png">

## After #3692
<img width="1769" alt="after_ 69bd7acce671b4feacc422f2b90f3d66c0d904e8" src="https://user-images.githubusercontent.com/2119742/165188288-b9ac770f-024c-49ae-85d5-471718bac463.png">
<img width="1184" alt="after" src="https://user-images.githubusercontent.com/2119742/165188298-966d4382-769a-4d7c-a178-d18e1e3bb2e4.png">

## With this PR
<img width="1769" alt="fix" src="https://user-images.githubusercontent.com/2119742/165188351-1826b66f-5148-446b-8caf-ee7a96d7d478.png">
<img width="1184" alt="patch" src="https://user-images.githubusercontent.com/2119742/165188370-cd1098b6-839f-4e1b-9ba6-869616a873ee.png">

