### PR TITLE
com.google.fonts/check/glyph_coverage: use glyphsets lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - Improve rendering of bullet lists (issue #3691)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/glyph_coverage]:** Use glyphsets lib so we can improve this check in the future. (pull #3753)
+
 #### On the Adobe Fonts Profile
   - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (pull #3743)
   - **[com.adobe.fonts/check/find_empty_letters]:** Was downgraded to WARN only for a specific set of Korean hangul syllable characters, which are known to be included in fonts as a workaround to undesired behavior from InDesign's Korean IME (Input Method Editor). More details available at issue #2894. (pull #3744)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1045,18 +1045,13 @@ def font_codepoints(ttFont):
 def com_google_fonts_check_glyph_coverage(ttFont, font_codepoints, config):
     """Check `Google Fonts Latin Core` glyph coverage."""
     from fontbakery.utils import bullet_list
+    from glyphsets import GFGlyphData as glyph_data
     import unicodedata2
 
-    codepoints.set_encoding_path(ENCODINGS_DIR + "/GF Glyph Sets")
-    required_codepoints = codepoints.CodepointsInSubset("GF-latin-core")
-    diff = required_codepoints - font_codepoints
-    missing = []
-    for c in sorted(diff):
-        try:
-            missing.append('0x%04X (%s)\n' % (c, unicodedata2.name(chr(c))))
-        except ValueError:
-            pass
-    if missing:
+    missing_glyphs = glyph_data.missing_glyphsets_in_font(ttFont)
+    if "GF_Latin_Core" in missing_glyphs:
+        missing_encoded_latin = [g["unicode"] for g in missing_glyphs["GF_Latin_Core"] if g["unicode"]]
+        missing = ['0x%04X (%s)\n' % (c, unicodedata2.name(chr(c))) for c in missing_encoded_latin]
         yield FAIL,\
               Message("missing-codepoints",
                       f"Missing required codepoints:\n\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fontTools[ufo,lxml,unicode]==4.31.2
 font-v==2.1.0
 freetype-py==2.2.0
 gflanguages==0.4.0
-glyphsets==0.2.1
+glyphsets==0.5.0
 lxml==4.8.0
 opentype-sanitizer==8.2.1
 opentypespec==1.8.4

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         'fontTools[ufo,lxml,unicode]>=3.34',  # 3.34 fixed some CFF2 issues, including calcBounds
         'font-v',
         'gflanguages>=0.3.0', # there was an api simplification/update on v0.3.0 (see https://github.com/googlefonts/gflanguages/pull/7)
-        'glyphsets',
+        'glyphsets>=0.5.0',
         'lxml',
         'opentype-sanitizer>=7.1.9',  # 7.1.9 fixes caret value format = 3 bug
                                       # (see https://github.com/khaledhosny/ots/pull/182)


### PR DESCRIPTION
## Description

I've updated this check so it now uses https://github.com/googlefonts/glyphsets. I haven't added any additional functionality. I'll eventually update/add a new to determine which glyphs are missing from any glyph set.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review


~~Depends on me merging https://github.com/googlefonts/glyphsets/pull/55 and cutting a v0.5.0 release~~