### PR TITLE
Enable CFF/CFF2 fonts in 'com.google.fonts/check/required_tables'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the Universal Profile
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)
+  - **[com.google.fonts/check/required_tables]:** CFF/CFF2 fonts are now checked instead of skipped. (pull #3742)
 
 ### New Checks
 #### Added to the Adobe Fonts Profile

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -558,15 +558,17 @@ def com_google_fonts_check_whitespace_ink(ttFont):
         The spec also documents that variable fonts require the following table:
 
         - STAT (Style attributes)
+
+        Depending on the typeface and coverage of a font, certain tables are
+        recommended for optimum quality.
+
+        For example:⏎
+        - the performance of a non-linear font is improved if the VDMX, LTSH,
+          and hdmx tables are present.⏎
+        - Non-monospaced Latin fonts should have a kern table.⏎
+        - A gasp table is necessary if a designer wants to influence the sizes
+          at which grayscaling is used under Windows. Etc.
     """,
-    # Depending on the typeface and coverage of a font, certain tables are
-    # recommended for optimum quality.
-    # For example:
-    # - the performance of a non-linear font is improved if the VDMX, LTSH,
-    #   and hdmx tables are present.
-    # - Non-monospaced Latin fonts should have a kern table.
-    # - A gasp table is necessary if a designer wants to influence the sizes
-    #   at which grayscaling is used under Windows. Etc.
     proposal = 'legacy:check/052'
 )
 def com_google_fonts_check_required_tables(ttFont, config, is_variable_font):

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -101,7 +101,7 @@ def com_google_fonts_check_name_trailing_spaces(ttFont):
     conditions = ['vmetrics',
                   'not is_cjk_font'],
     rationale = """
-        A font's winAscent and winDescent values should be greater than or equal to 
+        A font's winAscent and winDescent values should be greater than or equal to
         the head table's yMax, abs(yMin) values. If they are less than these values,
         clipping can occur on Windows platforms
         (https://github.com/RedHatBrand/Overpass/issues/33).
@@ -542,14 +542,11 @@ def com_google_fonts_check_whitespace_ink(ttFont):
     rationale = """
         Depending on the typeface and coverage of a font, certain tables are
         recommended for optimum quality.
-        
-        For example:
-        
+
+        For example:⏎
         - the performance of a non-linear font is improved if the VDMX, LTSH,
-          and hdmx tables are present.
-          
-        - Non-monospaced Latin fonts should have a kern table.
-        
+          and hdmx tables are present.⏎
+        - Non-monospaced Latin fonts should have a kern table.⏎
         - A gasp table is necessary if a designer wants to influence the sizes
           at which grayscaling is used under Windows. Etc.
     """,
@@ -1082,14 +1079,14 @@ def com_google_fonts_check_rupee(ttFont):
                       ' Indian Rupee Sign “₹” at codepoint U+20B9.')
     else:
         yield PASS, "Looks good!"
-        
+
 
 @check(
     id = "com.google.fonts/check/designspace_has_sources",
     rationale = """
         This check parses a designspace file and tries to load the
         source files specified.
-        
+
         This is meant to ensure that the file is not malformed,
         can be properly parsed and does include valid source file references.
     """,
@@ -1476,7 +1473,7 @@ def com_google_fonts_check_cjk_chws_feature(ttFont):
 
         When building the font with fontmake, the problem can be fixed by adding
         this to the command line:
-        
+
         --filter DecomposeTransformedComponentsFilter
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2011',

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -554,6 +554,10 @@ def com_google_fonts_check_whitespace_ink(ttFont):
         - name (Naming table)⏎
         - OS/2 (OS/2 and Windows specific metrics)⏎
         - post (PostScript information)
+
+        The spec also documents that variable fonts require the following table:
+
+        - STAT (Style attributes)
     """,
     proposal = 'legacy:check/052'
 )
@@ -579,8 +583,6 @@ def com_google_fonts_check_required_tables(ttFont, config):
                       f"{bullet_list(config, optional_tables)}")
 
     if is_variable_font(ttFont):
-        # According to https://github.com/googlefonts/fontbakery/issues/1671
-        # STAT table is required on WebKit on MacOS 10.12 for variable fonts.
         REQUIRED_TABLES.append("STAT")
 
     missing_tables = [req for req in REQUIRED_TABLES

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -540,19 +540,21 @@ def com_google_fonts_check_whitespace_ink(ttFont):
     id='com.google.fonts/check/required_tables',
     conditions = ['is_ttf'],
     rationale = """
-        Depending on the typeface and coverage of a font, certain tables are
-        recommended for optimum quality.
+        According to the OpenType spec
+        https://docs.microsoft.com/en-us/typography/opentype/spec/otff#required-tables
 
-        For example:⏎
-        - the performance of a non-linear font is improved if the VDMX, LTSH,
-          and hdmx tables are present.⏎
-        - Non-monospaced Latin fonts should have a kern table.⏎
-        - A gasp table is necessary if a designer wants to influence the sizes
-          at which grayscaling is used under Windows. Etc.
+        Whether TrueType or CFF outlines are used in an OpenType font, the following
+        tables are required for the font to function correctly:
+
+        - cmap (Character to glyph mapping)⏎
+        - head (Font header)⏎
+        - hhea (Horizontal header)⏎
+        - hmtx (Horizontal metrics)⏎
+        - maxp (Maximum profile)⏎
+        - name (Naming table)⏎
+        - OS/2 (OS/2 and Windows specific metrics)⏎
+        - post (PostScript information)
     """,
-    # FIXME:
-    # The rationale description above comes from FontValidator, check W0022.
-    # We may want to improve it and/or rephrase it.
     proposal = 'legacy:check/052'
 )
 def com_google_fonts_check_required_tables(ttFont, config):
@@ -568,15 +570,6 @@ def com_google_fonts_check_required_tables(ttFont, config):
                        "BASE", "GPOS", "GSUB", "JSTF",
                        "gasp", "hdmx", "LTSH", "PCLT",
                        "VDMX", "vhea", "vmtx", "kern"]
-    # See https://github.com/googlefonts/fontbakery/issues/617
-    #
-    # We should collect the rationale behind the need for each of the
-    # required tables above. Perhaps split it into individual checks
-    # with the correspondent rationales for each subset of required tables.
-    #
-    # com.google.fonts/check/kern_table is a good example of a separate
-    # check for a specific table providing a detailed description of
-    # the rationale behind it.
 
     optional_tables = [opt for opt in OPTIONAL_TABLES if opt in ttFont.keys()]
     if optional_tables:

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -559,6 +559,14 @@ def com_google_fonts_check_whitespace_ink(ttFont):
 
         - STAT (Style attributes)
     """,
+    # Depending on the typeface and coverage of a font, certain tables are
+    # recommended for optimum quality.
+    # For example:
+    # - the performance of a non-linear font is improved if the VDMX, LTSH,
+    #   and hdmx tables are present.
+    # - Non-monospaced Latin fonts should have a kern table.
+    # - A gasp table is necessary if a designer wants to influence the sizes
+    #   at which grayscaling is used under Windows. Etc.
     proposal = 'legacy:check/052'
 )
 def com_google_fonts_check_required_tables(ttFont, config, is_variable_font):
@@ -574,6 +582,16 @@ def com_google_fonts_check_required_tables(ttFont, config, is_variable_font):
                        "gasp", "hdmx", "LTSH", "PCLT",
                        "VDMX", "vhea", "vmtx", "kern"]
 
+    # See https://github.com/googlefonts/fontbakery/issues/617
+    #
+    # We should collect the rationale behind the need for each of the
+    # required tables above. Perhaps split it into individual checks
+    # with the correspondent rationales for each subset of required tables.
+    #
+    # com.google.fonts/check/kern_table is a good example of a separate
+    # check for a specific table providing a detailed description of
+    # the rationale behind it.
+
     font_tables = ttFont.keys()
 
     optional_tables = [opt for opt in OPTIONAL_TABLES if opt in font_tables]
@@ -584,6 +602,8 @@ def com_google_fonts_check_required_tables(ttFont, config, is_variable_font):
                       f"{bullet_list(config, optional_tables)}")
 
     if is_variable_font:
+        # According to https://github.com/googlefonts/fontbakery/issues/1671
+        # STAT table is required on WebKit on MacOS 10.12 for variable fonts.
         REQUIRED_TABLES.append("STAT")
 
     missing_tables = [req for req in REQUIRED_TABLES

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -486,13 +486,15 @@ def test_check_required_tables():
     check = CheckTester(universal_profile,
                         "com.google.fonts/check/required_tables")
 
-    required_tables = ["cmap", "head", "hhea", "hmtx",
+    REQUIRED_TABLES = ["cmap", "head", "hhea", "hmtx",
                        "maxp", "name", "OS/2", "post"]
-    optional_tables = ["cvt ", "fpgm", "loca", "prep",
+
+    OPTIONAL_TABLES = ["cvt ", "fpgm", "loca", "prep",
                        "VORG", "EBDT", "EBLC", "EBSC",
                        "BASE", "GPOS", "GSUB", "JSTF",
-                       "gasp", "hdmx", "kern", "LTSH",
-                       "PCLT", "VDMX", "vhea", "vmtx"]
+                       "gasp", "hdmx", "LTSH", "PCLT",
+                       "VDMX", "vhea", "vmtx", "kern"]
+
     # Our reference Mada Regular font is good here
     ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
 
@@ -521,7 +523,7 @@ def test_check_required_tables():
     # and finally remove what we've just added:
     del ttFont.reader.tables["STAT"]
     # Now we remove required tables one-by-one to validate the FAIL code-path:
-    for required in required_tables:
+    for required in REQUIRED_TABLES:
         ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
         if required in ttFont.reader.tables:
             del ttFont.reader.tables[required]
@@ -530,12 +532,12 @@ def test_check_required_tables():
                                f'with missing mandatory table {required} ...')
     # Then, in preparation for the next step, we make sure
     # there's no optional table (by removing them all):
-    for optional in optional_tables:
+    for optional in OPTIONAL_TABLES:
         if optional in ttFont.reader.tables:
             del ttFont.reader.tables[optional]
 
     # Then re-insert them one by one to validate the INFO code-path:
-    for optional in optional_tables:
+    for optional in OPTIONAL_TABLES:
         ttFont.reader.tables[optional] = "foo"
         # and ensure that the second to last logged message is an
         # INFO status informing the user about it:

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -497,6 +497,8 @@ def test_check_required_tables():
 
     # Our reference Mada Regular font is good here
     ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+    cff_ft = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Black.otf"))
+    cff2_ft = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
 
     # So it must PASS the check:
     msg = assert_PASS(check(ttFont), 'with a good font...')
@@ -505,6 +507,38 @@ def test_check_required_tables():
     msg = assert_results_contain(check(ttFont), INFO, "optional-tables")
     for tag in {"loca", "GPOS", "GSUB"}:
         assert tag in msg
+
+    # CFF ------
+    msg = assert_PASS(check(cff_ft), 'with a good font...')
+    assert msg == "Font contains all required tables."
+
+    msg = assert_results_contain(check(cff_ft), INFO, "optional-tables")
+    for tag in {"BASE", "GPOS", "GSUB"}:
+        assert tag in msg
+
+    del cff_ft.reader.tables["CFF "]
+    msg = assert_results_contain(check(cff_ft), FAIL, "required-tables")
+    assert "CFF " in msg
+
+    # CFF2 ------
+    msg = assert_PASS(check(cff2_ft), 'with a good font...')
+    assert msg == "Font contains all required tables."
+
+    msg = assert_results_contain(check(cff2_ft), INFO, "optional-tables")
+    for tag in {"BASE", "GPOS", "GSUB"}:
+        assert tag in msg
+
+    del cff2_ft.reader.tables["CFF2"]
+    msg = assert_results_contain(check(cff2_ft), FAIL, "required-tables")
+    assert "CFF2" in msg
+
+    del cff2_ft.reader.tables["STAT"]
+    msg = assert_results_contain(check(cff2_ft), FAIL, "required-tables")
+    assert "STAT" in msg
+
+    del cff2_ft.reader.tables["fvar"]
+    msg = assert_results_contain(check(cff2_ft), FAIL, "required-tables")
+    assert "CFF " in msg
 
     # Now we test the special cases for variable fonts:
     #
@@ -530,7 +564,7 @@ def test_check_required_tables():
     del ttFont.reader.tables["STAT"]
 
     # Now we remove required tables one-by-one to validate the FAIL code-path:
-    for required in REQUIRED_TABLES:
+    for required in REQUIRED_TABLES + ["glyf"]:
         ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
         if required in ttFont.reader.tables:
             del ttFont.reader.tables[required]

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -497,8 +497,8 @@ def test_check_required_tables():
 
     # Our reference Mada Regular font is good here
     ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-    cff_ft = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Black.otf"))
-    cff2_ft = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
+    cff_font = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Black.otf"))
+    cff2_font = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
 
     # So it must PASS the check:
     msg = assert_PASS(check(ttFont), 'with a good font...')
@@ -509,35 +509,35 @@ def test_check_required_tables():
         assert tag in msg
 
     # CFF ------
-    msg = assert_PASS(check(cff_ft), 'with a good font...')
+    msg = assert_PASS(check(cff_font), 'with a good font...')
     assert msg == "Font contains all required tables."
 
-    msg = assert_results_contain(check(cff_ft), INFO, "optional-tables")
+    msg = assert_results_contain(check(cff_font), INFO, "optional-tables")
     for tag in {"BASE", "GPOS", "GSUB"}:
         assert tag in msg
 
-    del cff_ft.reader.tables["CFF "]
-    msg = assert_results_contain(check(cff_ft), FAIL, "required-tables")
+    del cff_font.reader.tables["CFF "]
+    msg = assert_results_contain(check(cff_font), FAIL, "required-tables")
     assert "CFF " in msg
 
     # CFF2 ------
-    msg = assert_PASS(check(cff2_ft), 'with a good font...')
+    msg = assert_PASS(check(cff2_font), 'with a good font...')
     assert msg == "Font contains all required tables."
 
-    msg = assert_results_contain(check(cff2_ft), INFO, "optional-tables")
+    msg = assert_results_contain(check(cff2_font), INFO, "optional-tables")
     for tag in {"BASE", "GPOS", "GSUB"}:
         assert tag in msg
 
-    del cff2_ft.reader.tables["CFF2"]
-    msg = assert_results_contain(check(cff2_ft), FAIL, "required-tables")
+    del cff2_font.reader.tables["CFF2"]
+    msg = assert_results_contain(check(cff2_font), FAIL, "required-tables")
     assert "CFF2" in msg
 
-    del cff2_ft.reader.tables["STAT"]
-    msg = assert_results_contain(check(cff2_ft), FAIL, "required-tables")
+    del cff2_font.reader.tables["STAT"]
+    msg = assert_results_contain(check(cff2_font), FAIL, "required-tables")
     assert "STAT" in msg
 
-    del cff2_ft.reader.tables["fvar"]
-    msg = assert_results_contain(check(cff2_ft), FAIL, "required-tables")
+    del cff2_font.reader.tables["fvar"]
+    msg = assert_results_contain(check(cff2_font), FAIL, "required-tables")
     assert "CFF " in msg
 
     # Now we test the special cases for variable fonts:


### PR DESCRIPTION
Updates check's rationale and enables CFF/CFF2 fonts.