### PR TITLE
Override three Universal checks in Adobe Fonts profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Adobe Fonts Profile
   - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (pull #3743)
   - **[com.adobe.fonts/check/find_empty_letters]:** Was downgraded to WARN only for a specific set of Korean hangul syllable characters, which are known to be included in fonts as a workaround to undesired behavior from InDesign's Korean IME (Input Method Editor). More details available at issue #2894. (pull #3744)
+  - **[com.adobe.fonts/check/freetype_rasterizer]:** This check from the Universal profile is overridden to yield ERROR if FreeType is not installed, ensuring that the check isn't skipped. (pull #3745)
+  - **[com.google.fonts/check/family/win_ascent_and_descent]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (pull #3745)
+  - **[com.google.fonts/check/os2_metrics_match_hhea]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (pull #3745)
 
 #### On the GoogleFonts Profile
   - **[com.google.fonts/check/license/OFL_copyright]:** Improve wording of log message to clarify its meaning. It was too easy to think that the displayed copyright string (read from the font binary and reported for reference) was an example of the actually expected string format. (issue #3674)
@@ -26,6 +29,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal Profile
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)
   - **[com.google.fonts/check/required_tables]:** CFF/CFF2 fonts are now checked instead of skipped. (pull #3742)
+  - **[com.google.fonts/check/family/win_ascent_and_descent]:** Fixed the parameter used in the FAIL message that is issued when the value of `usWinAscent` is too large. (pull #3745)
 
 ### New Checks
 #### Added to the Adobe Fonts Profile

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -180,7 +180,7 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/name/trailing_spaces",
     # ---
     # Excluding these two checks until we override them to WARN (a downgrade)
-    # "com.google.fonts/check/family/win_ascent_and_descent",
+    "com.google.fonts/check/family/win_ascent_and_descent",
     # "com.google.fonts/check/os2_metrics_match_hhea",
     # ---
     # NOTE: This check is broken in AWS Lambda
@@ -229,6 +229,7 @@ ADOBEFONTS_PROFILE_CHECKS = [
 OVERRIDDEN_CHECKS = [
     "com.google.fonts/check/whitespace_glyphs",
     "com.google.fonts/check/valid_glyphnames",
+    "com.google.fonts/check/family/win_ascent_and_descent",
     "com.adobe.fonts/check/freetype_rasterizer",
 ]
 
@@ -419,6 +420,16 @@ profile.check_log_override(
     # From universal.py
     "com.google.fonts/check/valid_glyphnames",
     overrides=(("found-invalid-names", WARN, KEEP_ORIGINAL_MESSAGE),),
+)
+
+
+profile.check_log_override(
+    # From universal.py
+    "com.google.fonts/check/family/win_ascent_and_descent",
+    overrides=(
+        ("ascent", WARN, KEEP_ORIGINAL_MESSAGE),
+        ("descent", WARN, KEEP_ORIGINAL_MESSAGE),
+    ),
 )
 
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -178,10 +178,8 @@ SET_EXPLICIT_CHECKS = {
     # From universal.py
     "com.google.fonts/check/ots",
     "com.google.fonts/check/name/trailing_spaces",
-    # ---
-    # Excluding these two checks until we override them to WARN (a downgrade)
     "com.google.fonts/check/family/win_ascent_and_descent",
-    # "com.google.fonts/check/os2_metrics_match_hhea",
+    "com.google.fonts/check/os2_metrics_match_hhea",
     # ---
     # NOTE: This check is broken in AWS Lambda
     # https://github.com/googlefonts/fontbakery/issues/2405
@@ -230,6 +228,7 @@ OVERRIDDEN_CHECKS = [
     "com.google.fonts/check/whitespace_glyphs",
     "com.google.fonts/check/valid_glyphnames",
     "com.google.fonts/check/family/win_ascent_and_descent",
+    "com.google.fonts/check/os2_metrics_match_hhea",
     "com.adobe.fonts/check/freetype_rasterizer",
 ]
 
@@ -429,6 +428,16 @@ profile.check_log_override(
     overrides=(
         ("ascent", WARN, KEEP_ORIGINAL_MESSAGE),
         ("descent", WARN, KEEP_ORIGINAL_MESSAGE),
+    ),
+)
+
+
+profile.check_log_override(
+    # From universal.py
+    "com.google.fonts/check/os2_metrics_match_hhea",
+    overrides=(
+        ("ascender", WARN, KEEP_ORIGINAL_MESSAGE),
+        ("descender", WARN, KEEP_ORIGINAL_MESSAGE),
     ),
 )
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -229,6 +229,7 @@ ADOBEFONTS_PROFILE_CHECKS = [
 OVERRIDDEN_CHECKS = [
     "com.google.fonts/check/whitespace_glyphs",
     "com.google.fonts/check/valid_glyphnames",
+    "com.adobe.fonts/check/freetype_rasterizer",
 ]
 
 
@@ -418,6 +419,14 @@ profile.check_log_override(
     # From universal.py
     "com.google.fonts/check/valid_glyphnames",
     overrides=(("found-invalid-names", WARN, KEEP_ORIGINAL_MESSAGE),),
+)
+
+
+profile.check_log_override(
+    # From universal.py
+    "com.adobe.fonts/check/freetype_rasterizer",
+    overrides=(("freetype-not-installed", ERROR, KEEP_ORIGINAL_MESSAGE),),
+    reason=("For Adobe, this check is very important and should never be skipped."),
 )
 
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -143,7 +143,7 @@ def com_google_fonts_check_family_win_ascent_and_descent(ttFont, vmetrics):
         yield FAIL,\
               Message("ascent",
                       f"OS/2.usWinAscent value"
-                      f" {ttFont['OS/2'].usWinDescent} is too large."
+                      f" {ttFont['OS/2'].usWinAscent} is too large."
                       f" It should be less than double the yMax."
                       f" Current yMax value is {vmetrics['ymax']}")
     # OS/2 usWinDescent:

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -129,40 +129,45 @@ def com_google_fonts_check_family_win_ascent_and_descent(ttFont, vmetrics):
         return
 
     failed = False
+    os2_table = ttFont['OS/2']
+    win_ascent = os2_table.usWinAscent
+    win_descent = os2_table.usWinDescent
+    y_max = vmetrics['ymax']
+    y_min = vmetrics['ymin']
 
     # OS/2 usWinAscent:
-    if ttFont['OS/2'].usWinAscent < vmetrics['ymax']:
+    if win_ascent < y_max:
         failed = True
         yield FAIL,\
               Message("ascent",
                       f"OS/2.usWinAscent value should be"
-                      f" equal or greater than {vmetrics['ymax']},"
-                      f" but got {ttFont['OS/2'].usWinAscent} instead")
-    if ttFont['OS/2'].usWinAscent > vmetrics['ymax'] * 2:
+                      f" equal or greater than {y_max},"
+                      f" but got {win_ascent} instead")
+    if win_ascent > y_max * 2:
         failed = True
         yield FAIL,\
               Message("ascent",
                       f"OS/2.usWinAscent value"
-                      f" {ttFont['OS/2'].usWinAscent} is too large."
+                      f" {win_ascent} is too large."
                       f" It should be less than double the yMax."
-                      f" Current yMax value is {vmetrics['ymax']}")
+                      f" Current yMax value is {y_max}")
     # OS/2 usWinDescent:
-    if ttFont['OS/2'].usWinDescent < abs(vmetrics['ymin']):
+    if win_descent < abs(y_min):
         failed = True
         yield FAIL,\
               Message("descent",
                       f"OS/2.usWinDescent value should be equal or"
-                      f" greater than {abs(vmetrics['ymin'])}, but got"
-                      f" {ttFont['OS/2'].usWinDescent} instead.")
+                      f" greater than {abs(y_min)}, but got"
+                      f" {win_descent} instead.")
 
-    if ttFont['OS/2'].usWinDescent > abs(vmetrics['ymin']) * 2:
+    if win_descent > abs(y_min) * 2:
         failed = True
         yield FAIL,\
               Message("descent",
                       f"OS/2.usWinDescent value"
-                      f" {ttFont['OS/2'].usWinDescent} is too large."
+                      f" {win_descent} is too large."
                       f" It should be less than double the yMin."
-                      f" Current absolute yMin value is {abs(vmetrics['ymin'])}")
+                      f" Current absolute yMin value is {abs(y_min)}")
     if not failed:
         yield PASS, "OS/2 usWinAscent & usWinDescent values look good!"
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1649,6 +1649,7 @@ def com_google_fonts_check_gpos7(ttFont):
 
 @check(
     id="com.adobe.fonts/check/freetype_rasterizer",
+    conditions=['ttFont'],
     severity=10,
     rationale="""
         Malformed fonts can cause FreeType to crash.
@@ -1666,9 +1667,10 @@ def com_adobe_fonts_check_freetype_rasterizer(font):
         face.load_char("✅")  # any character can be used here
 
     except ImportError:
-        return SKIP, (
+        return SKIP, Message(
+            "freetype-not-installed",
             "FreeType is not available; to install it, invoke the "
-            "'freetype' extra when installing FontBakery."
+            "'freetype' extra when installing Font Bakery.",
         )
     except FT_Exception as err:
         return FAIL, Message(

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -2,8 +2,10 @@
 Unit tests for Adobe Fonts profile.
 """
 import os
+from unittest.mock import patch
 
 from fontTools.ttLib import TTFont
+
 from fontbakery.checkrunner import WARN, FAIL, ERROR
 from fontbakery.codetesting import (
     assert_PASS,
@@ -199,3 +201,16 @@ def test_check_valid_glyphnames_adobefonts_override():
     assert bad_name1 in message
     assert bad_name2 in message
     assert bad_name3 in message
+
+
+@patch("freetype.Face", side_effect=ImportError)
+def test_check_freetype_rasterizer_adobefonts_override(mock_import_error):
+    """Check that overridden test yields ERROR rather than SKIP."""
+    check = CheckTester(
+        adobefonts_profile,
+        f"com.adobe.fonts/check/freetype_rasterizer{OVERRIDE_SUFFIX}",
+    )
+
+    font = TEST_FILE("cabin/Cabin-Regular.ttf")
+    msg = assert_results_contain(check(font), ERROR, "freetype-not-installed")
+    assert "FreeType is not available" in msg

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -712,7 +712,7 @@ def test_check_family_win_ascent_and_descent(mada_ttFonts):
                            'with a bad OS/2.usWinDescent...')
 
 
-def test_check_os2_metrics_match_hhea(mada_ttFonts):
+def test_check_os2_metrics_match_hhea():
     """ Checking OS/2 Metrics match hhea Metrics. """
     check = CheckTester(universal_profile,
                         "com.google.fonts/check/os2_metrics_match_hhea")


### PR DESCRIPTION
The two checks —from the Universal profile— listed below are now overridden (downgraded from FAIL to WARN) in the Adobe Fonts profile.
- `com.google.fonts/check/family/win_ascent_and_descent`
- `com.google.fonts/check/os2_metrics_match_hhea`

`com.adobe.fonts/check/freetype_rasterizer` from the Universal profile is now also overridden in the Adobe Fonts profile; if FreeType is not installed, the check will yield ERROR instead of SKIP.

While implementing these overrides, I also found and fixed a bug in one of the FAIL messages of `com.google.fonts/check/family/win_ascent_and_descent`; the check result was correct, but the message displayed to the user was not.