### PR TITLE
Account for the check's `conditions` in CheckTester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/superfamily/vertical_metrics]:** Included hhea.lineGap in comparison
   - **[com.google.fonts/check/glyph_coverage]:** Use glyphsets lib so we can improve this check in the future. (pull #3753)
   - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check fails. (pull #3756)
-  - **[com.google.fonts/check/varfont/regular_wght_coord]:** This check is no longer skipped when the value of "wght" axis coordinate of the "Regular" instance is not 400. (pull #3766)
-  - **[com.google.fonts/check/varfont/regular_wdth_coord]:** This check is no longer skipped when the value of "wdth" axis coordinate of the "Regular" instance is not 100. (pull #3766)
-  - **[com.google.fonts/check/varfont/regular_slnt_coord]:** This check is no longer skipped when the value of "slnt" axis coordinate of the "Regular" instance is not 0. (pull #3766)
-  - **[com.google.fonts/check/varfont/regular_ital_coord]:** This check is no longer skipped when the value of "ital" axis coordinate of the "Regular" instance is not 0. (pull #3766)
 
 #### On the Adobe Fonts Profile
   - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (pull #3743)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Noteworthy code-changes
   - Improve implementation of `is_italic` condition and provide an `is_bold` counterpart (issue #3693)
   - Nicer cancellation for terminal runner. (issue #3672)
+  - The CheckTester class now takes into account the check's own `conditions`. (pull #3766)
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)
@@ -17,6 +18,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/superfamily/vertical_metrics]:** Included hhea.lineGap in comparison
   - **[com.google.fonts/check/glyph_coverage]:** Use glyphsets lib so we can improve this check in the future. (pull #3753)
   - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check fails. (pull #3756)
+  - **[com.google.fonts/check/varfont/regular_wght_coord]:** This check is no longer skipped when the value of "wght" axis coordinate of the "Regular" instance is not 400. (pull #3766)
+  - **[com.google.fonts/check/varfont/regular_wdth_coord]:** This check is no longer skipped when the value of "wdth" axis coordinate of the "Regular" instance is not 100. (pull #3766)
+  - **[com.google.fonts/check/varfont/regular_slnt_coord]:** This check is no longer skipped when the value of "slnt" axis coordinate of the "Regular" instance is not 0. (pull #3766)
+  - **[com.google.fonts/check/varfont/regular_ital_coord]:** This check is no longer skipped when the value of "ital" axis coordinate of the "Regular" instance is not 0. (pull #3766)
 
 #### On the Adobe Fonts Profile
   - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (pull #3743)

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -97,6 +97,8 @@ class CheckTester:
         if isinstance(values, str):
             if values.endswith('README.md'):
                 values = {'readme_md': values}
+            elif values.endswith('.ufo'):
+                values = {'ufo': values}
             elif values.endswith('.designspace'):
                 values = {'designspace': values}
             elif values.endswith('METADATA.pb'):

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -109,7 +109,8 @@ class CheckTester:
                           'fonts': fonts}
             else:
                 values = {'font': values,
-                          'fonts': [values]}
+                          'fonts': [values],
+                          'ufo': values}
         elif isinstance(values, TTFont):
             values = {'font': values.reader.file.name,
                       'fonts': [values.reader.file.name],

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -97,8 +97,6 @@ class CheckTester:
         if isinstance(values, str):
             if values.endswith('README.md'):
                 values = {'readme_md': values}
-            elif values.endswith('.ufo'):
-                values = {'ufo': values}
             elif values.endswith('.designspace'):
                 values = {'designspace': values}
             elif values.endswith('METADATA.pb'):

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS, WARN
+from fontbakery.status import FAIL, PASS, WARN, SKIP
 from fontbakery.message import Message
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import
@@ -20,19 +20,20 @@ profile_imports = [
         If a variable font has a 'wght' (Weight) axis, then the coordinate of
         its 'Regular' instance is required to be 400.
     """,
-    conditions = ['is_variable_font',
-                  'regular_wght_coord'],
+    conditions = ['is_variable_font'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_wght_coord(ttFont, regular_wght_coord):
     """The variable font 'wght' (Weight) axis coordinate must be 400 on the
     'Regular' instance."""
 
-    if regular_wght_coord == 400:
+    if regular_wght_coord is None:
+        yield SKIP, "Font has no 'wght' (Weight) axis."
+    elif regular_wght_coord == 400:
         yield PASS, "Regular:wght is 400."
     else:
         yield FAIL,\
-              Message("not-400",
+              Message("wght-not-400",
                       f'The "wght" axis coordinate of'
                       f' the "Regular" instance must be 400.'
                       f' Got {regular_wght_coord} instead.')
@@ -48,19 +49,20 @@ def com_google_fonts_check_varfont_regular_wght_coord(ttFont, regular_wght_coord
         If a variable font has a 'wdth' (Width) axis, then the coordinate of
         its 'Regular' instance is required to be 100.
     """,
-    conditions = ['is_variable_font',
-                  'regular_wdth_coord'],
+    conditions = ['is_variable_font'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_wdth_coord(ttFont, regular_wdth_coord):
     """The variable font 'wdth' (Width) axis coordinate must be 100 on the 'Regular' instance."""
 
-    if regular_wdth_coord == 100:
+    if regular_wdth_coord is None:
+        yield SKIP, "Font has no 'wdth' (Width) axis."
+    elif regular_wdth_coord == 100:
         yield PASS, "Regular:wdth is 100."
     else:
         yield FAIL,\
-              Message("not-100",
-                      f'The "wdth" coordinate of'
+              Message("wdth-not-100",
+                      f'The "wdth" axis coordinate of'
                       f' the "Regular" instance must be 100.'
                       f' Got {regular_wdth_coord} as a default value instead.')
 
@@ -75,19 +77,20 @@ def com_google_fonts_check_varfont_regular_wdth_coord(ttFont, regular_wdth_coord
         If a variable font has a 'slnt' (Slant) axis, then the coordinate of
         its 'Regular' instance is required to be zero.
     """,
-    conditions = ['is_variable_font',
-                  'regular_slnt_coord'],
+    conditions = ['is_variable_font'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_slnt_coord(ttFont, regular_slnt_coord):
     """The variable font 'slnt' (Slant) axis coordinate must be zero on the 'Regular' instance."""
 
-    if regular_slnt_coord == 0:
+    if regular_slnt_coord is None:
+        yield SKIP, "Font has no 'slnt' (Slant) axis."
+    elif regular_slnt_coord == 0:
         yield PASS, "Regular:slnt is zero."
     else:
         yield FAIL,\
-              Message("non-zero",
-                      f'The "slnt" coordinate of'
+              Message("slnt-not-0",
+                      f'The "slnt" axis coordinate of'
                       f' the "Regular" instance must be zero.'
                       f' Got {regular_slnt_coord} as a default value instead.')
 
@@ -102,19 +105,20 @@ def com_google_fonts_check_varfont_regular_slnt_coord(ttFont, regular_slnt_coord
         If a variable font has a 'ital' (Italic) axis, then the coordinate of
         its 'Regular' instance is required to be zero.
     """,
-    conditions = ['is_variable_font',
-                  'regular_ital_coord'],
+    conditions = ['is_variable_font'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_ital_coord(ttFont, regular_ital_coord):
     """The variable font 'ital' (Italic) axis coordinate must be zero on the 'Regular' instance."""
 
-    if regular_ital_coord == 0:
+    if regular_ital_coord is None:
+        yield SKIP, "Font has no 'ital' (Italic) axis."
+    elif regular_ital_coord == 0:
         yield PASS, "Regular:ital is zero."
     else:
         yield FAIL,\
-              Message("non-zero",
-                      f'The "ital" coordinate of'
+              Message("ital-not-0",
+                      f'The "ital" axis coordinate of'
                       f' the "Regular" instance must be zero.'
                       f' Got {regular_ital_coord} as a default value instead.')
 

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -482,7 +482,8 @@ def com_adobe_fonts_check_name_postscript_vs_cff(ttFont):
     """CFF table FontName must match name table ID 6 (PostScript name)."""
     cff_names = ttFont['CFF '].cff.fontNames
     if len(cff_names) != 1:
-        yield ERROR, "Unexpected number of font names in CFF table."
+        yield ERROR, Message("cff-name-error",
+                             "Unexpected number of font names in CFF table.")
         return
 
     passed = True
@@ -493,7 +494,7 @@ def com_adobe_fonts_check_name_postscript_vs_cff(ttFont):
             if postscript_name != cff_name:
                 passed = False
                 yield FAIL,\
-                      Message("mismatch",
+                      Message("ps-cff-name-mismatch",
                               f"Name table PostScript name '{postscript_name}' "
                               f"does not match CFF table FontName '{cff_name}'.")
 

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.status import ERROR, FAIL, PASS, WARN, INFO
+from fontbakery.status import FAIL, PASS, WARN, INFO
 from fontbakery.message import Message
 from fontbakery.constants import (NameID,
                                   PlatformID,
@@ -482,8 +482,8 @@ def com_adobe_fonts_check_name_postscript_vs_cff(ttFont):
     """CFF table FontName must match name table ID 6 (PostScript name)."""
     cff_names = ttFont['CFF '].cff.fontNames
     if len(cff_names) != 1:
-        yield ERROR, Message("cff-name-error",
-                             "Unexpected number of font names in CFF table.")
+        yield FAIL, Message("cff-name-error",
+                            "Unexpected number of font names in CFF table.")
         return
 
     passed = True

--- a/Lib/fontbakery/profiles/ufo_sources.py
+++ b/Lib/fontbakery/profiles/ufo_sources.py
@@ -16,10 +16,10 @@ UFO_PROFILE_CHECKS = [
 
 
 @condition
-def ufo_font(font):
+def ufo_font(ufo):
     try:
         import defcon
-        return defcon.Font(font)
+        return defcon.Font(ufo)
     except Exception:
         return None
 
@@ -28,14 +28,14 @@ def ufo_font(font):
     id = 'com.daltonmaag/check/ufolint',
     proposal = 'https://github.com/googlefonts/fontbakery/pull/1736'
 )
-def com_daltonmaag_check_ufolint(font):
+def com_daltonmaag_check_ufolint(ufo):
     """Run ufolint on UFO source directory."""
 
     # IMPORTANT: This check cannot use the 'ufo_font' condition because it makes it
     # skip malformed UFOs (e.g. if metainfo.plist file is missing).
 
     import subprocess
-    ufolint_cmd = ["ufolint", font]
+    ufolint_cmd = ["ufolint", ufo]
 
     try:
         subprocess.check_output(ufolint_cmd, stderr=subprocess.STDOUT)

--- a/Lib/fontbakery/profiles/ufo_sources.py
+++ b/Lib/fontbakery/profiles/ufo_sources.py
@@ -1,7 +1,4 @@
-import os
-
 from fontbakery.callable import check, condition
-from fontbakery.callable import FontBakeryExpectedValue as ExpectedValue
 from fontbakery.status import ERROR, FAIL, PASS, WARN
 from fontbakery.section import Section
 from fontbakery.message import Message
@@ -19,11 +16,11 @@ UFO_PROFILE_CHECKS = [
 
 
 @condition
-def ufo_font(ufo):
+def ufo_font(font):
     try:
         import defcon
-        return defcon.Font(ufo)
-    except:
+        return defcon.Font(font)
+    except Exception:
         return None
 
 
@@ -31,10 +28,14 @@ def ufo_font(ufo):
     id = 'com.daltonmaag/check/ufolint',
     proposal = 'https://github.com/googlefonts/fontbakery/pull/1736'
 )
-def com_daltonmaag_check_ufolint(ufo):
+def com_daltonmaag_check_ufolint(font):
     """Run ufolint on UFO source directory."""
+
+    # IMPORTANT: This check cannot use the 'ufo_font' condition because it makes it
+    # skip malformed UFOs (e.g. if metainfo.plist file is missing).
+
     import subprocess
-    ufolint_cmd = ["ufolint", ufo]
+    ufolint_cmd = ["ufolint", font]
 
     try:
         subprocess.check_output(ufolint_cmd, stderr=subprocess.STDOUT)
@@ -151,4 +152,3 @@ def com_daltonmaag_check_unnecessary_fields(ufo_font):
 # is useful.
 
 profile.auto_register(globals())
-

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1,6 +1,6 @@
 import os
 
-from fontbakery.status import PASS, FAIL, WARN, ERROR, INFO, SKIP
+from fontbakery.status import PASS, FAIL, WARN, INFO, SKIP
 from fontbakery.section import Section
 from fontbakery.callable import condition, check, disable
 from fontbakery.message import Message
@@ -464,13 +464,7 @@ def com_google_fonts_check_whitespace_glyphnames(ttFont):
         passed = True
 
         space = get_glyph_name(ttFont, 0x0020)
-        if not space:
-            passed = False
-            yield FAIL,\
-                  Message('missing-0020',
-                          'Glyph 0x0020 is missing a glyph name!')
-
-        elif space in AGL_RECOMMENDED_0020:
+        if space in AGL_RECOMMENDED_0020:
             pass
 
         elif space in AGL_COMPLIANT_BUT_NOT_RECOMMENDED_0020:
@@ -488,12 +482,7 @@ def com_google_fonts_check_whitespace_glyphnames(ttFont):
 
 
         nbsp = get_glyph_name(ttFont, 0x00A0)
-        if not nbsp:
-            yield FAIL,\
-                  Message('missing-00a0',
-                          'Glyph 0x00A0 is missing a glyph name!')
-
-        elif nbsp == space:
+        if nbsp == space:
             # This is OK.
             # Some fonts use the same glyph for both space and nbsp.
             pass

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -1,7 +1,5 @@
 import os
-from types import SimpleNamespace
 
-import fontTools.ttLib
 from fontTools.ttLib import TTFont
 
 from fontbakery.constants import (NameID,
@@ -10,7 +8,7 @@ from fontbakery.constants import (NameID,
                                   WindowsLanguageID,
                                   MacintoshEncodingID,
                                   MacintoshLanguageID)
-from fontbakery.checkrunner import (INFO, WARN, PASS, FAIL)
+from fontbakery.checkrunner import INFO, WARN, PASS, FAIL, SKIP, ERROR
 from fontbakery.codetesting import (assert_PASS,
                                     assert_results_contain,
                                     CheckTester,
@@ -385,31 +383,41 @@ def test_check_family_naming_recommendations():
 def test_check_name_postscript_vs_cff():
     check = CheckTester(opentype_profile,
                         "com.adobe.fonts/check/name/postscript_vs_cff")
-    test_font = TTFont()
-    test_font['CFF '] = fontTools.ttLib.newTable('CFF ')
-    test_font['CFF '].cff.fontNames = ['SomeFontName']
-    test_font['name'] = fontTools.ttLib.newTable('name')
 
-    test_font['name'].setName(
-        'SomeOtherFontName',
+    # Test a font that has matching names. Check should PASS.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
+    msg = assert_PASS(check(ttFont))
+    assert msg == "Name table PostScript name matches CFF table FontName."
+
+    # Change the name-table string. Check should FAIL.
+    other_name = 'SomeOtherFontName'
+    ttFont['name'].setName(
+        other_name,
         NameID.POSTSCRIPT_NAME,
         PlatformID.WINDOWS,
         WindowsEncodingID.UNICODE_BMP,
         WindowsLanguageID.ENGLISH_USA
     )
+    msg = assert_results_contain(check(ttFont), FAIL, "ps-cff-name-mismatch")
+    assert msg == (f"Name table PostScript name '{other_name}' does not match"
+                   " CFF table FontName 'SourceSansPro-Bold'.")
 
-    test_font.reader = SimpleNamespace(file=SimpleNamespace(name="whatever"))
-    assert_results_contain(check(test_font),
-                           FAIL, 'mismatch')
+    # Change the CFF-table name. Check should ERROR.
+    ttFont['CFF '].cff.fontNames = ["name1", "name2"]
+    msg = assert_results_contain(check(ttFont), ERROR, "cff-name-error")
+    assert msg == "Unexpected number of font names in CFF table."
 
-    test_font['name'].setName(
-        'SomeFontName',
-        NameID.POSTSCRIPT_NAME,
-        PlatformID.WINDOWS,
-        WindowsEncodingID.UNICODE_BMP,
-        WindowsLanguageID.ENGLISH_USA
-    )
-    assert_PASS(check(test_font))
+    # Now test with a TrueType font.
+    # The test should be skipped due to an unfulfilled condition.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/TTF/SourceSansPro-Bold.ttf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: is_cff"
+
+    # Now test with a CFF2 font.
+    # The test should be skipped due to an unfulfilled condition.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: is_cff"
 
 
 def test_check_name_postscript_name_consistency():

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -8,7 +8,7 @@ from fontbakery.constants import (NameID,
                                   WindowsLanguageID,
                                   MacintoshEncodingID,
                                   MacintoshLanguageID)
-from fontbakery.checkrunner import INFO, WARN, PASS, FAIL, SKIP, ERROR
+from fontbakery.checkrunner import INFO, WARN, PASS, FAIL, SKIP
 from fontbakery.codetesting import (assert_PASS,
                                     assert_results_contain,
                                     CheckTester,
@@ -402,9 +402,9 @@ def test_check_name_postscript_vs_cff():
     assert msg == (f"Name table PostScript name '{other_name}' does not match"
                    " CFF table FontName 'SourceSansPro-Bold'.")
 
-    # Change the CFF-table name. Check should ERROR.
+    # Change the CFF-table name. Check should FAIL.
     ttFont['CFF '].cff.fontNames = ["name1", "name2"]
-    msg = assert_results_contain(check(ttFont), ERROR, "cff-name-error")
+    msg = assert_results_contain(check(ttFont), FAIL, "cff-name-error")
     assert msg == "Unexpected number of font names in CFF table."
 
     # Now test with a TrueType font.

--- a/tests/profiles/ufo_sources_test.py
+++ b/tests/profiles/ufo_sources_test.py
@@ -3,18 +3,20 @@ import os
 import defcon
 import pytest
 
-from fontbakery.checkrunner import (DEBUG, ERROR, FAIL, INFO, PASS, SKIP, WARN)
-from fontbakery.codetesting import (assert_PASS,
-                                    assert_results_contain,
-                                    CheckTester)
+from fontbakery.checkrunner import FAIL, SKIP, WARN
+from fontbakery.codetesting import (
+    assert_PASS,
+    assert_results_contain,
+    CheckTester,
+    TEST_FILE,
+)
 from fontbakery.profiles.ufo_sources import profile as ufo_sources_profile
-
-check_statuses = (ERROR, FAIL, SKIP, PASS, WARN, INFO, DEBUG)
 
 
 @pytest.fixture
 def empty_ufo_font(tmpdir):
     ufo = defcon.Font()
+    ufo.newGlyph("gname")
     ufo_path = str(tmpdir.join("empty_font.ufo"))
     ufo.save(ufo_path)
     return (ufo, ufo_path)
@@ -26,13 +28,16 @@ def test_check_ufolint(empty_ufo_font):
 
     _, ufo_path = empty_ufo_font
 
-    assert_PASS(check(ufo_path),
-                'with an empty UFO.')
+    assert assert_PASS(check(ufo_path)) == "ufolint passed the UFO source."
 
     os.remove(os.path.join(ufo_path, "metainfo.plist"))
-    assert_results_contain(check(ufo_path),
-                           FAIL, "ufolint-fail",
-                           'with maimed UFO.')
+    msg = assert_results_contain(check(ufo_path), FAIL, "ufolint-fail")
+    assert "ufolint failed the UFO source." in msg
+
+    # Run the check on a non-UFO font. The result is PASS because ufolint does not
+    # issue any error when it's run on a non-UFO font.
+    font = TEST_FILE("source-sans-pro/OTF/SourceSansPro-Regular.otf")
+    assert assert_PASS(check(font)) == "ufolint passed the UFO source."
 
 
 def test_check_required_fields(empty_ufo_font):
@@ -41,9 +46,8 @@ def test_check_required_fields(empty_ufo_font):
 
     ufo, _ = empty_ufo_font
 
-    assert_results_contain(check(ufo),
-                           FAIL, "missing-required-fields",
-                           'with an empty UFO.')
+    msg = assert_results_contain(check(ufo), FAIL, "missing-required-fields")
+    assert "Required field(s) missing:" in msg
 
     ufo.info.unitsPerEm = 1000
     ufo.info.ascender = 800
@@ -52,8 +56,12 @@ def test_check_required_fields(empty_ufo_font):
     ufo.info.capHeight = 700
     ufo.info.familyName = "Test"
 
-    assert_PASS(check(ufo),
-                'with an almost empty UFO.')
+    assert assert_PASS(check(ufo)) == "Required fields present."
+
+    # Run the check on a non-UFO font.
+    font = TEST_FILE("source-sans-pro/OTF/SourceSansPro-Regular.otf")
+    msg = assert_results_contain(check(font), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: ufo_font"
 
 
 def test_check_recommended_fields(empty_ufo_font):
@@ -62,9 +70,8 @@ def test_check_recommended_fields(empty_ufo_font):
 
     ufo, _ = empty_ufo_font
 
-    assert_results_contain(check(ufo),
-                           WARN, "missing-recommended-fields",
-                           'with an empty UFO.')
+    msg = assert_results_contain(check(ufo), WARN, "missing-recommended-fields")
+    assert "Recommended field(s) missing:" in msg
 
     ufo.info.postscriptUnderlineThickness = 1000
     ufo.info.postscriptUnderlinePosition = 800
@@ -74,8 +81,12 @@ def test_check_recommended_fields(empty_ufo_font):
     ufo.info.copyright = "Test"
     ufo.info.openTypeOS2Panose = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-    assert_PASS(check(ufo),
-                'with an almost empty UFO.')
+    assert assert_PASS(check(ufo)) == "Recommended fields present."
+
+    # Run the check on a non-UFO font.
+    font = TEST_FILE("source-sans-pro/OTF/SourceSansPro-Regular.otf")
+    msg = assert_results_contain(check(font), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: ufo_font"
 
 
 def test_check_unnecessary_fields(empty_ufo_font):
@@ -84,15 +95,17 @@ def test_check_unnecessary_fields(empty_ufo_font):
 
     ufo, _ = empty_ufo_font
 
-    assert_PASS(check(ufo),
-                'with an empty UFO.')
+    assert assert_PASS(check(ufo)) == "Unnecessary fields omitted."
 
     ufo.info.openTypeNameUniqueID = "aaa"
     ufo.info.openTypeNameVersion = "1.000"
     ufo.info.postscriptUniqueID = -1
     ufo.info.year = 2018
 
-    assert_results_contain(check(ufo),
-                           WARN, "unnecessary-fields",
-                           'with unnecessary fields in UFO.')
+    msg = assert_results_contain(check(ufo), WARN, "unnecessary-fields")
+    assert "Unnecessary field(s) present:" in msg
 
+    # Run the check on a non-UFO font.
+    font = TEST_FILE("source-sans-pro/OTF/SourceSansPro-Regular.otf")
+    msg = assert_results_contain(check(font), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: ufo_font"


### PR DESCRIPTION
The changes made to `CheckTester` make the test suite behave the same way as when the checks are run via the CLI.
Prior to these changes `CheckTester` did NOT take into account the check's own `conditions`.
These changes also enable us to now assert (in the test suite) when a check is skipped due to unfulfilled conditions.

The patch made to `CheckTester` uncovered bugs in several checks and tests, which were also fixed.