### PR TITLE
Rewrite of "com.google.fonts/check/name/match_familyname_fullfont" (OpenType profile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Fontwerk Profile
   - Added a few more checks to the `CHECKS_NOT_TO_INCLUDE` list. These are checks (most of them from the Google Fonts profile) that Fontwerk is not interested in including in its vendor-specific profile.
 
+#### On the OpenType Profile
+  - **[com.google.fonts/check/name/match_familyname_fullfont]:** The check was completely rewritten; it now correctly compares full name and family name strings that are from the same platform, same encoding, and same language. (pull #3747)
+
 #### On the Universal Profile
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)
   - **[com.google.fonts/check/required_tables]:** CFF/CFF2 fonts are now checked instead of skipped. (pull #3742)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -133,10 +133,7 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/name/empty_records",
     # "com.google.fonts/check/name/no_copyright_on_description",  # PERMANENTLY_EXCLUDED # noqa
     "com.google.fonts/check/monospace",
-    # ---
-    # Excluding this check because it wrongly compares names of different languageIDs
-    # "com.google.fonts/check/name/match_familyname_fullfont",
-    # ---
+    "com.google.fonts/check/name/match_familyname_fullfont",
     "com.google.fonts/check/family_naming_recommendations",
     "com.adobe.fonts/check/name/postscript_vs_cff",
     "com.adobe.fonts/check/name/postscript_name_consistency",

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -308,7 +308,7 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
 
                     if not full_name.startswith(family_name):
                         yield FAIL, Message(
-                            "does-not",
+                            "mismatch-font-names",
                             f"On the 'name' table, the full font name {full_name!r}"
                             f" does not begin with the font family name {family_name!r}"
                             f" in platformID {plat_id},"

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -298,13 +298,35 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
 
                     names_compared = True  # Yay! At least one comparison will be made!!
 
+                    decode_error_msg_prefix = (
+                        f"On the 'name' table, the name record"
+                        f" for platformID {plat_id},"
+                        f" encodingID {enc_id},"
+                        f" languageID {lang_id}({lang_id:04X}),"
+                    )
                     try:
                         family_name = name_table.getName(
                             family_name_id, plat_id, enc_id, lang_id).toUnicode()
+                    except UnicodeDecodeError:
+                        yield FAIL, Message(
+                            f"cannot-decode-nameid-{family_name_id}",
+                            f"{decode_error_msg_prefix} and nameID {family_name_id}"
+                            " failed to be decoded."
+                        )
+                        passed = False
+                        continue
+
+                    try:
                         full_name = name_table.getName(
                             full_name_id, plat_id, enc_id, lang_id).toUnicode()
-                    except UnicodeDecodeError as err:
-                        raise err
+                    except UnicodeDecodeError:
+                        yield FAIL, Message(
+                            f"cannot-decode-nameid-{full_name_id}",
+                            f"{decode_error_msg_prefix} and nameID {full_name_id}"
+                            " failed to be decoded."
+                        )
+                        passed = False
+                        continue
 
                     if not full_name.startswith(family_name):
                         yield FAIL, Message(

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -52,7 +52,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 78
+    assert len(SET_EXPLICIT_CHECKS) == 79
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -226,7 +226,7 @@ def test_check_name_match_familyname_fullfont():
 
     # 4. Now re-run the check. It should yield FAIL because the full_name string
     # no longer starts with the family_name string.
-    msg = assert_results_contain(check(ttFont), FAIL, "does-not")
+    msg = assert_results_contain(check(ttFont), FAIL, "mismatch-font-names")
     assert msg == (f"On the 'name' table, the full font name {full_name_after!r}"
                    f" does not begin with the font family name {family_name!r}"
                    f" in platformID {platform_id},"


### PR DESCRIPTION
The check now correctly compares full name and family name strings that are from the same platform, same encoding, and same language.