### PR TITLE
Include hhea.lineGap in all checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - Improve rendering of bullet lists (issue #3691 & pull #3741)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/os2_metrics_match_hhea]:** Included lineGap in comparison
+  - **[com.google.fonts/check/family/vertical_metrics]:** Included hhea.lineGap in comparison
+  - **[com.google.fonts/check/superfamily/vertical_metrics]:** Included hhea.lineGap in comparison
   - **[com.google.fonts/check/glyph_coverage]:** Use glyphsets lib so we can improve this check in the future. (pull #3753)
   - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check fails. (pull #3756)
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -229,6 +229,12 @@ def com_google_fonts_check_os2_metrics_match_hhea(ttFont):
                       f"OS/2 sTypoDescender ({ttFont['OS/2'].sTypoDescender})"
                       f" and hhea descent ({ttFont['hhea'].descent})"
                       f" must be equal.")
+    elif ttFont["OS/2"].sTypoLineGap != ttFont["hhea"].lineGap:
+        yield FAIL,\
+              Message("lineGap",
+                      f"OS/2 sTypoLineGap ({ttFont['OS/2'].sTypoLineGap})"
+                      f" and hhea lineGap ({ttFont['hhea'].lineGap})"
+                      f" must be equal.")
     else:
         yield PASS, ("OS/2.sTypoAscender/Descender values"
                      " match hhea.ascent/descent.")
@@ -979,7 +985,8 @@ def com_google_fonts_check_family_vertical_metrics(ttFonts):
         "usWinAscent": {},
         "usWinDescent": {},
         "ascent": {},
-        "descent": {}
+        "descent": {},
+        "lineGap": {}
     }
 
     missing_tables = False
@@ -1007,6 +1014,7 @@ def com_google_fonts_check_family_vertical_metrics(ttFonts):
         vmetrics['usWinDescent'][full_font_name] = ttFont['OS/2'].usWinDescent
         vmetrics['ascent'][full_font_name] = ttFont['hhea'].ascent
         vmetrics['descent'][full_font_name] = ttFont['hhea'].descent
+        vmetrics['lineGap'][full_font_name] = ttFont['hhea'].lineGap
 
 
     if not missing_tables:
@@ -1076,7 +1084,8 @@ def com_google_fonts_check_superfamily_vertical_metrics(superfamily_ttFonts):
         "usWinAscent": {},
         "usWinDescent": {},
         "ascent": {},
-        "descent": {}
+        "descent": {},
+        "lineGap": {}
     }
 
     for family_ttFonts in superfamily_ttFonts:
@@ -1089,6 +1098,7 @@ def com_google_fonts_check_superfamily_vertical_metrics(superfamily_ttFonts):
             vmetrics['usWinDescent'][full_font_name] = ttFont['OS/2'].usWinDescent
             vmetrics['ascent'][full_font_name] = ttFont['hhea'].ascent
             vmetrics['descent'][full_font_name] = ttFont['hhea'].descent
+            vmetrics['lineGap'][full_font_name] = ttFont['hhea'].lineGap
 
     for k, v in vmetrics.items():
         metric_vals = set(vmetrics[k].values())

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -265,9 +265,14 @@ def test_check_override_os2_metrics_match_hhea():
         f"com.google.fonts/check/os2_metrics_match_hhea{OVERRIDE_SUFFIX}",
     )
 
-    # Our reference Mada Regular is know to be good here.
+    # Our reference Mada Regular is know to be faulty here.
     ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+    assert_results_contain(check(ttFont),
+                           FAIL, 'lineGap',
+                           'OS/2 sTypoLineGap (100) and hhea lineGap (96) must be equal.')
 
+    # Our reference Mada Black is know to be good here.
+    ttFont = TTFont(TEST_FILE("mada/Mada-Black.ttf"))
     msg = assert_PASS(check(ttFont), PASS)
     assert msg == "OS/2.sTypoAscender/Descender values match hhea.ascent/descent."
 

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -796,8 +796,14 @@ def test_check_os2_metrics_match_hhea():
     check = CheckTester(universal_profile,
                         "com.google.fonts/check/os2_metrics_match_hhea")
 
-    # Our reference Mada Regular is know to be good here.
+    # Our reference Mada Regular is know to be faulty here.
     ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+    assert_results_contain(check(ttFont),
+                           FAIL, 'lineGap',
+                           'OS/2 sTypoLineGap (100) and hhea lineGap (96) must be equal.')
+
+    # Our reference Mada Black is know to be good here.
+    ttFont = TTFont(TEST_FILE("mada/Mada-Black.ttf"))
 
     assert_PASS(check(ttFont),
                 'with a good font...')


### PR DESCRIPTION
## Description
hhea.lineGap was omitted from hhea/typo comparison checks and should be included.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

