### PR TITLE
Fix & improve "com.google.fonts/check/fontbakery_version"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/freetype_rasterizer]:** This check from the Universal profile is overridden to yield ERROR if FreeType is not installed, ensuring that the check isn't skipped. (pull #3745)
   - **[com.google.fonts/check/family/win_ascent_and_descent]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (pull #3745)
   - **[com.google.fonts/check/os2_metrics_match_hhea]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (pull #3745)
+  - **[com.google.fonts/check/fontbakery_version]:** This check from the Universal profile is overridden to be skipped instead of failing, when the user's internet connection isn't functional. (pull #3756)
 
 #### On the GoogleFonts Profile
   - **[com.google.fonts/check/license/OFL_copyright]:** Improve wording of log message to clarify its meaning. It was too easy to think that the displayed copyright string (read from the font binary and reported for reference) was an example of the actually expected string format. (issue #3674)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
   - **[com.google.fonts/check/glyph_coverage]:** Use glyphsets lib so we can improve this check in the future. (pull #3753)
-  - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check is skipped. (pull #3756)
+  - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check fails. (pull #3756)
 
 #### On the Adobe Fonts Profile
   - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (pull #3743)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)
-  - Improve rendering of bullet lists (issue #3691)
+  - Improve rendering of bullet lists (issue #3691 & pull #3741)
 
 ### Changes to existing checks
   - **[com.google.fonts/check/glyph_coverage]:** Use glyphsets lib so we can improve this check in the future. (pull #3753)
+  - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check is skipped. (pull #3756)
 
 #### On the Adobe Fonts Profile
   - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (pull #3743)
@@ -37,6 +38,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)
   - **[com.google.fonts/check/required_tables]:** CFF/CFF2 fonts are now checked instead of skipped. (pull #3742)
   - **[com.google.fonts/check/family/win_ascent_and_descent]:** Fixed the parameter used in the FAIL message that is issued when the value of `usWinAscent` is too large. (pull #3745)
+  - **[com.google.fonts/check/fontbakery_version]:** A change introduced in #3432 made this check always be skipped; that's now fixed. (issue #3576)
 
 ### New Checks
 #### Added to the Adobe Fonts Profile

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -15,7 +15,7 @@ from fontbakery.profiles.googlefonts import GOOGLEFONTS_PROFILE_CHECKS
 from fontbakery.profiles.notofonts import NOTOFONTS_PROFILE_CHECKS
 from fontbakery.profiles.universal import UNIVERSAL_PROFILE_CHECKS
 from fontbakery.section import Section
-from fontbakery.status import PASS, FAIL, WARN, ERROR
+from fontbakery.status import PASS, FAIL, WARN, ERROR, SKIP
 from fontbakery.utils import add_check_overrides
 
 profile_imports = (
@@ -223,6 +223,7 @@ OVERRIDDEN_CHECKS = [
     "com.google.fonts/check/family/win_ascent_and_descent",
     "com.google.fonts/check/os2_metrics_match_hhea",
     "com.adobe.fonts/check/freetype_rasterizer",
+    "com.google.fonts/check/fontbakery_version",
 ]
 
 
@@ -402,8 +403,8 @@ profile.check_log_override(
     "com.google.fonts/check/whitespace_glyphs",
     overrides=(("missing-whitespace-glyph-0x00A0", WARN, KEEP_ORIGINAL_MESSAGE),),
     reason=(
-        "For Adobe, this is not as severe "
-        "as assessed in the original check for 0x00A0."
+        "For Adobe, this is not as severe"
+        " as assessed in the original check for 0x00A0."
     ),
 )
 
@@ -439,7 +440,18 @@ profile.check_log_override(
     # From universal.py
     "com.adobe.fonts/check/freetype_rasterizer",
     overrides=(("freetype-not-installed", ERROR, KEEP_ORIGINAL_MESSAGE),),
-    reason=("For Adobe, this check is very important and should never be skipped."),
+    reason="For Adobe, this check is very important and should never be skipped.",
+)
+
+
+profile.check_log_override(
+    # From universal.py
+    "com.google.fonts/check/fontbakery_version",
+    overrides=(("connection-error", SKIP, KEEP_ORIGINAL_MESSAGE),),
+    reason=(
+        "For Adobe, users shouldn't be bothered with a failed check"
+        " if their internet connection isn't functional.",
+    ),
 )
 
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -177,11 +177,7 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/name/trailing_spaces",
     "com.google.fonts/check/family/win_ascent_and_descent",
     "com.google.fonts/check/os2_metrics_match_hhea",
-    # ---
-    # NOTE: This check is broken in AWS Lambda
-    # https://github.com/googlefonts/fontbakery/issues/2405
     "com.google.fonts/check/fontbakery_version",
-    # ---
     "com.google.fonts/check/ttx-roundtrip",
     "com.google.fonts/check/family/single_directory",
     "com.google.fonts/check/mandatory_glyphs",

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -346,7 +346,7 @@ def com_google_fonts_check_fontbakery_version(font):
 
     status_code = response.status_code
     if status_code != 200:
-        return SKIP, Message(
+        return FAIL, Message(
             f"unsuccessful-request-{status_code}",
             f"Request to PyPI.org was not successful:\n{response.content}",
         )

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -341,11 +341,12 @@ def com_google_fonts_check_fontbakery_version(font):
     installed = str(pip_api.installed_distributions()["fontbakery"].version)
 
     if not is_up_to_date(installed, latest):
-        yield FAIL, (f"Current Font Bakery version is {installed},"
-                     f" while a newer {latest} is already available."
-                     f" Please upgrade it with 'pip install -U fontbakery'")
+        yield FAIL, Message("outdated-fontbakery",
+                            f"Current Font Bakery version is {installed},"
+                            f" while a newer {latest} is already available."
+                            f" Please upgrade it with 'pip install -U fontbakery'")
     else:
-        yield PASS, "Font Bakery is up-to-date"
+        yield PASS, "Font Bakery is up-to-date."
 
 
 @check(

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -330,7 +330,7 @@ def is_up_to_date(installed, latest):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2093'
 )
-def com_google_fonts_check_fontbakery_version():
+def com_google_fonts_check_fontbakery_version(font):
     """Do we have the latest version of FontBakery installed?"""
     import json
     import requests

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -339,7 +339,7 @@ def com_google_fonts_check_fontbakery_version(font):
         response = requests.get('https://pypi.org/pypi/fontbakery/json')
 
     except requests.exceptions.ConnectionError as err:
-        return SKIP, Message(
+        return FAIL, Message(
             "connection-error",
             f"Request to PyPI.org failed with this message:\n{err}",
         )

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -332,12 +332,11 @@ def is_up_to_date(installed, latest):
 )
 def com_google_fonts_check_fontbakery_version(font):
     """Do we have the latest version of FontBakery installed?"""
-    import json
     import requests
     import pip_api
 
     pypi_data = requests.get('https://pypi.org/pypi/fontbakery/json')
-    latest = json.loads(pypi_data.content)["info"]["version"]
+    latest = pypi_data.json()["info"]["version"]
     installed = str(pip_api.installed_distributions()["fontbakery"].version)
 
     if not is_up_to_date(installed, latest):

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -363,6 +363,22 @@ def test_fontbakery_version(mock_get, mock_installed):
     assert "Request to PyPI.org failed with this message" in msg
 
 
+def test_fontbakery_version_live_apis():
+    """Check if Font Bakery is up-to-date. (No-API mocking edition)"""
+    check = CheckTester(universal_profile,
+                        "com.google.fonts/check/fontbakery_version")
+
+    # Any of the test fonts can be used here.
+    # The check requires a 'font' argument but it doesn't do anything with it.
+    font = TEST_FILE("nunito/Nunito-Regular.ttf")
+
+    # The check will make an actual request to PyPI.org,
+    # and will query 'pip' to determine which version of 'fontbakery' is installed.
+    # The check should PASS.
+    msg = assert_PASS(check(font), PASS)
+    assert msg == "Font Bakery is up-to-date."
+
+
 def test_check_mandatory_glyphs():
     """ Font contains the first few mandatory glyphs (.null or NULL, CR and space)? """
     check = CheckTester(universal_profile,

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -364,7 +364,7 @@ def test_fontbakery_version(mock_get, mock_installed):
 
 
 def test_fontbakery_version_live_apis():
-    """Check if Font Bakery is up-to-date. (No-API mocking edition)"""
+    """Check if Font Bakery is up-to-date. (No API-mocking edition)"""
     check = CheckTester(universal_profile,
                         "com.google.fonts/check/fontbakery_version")
 

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -354,7 +354,7 @@ def test_fontbakery_version(mock_get, mock_installed):
     # Test the case of an unsuccessful response to the GET request.
     mock_response.status_code = 500
     mock_response.content = "500 Internal Server Error"
-    msg = assert_results_contain(check(font), SKIP, "unsuccessful-request-500")
+    msg = assert_results_contain(check(font), FAIL, "unsuccessful-request-500")
     assert "Request to PyPI.org was not successful" in msg
 
     # Test the case of the GET request failing due to a connection error.

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -219,29 +219,6 @@ def test_check_ttx_roundtrip():
     #                        FAIL, None) # FIXME: This needs a message keyword
 
 
-def test_is_up_to_date():
-    from fontbakery.profiles.universal import is_up_to_date
-    # is_up_to_date(installed, latest)
-    assert(is_up_to_date(installed="0.5.0",
-                            latest="0.5.0") == True)
-    assert(is_up_to_date(installed="0.5.1",
-                            latest="0.5.0") == True)
-    assert(is_up_to_date(installed="0.4.1",
-                            latest="0.5.0") == False)
-    assert(is_up_to_date(installed="0.3.4",
-                            latest="0.3.5") == False)
-    assert(is_up_to_date(installed="1.0.0",
-                            latest="1.0.1") == False)
-    assert(is_up_to_date(installed="2.0.0",
-                            latest="1.5.3") == True)
-    assert(is_up_to_date(installed="0.5.2.dev73+g8c9ebc0.d20181023",
-                            latest="0.5.1") == True)
-    assert(is_up_to_date(installed="0.5.2.dev73+g8c9ebc0.d20181023",
-                            latest="0.5.2") == False)
-    assert(is_up_to_date(installed="0.5.2.dev73+g8c9ebc0.d20181023",
-                            latest="0.5.3") == False)
-
-
 def test_check_name_trailing_spaces():
     """ Name table entries must not have trailing spaces. """
     check = CheckTester(universal_profile,
@@ -298,6 +275,29 @@ def test_check_ots():
                                      FAIL, "ots-sanitize-error")
     assert "invalid sfntVersion" in message
     assert "Failed to sanitize file!" in message
+
+
+def test_is_up_to_date():
+    from fontbakery.profiles.universal import is_up_to_date
+    # is_up_to_date(installed, latest)
+    assert(is_up_to_date("0.5.0",
+                         "0.5.0") is True)
+    assert(is_up_to_date("0.5.1",
+                         "0.5.0") is True)
+    assert(is_up_to_date("0.4.1",
+                         "0.5.0") is False)
+    assert(is_up_to_date("0.3.4",
+                         "0.3.5") is False)
+    assert(is_up_to_date("1.0.0",
+                         "1.0.1") is False)
+    assert(is_up_to_date("2.0.0",
+                         "1.5.3") is True)
+    assert(is_up_to_date("0.5.2.dev73+g8c9ebc0.d20181023",
+                         "0.5.1") is True)
+    assert(is_up_to_date("0.5.2.dev73+g8c9ebc0.d20181023",
+                         "0.5.2") is False)
+    assert(is_up_to_date("0.5.2.dev73+g8c9ebc0.d20181023",
+                         "0.5.3") is False)
 
 
 def test_check_mandatory_glyphs():

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -318,7 +318,7 @@ class MockDistribution:
 # We'll also mock pip-api's 'installed_distributions' method.
 @patch("pip_api.installed_distributions")
 @patch("requests.get")
-def test_fontbakery_version(mock_get, mock_installed):
+def test_check_fontbakery_version(mock_get, mock_installed):
     """Check if Font Bakery is up-to-date"""
     check = CheckTester(universal_profile,
                         "com.google.fonts/check/fontbakery_version")
@@ -359,11 +359,11 @@ def test_fontbakery_version(mock_get, mock_installed):
 
     # Test the case of the GET request failing due to a connection error.
     mock_get.side_effect = ConnectionError
-    msg = assert_results_contain(check(font), SKIP, "connection-error")
+    msg = assert_results_contain(check(font), FAIL, "connection-error")
     assert "Request to PyPI.org failed with this message" in msg
 
 
-def test_fontbakery_version_live_apis():
+def test_check_fontbakery_version_live_apis():
     """Check if Font Bakery is up-to-date. (No API-mocking edition)"""
     check = CheckTester(universal_profile,
                         "com.google.fonts/check/fontbakery_version")

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1,5 +1,4 @@
 import io
-import json
 from unittest.mock import patch, MagicMock
 
 from fontTools.ttLib import TTFont
@@ -332,7 +331,7 @@ def test_fontbakery_version(mock_get, mock_installed):
 
     # Test the case of installed version being the same as PyPI's version.
     latest_ver = installed_ver = "0.1.0"
-    mock_response.content = json.dumps({"info": {"version": latest_ver}})
+    mock_response.json.return_value = {"info": {"version": latest_ver}}
     mock_get.return_value = mock_response
     mock_installed.return_value = {"fontbakery": MockDistribution(installed_ver)}
     msg = assert_PASS(check(font), PASS)

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -11,6 +11,7 @@ from fontbakery.codetesting import (assert_PASS,
                                     TEST_FILE)
 from fontbakery.constants import NameID
 from fontbakery.profiles import universal as universal_profile
+from fontbakery.profiles.universal import is_up_to_date
 
 
 @pytest.fixture
@@ -277,27 +278,30 @@ def test_check_ots():
     assert "Failed to sanitize file!" in message
 
 
-def test_is_up_to_date():
-    from fontbakery.profiles.universal import is_up_to_date
-    # is_up_to_date(installed, latest)
-    assert(is_up_to_date("0.5.0",
-                         "0.5.0") is True)
-    assert(is_up_to_date("0.5.1",
-                         "0.5.0") is True)
-    assert(is_up_to_date("0.4.1",
-                         "0.5.0") is False)
-    assert(is_up_to_date("0.3.4",
-                         "0.3.5") is False)
-    assert(is_up_to_date("1.0.0",
-                         "1.0.1") is False)
-    assert(is_up_to_date("2.0.0",
-                         "1.5.3") is True)
-    assert(is_up_to_date("0.5.2.dev73+g8c9ebc0.d20181023",
-                         "0.5.1") is True)
-    assert(is_up_to_date("0.5.2.dev73+g8c9ebc0.d20181023",
-                         "0.5.2") is False)
-    assert(is_up_to_date("0.5.2.dev73+g8c9ebc0.d20181023",
-                         "0.5.3") is False)
+@pytest.mark.parametrize('installed, latest, result', [
+    ("0.5.0",
+     "0.5.0", True),
+    ("0.5.1",
+     "0.5.0", True),
+    ("0.4.1",
+     "0.5.0", False),
+    ("0.3.4",
+     "0.3.5", False),
+    ("1.0.0",
+     "1.0.1", False),
+    ("2.0.0",
+     "1.5.1", True),
+    ("0.5.2.dev73+g8c9ebc0.d20181023",
+     "0.5.1", True),
+    ("0.5.2.dev73+g8c9ebc0.d20181023",
+     "0.5.2", False),
+    ("0.5.2.dev73+g8c9ebc0.d20181023",
+     "0.5.3", False),
+])
+def test_is_up_to_date(installed, latest, result):
+    assert is_up_to_date(installed, latest) is result
+
+
 
 
 def test_check_mandatory_glyphs():


### PR DESCRIPTION
These changes fix #3576 and improve the check by adding safeguards against unsuccessful requests to PyPI.org.
Added unit tests and made a few other tweaks and fixes.