### PR TITLE
Follow up to PR #3766

### DIFF
--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -4,11 +4,9 @@ from fontbakery.message import Message
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import
 
-profile_imports = [
-    ('.shared_conditions', ('is_variable_font'
-            , 'regular_wght_coord', 'regular_wdth_coord', 'regular_slnt_coord'
-            , 'regular_ital_coord', 'regular_opsz_coord', 'bold_wght_coord'))
-]
+profile_imports = (
+    (".", ("shared_conditions",)),
+)
 
 @check(
     id = 'com.google.fonts/check/varfont/regular_wght_coord',
@@ -20,16 +18,15 @@ profile_imports = [
         If a variable font has a 'wght' (Weight) axis, then the coordinate of
         its 'Regular' instance is required to be 400.
     """,
-    conditions = ['is_variable_font'],
+    conditions = ['is_variable_font',
+                  'has_wght_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_wght_coord(ttFont, regular_wght_coord):
     """The variable font 'wght' (Weight) axis coordinate must be 400 on the
     'Regular' instance."""
 
-    if regular_wght_coord is None:
-        yield SKIP, "Font has no 'wght' (Weight) axis."
-    elif regular_wght_coord == 400:
+    if regular_wght_coord == 400:
         yield PASS, "Regular:wght is 400."
     else:
         yield FAIL,\
@@ -49,15 +46,14 @@ def com_google_fonts_check_varfont_regular_wght_coord(ttFont, regular_wght_coord
         If a variable font has a 'wdth' (Width) axis, then the coordinate of
         its 'Regular' instance is required to be 100.
     """,
-    conditions = ['is_variable_font'],
+    conditions = ['is_variable_font',
+                  'has_wdth_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_wdth_coord(ttFont, regular_wdth_coord):
     """The variable font 'wdth' (Width) axis coordinate must be 100 on the 'Regular' instance."""
 
-    if regular_wdth_coord is None:
-        yield SKIP, "Font has no 'wdth' (Width) axis."
-    elif regular_wdth_coord == 100:
+    if regular_wdth_coord == 100:
         yield PASS, "Regular:wdth is 100."
     else:
         yield FAIL,\
@@ -77,15 +73,14 @@ def com_google_fonts_check_varfont_regular_wdth_coord(ttFont, regular_wdth_coord
         If a variable font has a 'slnt' (Slant) axis, then the coordinate of
         its 'Regular' instance is required to be zero.
     """,
-    conditions = ['is_variable_font'],
+    conditions = ['is_variable_font',
+                  'has_slnt_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_slnt_coord(ttFont, regular_slnt_coord):
     """The variable font 'slnt' (Slant) axis coordinate must be zero on the 'Regular' instance."""
 
-    if regular_slnt_coord is None:
-        yield SKIP, "Font has no 'slnt' (Slant) axis."
-    elif regular_slnt_coord == 0:
+    if regular_slnt_coord == 0:
         yield PASS, "Regular:slnt is zero."
     else:
         yield FAIL,\
@@ -105,15 +100,14 @@ def com_google_fonts_check_varfont_regular_slnt_coord(ttFont, regular_slnt_coord
         If a variable font has a 'ital' (Italic) axis, then the coordinate of
         its 'Regular' instance is required to be zero.
     """,
-    conditions = ['is_variable_font'],
+    conditions = ['is_variable_font',
+                  'has_ital_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_regular_ital_coord(ttFont, regular_ital_coord):
     """The variable font 'ital' (Italic) axis coordinate must be zero on the 'Regular' instance."""
 
-    if regular_ital_coord is None:
-        yield SKIP, "Font has no 'ital' (Italic) axis."
-    elif regular_ital_coord == 0:
+    if regular_ital_coord == 0:
         yield PASS, "Regular:ital is zero."
     else:
         yield FAIL,\
@@ -142,10 +136,10 @@ def com_google_fonts_check_varfont_regular_opsz_coord(ttFont, regular_opsz_coord
     """The variable font 'opsz' (Optical Size) axis coordinate should be between 10 and 16 on the 'Regular' instance."""
 
     if regular_opsz_coord >= 10 and regular_opsz_coord <= 16:
-        yield PASS, ("Regular:opsz coordinate ({regular_opsz_coord}) looks good.")
+        yield PASS, f"Regular:opsz coordinate ({regular_opsz_coord}) looks good."
     else:
         yield WARN,\
-              Message("out-of-range",
+              Message("opsz-out-of-range",
                       f'The "opsz" (Optical Size) coordinate'
                       f' on the "Regular" instance is recommended'
                       f' to be a value in the range 10 to 16.'
@@ -164,7 +158,7 @@ def com_google_fonts_check_varfont_regular_opsz_coord(ttFont, regular_opsz_coord
         a required value of 700 in this case.
     """,
     conditions = ['is_variable_font',
-                  'bold_wght_coord'],
+                  'has_wght_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1707'
 )
 def com_google_fonts_check_varfont_bold_wght_coord(ttFont, bold_wght_coord):
@@ -174,7 +168,7 @@ def com_google_fonts_check_varfont_bold_wght_coord(ttFont, bold_wght_coord):
         yield PASS, "Bold:wght is 700."
     else:
         yield FAIL,\
-              Message("not-700",
+              Message("wght-not-700",
                       f'The "wght" axis coordinate of'
                       f' the "Bold" instance must be 700.'
                       f' Got {bold_wght_coord} instead.')
@@ -189,26 +183,27 @@ def com_google_fonts_check_varfont_bold_wght_coord(ttFont, bold_wght_coord):
 
         On the 'wght' (Weight) axis, the valid coordinate range is 1-1000.
     """,
-    conditions = ['is_variable_font'],
+    conditions = ['is_variable_font',
+                  'has_wght_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2264'
 )
 def com_google_fonts_check_varfont_wght_valid_range(ttFont):
     """The variable font 'wght' (Weight) axis coordinate
        must be within spec range of 1 to 1000 on all instances."""
 
-    Failed = False
+    passed = True
     for instance in ttFont['fvar'].instances:
         if 'wght' in instance.coordinates:
             value = instance.coordinates['wght']
             if value < 1 or value > 1000:
-                Failed = True
+                passed = False
                 yield FAIL,\
-                      Message("out-of-range",
+                      Message("wght-out-of-range",
                               f'Found a bad "wght" coordinate with value {value}'
                               f' outside of the valid range from 1 to 1000.')
                 break
 
-    if not Failed:
+    if passed:
         yield PASS, "OK"
 
 
@@ -221,26 +216,27 @@ def com_google_fonts_check_varfont_wght_valid_range(ttFont):
 
         On the 'wdth' (Width) axis, the valid coordinate range is 1-1000
     """,
-    conditions = ['is_variable_font'],
+    conditions = ['is_variable_font',
+                  'has_wdth_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/pull/2520'
 )
 def com_google_fonts_check_varfont_wdth_valid_range(ttFont):
     """The variable font 'wdth' (Width) axis coordinate
        must be within spec range of 1 to 1000 on all instances."""
 
-    Failed = False
+    passed = True
     for instance in ttFont['fvar'].instances:
         if 'wdth' in instance.coordinates:
             value = instance.coordinates['wdth']
             if value < 1 or value > 1000:
-                Failed = True
+                passed = False
                 yield FAIL,\
-                      Message("out-of-range",
+                      Message("wdth-out-of-range",
                               f'Found a bad "wdth" coordinate with value {value}'
                               f' outside of the valid range from 1 to 1000.')
                 break
 
-    if not Failed:
+    if passed:
         yield PASS, "OK"
 
 
@@ -256,7 +252,7 @@ def com_google_fonts_check_varfont_wdth_valid_range(ttFont):
         the scale used for the italicAngle field in the post table.
     """,
     conditions = ['is_variable_font',
-                  'slnt_axis'],
+                  'has_slnt_axis'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2572'
 )
 def com_google_fonts_check_varfont_slnt_range(ttFont, slnt_axis):
@@ -267,7 +263,7 @@ def com_google_fonts_check_varfont_slnt_range(ttFont, slnt_axis):
         yield PASS, "Looks good!"
     else:
         yield WARN,\
-              Message("unusual-range",
+              Message("unusual-slnt-range",
                       f'The range of values for the "slnt" axis in'
                       f' this font only allows positive coordinates'
                       f' (from {slnt_axis.minValue} to {slnt_axis.maxValue}),'

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -294,15 +294,18 @@ def vmetrics(ttFonts):
 def is_variable_font(ttFont):
     return "fvar" in ttFont.keys()
 
+
 @condition
 def is_not_variable_font(ttFont):
     return "fvar" not in ttFont.keys()
+
 
 @condition
 def VFs(ttFonts):
     """Returns a list of font files which are recognized as variable fonts"""
     return [ttFont for ttFont in ttFonts
             if is_variable_font(ttFont)]
+
 
 @condition
 def slnt_axis(ttFont):
@@ -311,12 +314,14 @@ def slnt_axis(ttFont):
             if axis.axisTag == "slnt":
                 return axis
 
+
 @condition
 def opsz_axis(ttFont):
     if "fvar" in ttFont:
         for axis in ttFont["fvar"].axes:
             if axis.axisTag == "opsz":
                 return axis
+
 
 @condition
 def ital_axis(ttFont):
@@ -325,12 +330,42 @@ def ital_axis(ttFont):
             if axis.axisTag == "ital":
                 return axis
 
+
 @condition
 def grad_axis(ttFont):
     if "fvar" in ttFont:
         for axis in ttFont["fvar"].axes:
             if axis.axisTag == "GRAD":
                 return axis
+
+
+def get_axis_tags_set(ttFont):
+    return set(axis.axisTag for axis in ttFont["fvar"].axes)
+
+
+@condition
+def has_wght_axis(ttFont):
+    if is_variable_font(ttFont) and "wght" in get_axis_tags_set(ttFont):
+        return True
+
+
+@condition
+def has_wdth_axis(ttFont):
+    if is_variable_font(ttFont) and "wdth" in get_axis_tags_set(ttFont):
+        return True
+
+
+@condition
+def has_slnt_axis(ttFont):
+    if is_variable_font(ttFont) and "slnt" in get_axis_tags_set(ttFont):
+        return True
+
+
+@condition
+def has_ital_axis(ttFont):
+    if is_variable_font(ttFont) and "ital" in get_axis_tags_set(ttFont):
+        return True
+
 
 def get_instance_axis_value(ttFont, instance_name, axis_tag):
     if not is_variable_font(ttFont):

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -30,16 +30,24 @@ def test_check_varfont_regular_wght_coord():
     assert msg == ('The "wght" axis coordinate of the "Regular" instance must be 400.'
                    ' Got 500 instead.')
 
+    # Reload the original font.
+    ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
+    # Change the name of the first instance from 'Regular' (nameID 258)
+    # to 'Medium' (nameID 259). The font now has no Regular instance.
+    ttFont["fvar"].instances[0].subfamilyNameID = 259
+    assert_results_contain(check(ttFont), FAIL, "wght-not-400")
+
     # Test with a variable font that doesn't have a 'wght' (Weight) axis.
     # The check should yield SKIP.
     ttFont = TTFont(TEST_FILE("BadGrades/BadGrades-VF.ttf"))
-    assert assert_SKIP(check(ttFont)) == "Font has no 'wght' (Weight) axis."
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: has_wght_axis"
 
     # Now test with a static font.
     # The test should be skipped due to an unfulfilled condition.
     ttFont = TTFont(TEST_FILE("source-sans-pro/TTF/SourceSansPro-Bold.ttf"))
     msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
-    assert msg == "Unfulfilled Conditions: is_variable_font"
+    assert msg == "Unfulfilled Conditions: is_variable_font, has_wght_axis"
 
 
 def test_check_varfont_regular_wdth_coord():
@@ -60,16 +68,24 @@ def test_check_varfont_regular_wdth_coord():
     assert msg == ('The "wdth" axis coordinate of the "Regular" instance must be 100.'
                    ' Got 0 as a default value instead.')
 
+    # Reload the original font.
+    ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
+    # Change the name of the first instance from 'Regular' (nameID 258)
+    # to 'Medium' (nameID 259). The font now has no Regular instance.
+    ttFont["fvar"].instances[0].subfamilyNameID = 259
+    assert_results_contain(check(ttFont), FAIL, "wdth-not-100")
+
     # Test with a variable font that doesn't have a 'wdth' (Width) axis.
     # The check should yield SKIP.
     ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
-    assert assert_SKIP(check(ttFont)) == "Font has no 'wdth' (Width) axis."
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: has_wdth_axis"
 
     # Now test with a static font.
     # The test should be skipped due to an unfulfilled condition.
     ttFont = TTFont(TEST_FILE("source-sans-pro/TTF/SourceSansPro-Bold.ttf"))
     msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
-    assert msg == "Unfulfilled Conditions: is_variable_font"
+    assert msg == "Unfulfilled Conditions: is_variable_font, has_wdth_axis"
 
 
 def test_check_varfont_regular_slnt_coord():
@@ -87,7 +103,8 @@ def test_check_varfont_regular_slnt_coord():
     ttFont["fvar"].axes.append(new_axis)
 
     # and specify a bad coordinate for the Regular:
-    ttFont["fvar"].instances[0].coordinates["slnt"] = 12
+    first_instance = ttFont["fvar"].instances[0]
+    first_instance.coordinates["slnt"] = 12
     # Note: I know the correct instance index for this hotfix because
     # I inspected our reference CabinVF using ttx
 
@@ -96,20 +113,26 @@ def test_check_varfont_regular_slnt_coord():
     assert msg == ('The "slnt" axis coordinate of the "Regular" instance must be zero.'
                    ' Got 12 as a default value instead.')
 
-    # We patch the parameter passed-in to the check to make it PASS.
-    msg = assert_PASS(check(ttFont, {"regular_slnt_coord": 0}))
-    assert msg == "Regular:slnt is zero."
+    # We correct the slant coordinate value to make the check PASS.
+    first_instance.coordinates["slnt"] = 0
+    assert assert_PASS(check(ttFont)) == "Regular:slnt is zero."
+
+    # Change the name of the first instance from 'Regular' (nameID 258)
+    # to 'Medium' (nameID 259). The font now has no Regular instance.
+    first_instance.subfamilyNameID = 259
+    assert_results_contain(check(ttFont), FAIL, "slnt-not-0")
 
     # Test with a variable font that doesn't have a 'slnt' (Slant) axis.
     # The check should yield SKIP.
     ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
-    assert assert_SKIP(check(ttFont)) == "Font has no 'slnt' (Slant) axis."
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: has_slnt_axis"
 
     # Now test with a static font.
     # The test should be skipped due to an unfulfilled condition.
     ttFont = TTFont(TEST_FILE("source-sans-pro/TTF/SourceSansPro-Bold.ttf"))
     msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
-    assert msg == "Unfulfilled Conditions: is_variable_font"
+    assert msg == "Unfulfilled Conditions: is_variable_font, has_slnt_axis"
 
 
 def test_check_varfont_regular_ital_coord():
@@ -127,7 +150,8 @@ def test_check_varfont_regular_ital_coord():
     ttFont["fvar"].axes.append(new_axis)
 
     # and specify a bad coordinate for the Regular:
-    ttFont["fvar"].instances[0].coordinates["ital"] = 123
+    first_instance = ttFont["fvar"].instances[0]
+    first_instance.coordinates["ital"] = 123
     # Note: I know the correct instance index for this hotfix because
     # I inspected the our reference CabinVF using ttx
 
@@ -136,20 +160,26 @@ def test_check_varfont_regular_ital_coord():
     assert msg == ('The "ital" axis coordinate of the "Regular" instance must be zero.'
                    ' Got 123 as a default value instead.')
 
-    # We patch the parameter passed-in to the check to make it PASS.
-    msg = assert_PASS(check(ttFont, {"regular_ital_coord": 0}))
-    assert msg == "Regular:ital is zero."
+    # We correct the italic coordinate value to make the check PASS.
+    first_instance.coordinates["ital"] = 0
+    assert assert_PASS(check(ttFont)) == "Regular:ital is zero."
+
+    # Change the name of the first instance from 'Regular' (nameID 258)
+    # to 'Medium' (nameID 259). The font now has no Regular instance.
+    first_instance.subfamilyNameID = 259
+    assert_results_contain(check(ttFont), FAIL, "ital-not-0")
 
     # Test with a variable font that doesn't have an 'ital' (Italic) axis.
     # The check should yield SKIP.
     ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
-    assert assert_SKIP(check(ttFont)) == "Font has no 'ital' (Italic) axis."
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: has_ital_axis"
 
     # Now test with a static font.
     # The test should be skipped due to an unfulfilled condition.
     ttFont = TTFont(TEST_FILE("source-sans-pro/TTF/SourceSansPro-It.ttf"))
     msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
-    assert msg == "Unfulfilled Conditions: is_variable_font"
+    assert msg == "Unfulfilled Conditions: is_variable_font, has_ital_axis"
 
 
 def test_check_varfont_regular_opsz_coord():
@@ -173,13 +203,13 @@ def test_check_varfont_regular_opsz_coord():
 
     # Then we ensure the problem is detected:
     assert_results_contain(check(ttFont),
-                           WARN, 'out-of-range',
+                           WARN, 'opsz-out-of-range',
                            'with a bad Regular:opsz coordinate (9)...')
 
     # We try yet another bad value
     # and the check should detect the problem:
     assert_results_contain(check(ttFont, {"regular_opsz_coord": 17}),
-                           WARN, 'out-of-range',
+                           WARN, 'opsz-out-of-range',
                            'with another bad Regular:opsz value (17)...')
 
     # We then test with good default opsz values:
@@ -203,7 +233,7 @@ def test_check_varfont_bold_wght_coord():
     # We then change the value to ensure the problem is properly detected by the check:
     ttFont["fvar"].instances[3].coordinates["wght"] = 600
     assert_results_contain(check(ttFont),
-                           FAIL, 'not-700',
+                           FAIL, 'wght-not-700',
                            'with a bad Bold:wght coordinage (600)...')
 
 
@@ -222,13 +252,13 @@ def test_check_varfont_wght_valid_range():
     # We then introduce the problem by setting a bad value:
     ttFont["fvar"].instances[0].coordinates["wght"] = 0
     assert_results_contain(check(ttFont),
-                           FAIL, 'out-of-range',
+                           FAIL, 'wght-out-of-range',
                            'with wght=0...')
 
     # And yet another bad value:
     ttFont["fvar"].instances[0].coordinates["wght"] = 1001
     assert_results_contain(check(ttFont),
-                           FAIL, 'out-of-range',
+                           FAIL, 'wght-out-of-range',
                            'with wght=1001...')
 
 
@@ -247,13 +277,13 @@ def test_check_varfont_wdth_valid_range():
     # We then introduce the problem by setting a bad value:
     ttFont["fvar"].instances[0].coordinates["wdth"] = 0
     assert_results_contain(check(ttFont),
-                           FAIL, 'out-of-range',
+                           FAIL, 'wdth-out-of-range',
                            'with wght=0...')
 
     # And yet another bad value:
     ttFont["fvar"].instances[0].coordinates["wdth"] = 1001
     assert_results_contain(check(ttFont),
-                           FAIL, 'out-of-range',
+                           FAIL, 'wdth-out-of-range',
                            'with wght=1001...')
 
 
@@ -266,7 +296,7 @@ def test_check_varfont_slnt_range():
     # Our reference Inter varfont has a bad slnt range
     ttFont = TTFont("data/test/varfont/inter/Inter[slnt,wght].ttf")
     assert_results_contain(check(ttFont),
-                           WARN, 'unusual-range',
+                           WARN, 'unusual-slnt-range',
                            'with a varfont that has an unusual "slnt" range.')
 
     # We then fix the font-bug by flipping the slnt axis range:


### PR DESCRIPTION
Follow up to PR #3766
Streamlines several `fvar` checks, and adjusts the expected results.

## Bonus question
What's the outcome of running the command below with FB v0.8.8 on the font attached?

    fontbakery check-opentype CabinVFBeta_mod.ttf -c regular_wght_coord -c regular_wdth_coord --verbose

[CabinVFBeta_mod.ttf.zip](https://github.com/googlefonts/fontbakery/files/8659730/CabinVFBeta_mod.ttf.zip)
