### PR TITLE
check_glyph_coverage: check all known glyphsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - Improve rendering of bullet lists (issue #3691 & pull #3741)
 
 ### Changes to existing checks
+  - **[com.google.fonts/check/glyph_coverage]:** Check all fonts against all glyphsets and report any glyphsets which are partially filled (pull #3775)
   - **[com.google.fonts/check/os2_metrics_match_hhea]:** Included lineGap in comparison
   - **[com.google.fonts/check/family/vertical_metrics]:** Included hhea.lineGap in comparison
   - **[com.google.fonts/check/superfamily/vertical_metrics]:** Included hhea.lineGap in comparison
-  - **[com.google.fonts/check/glyph_coverage]:** Use glyphsets lib so we can improve this check in the future. (pull #3753)
   - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check fails. (pull #3756)
 
 #### On the Adobe Fonts Profile

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1044,20 +1044,35 @@ def font_codepoints(ttFont):
     proposal = 'https://github.com/googlefonts/fontbakery/pull/2488'
 )
 def com_google_fonts_check_glyph_coverage(ttFont, font_codepoints, config):
-    """Check `Google Fonts Latin Core` glyph coverage."""
+    """Check `Google Fonts glyph coverage."""
     from fontbakery.utils import bullet_list
     from glyphsets import GFGlyphData as glyph_data
     import unicodedata2
 
+    def missing_encoded_glyphs(glyphs):
+        encoded_glyphs = [g["unicode"] for g in glyphs if g["unicode"]]
+        return ['0x%04X (%s)\n' % (c, unicodedata2.name(chr(c))) for c in encoded_glyphs]
+
     missing_glyphs = glyph_data.missing_glyphsets_in_font(ttFont)
+    fail_or_warn = False
     if "GF_Latin_Core" in missing_glyphs:
-        missing_encoded_latin = [g["unicode"] for g in missing_glyphs["GF_Latin_Core"] if g["unicode"]]
-        missing = ['0x%04X (%s)\n' % (c, unicodedata2.name(chr(c))) for c in missing_encoded_latin]
+        fail_or_warn = True
+        missing = missing_encoded_glyphs(missing_glyphs["GF_Latin_Core"])
         yield FAIL,\
               Message("missing-codepoints",
                       f"Missing required codepoints:\n\n"
                       f"{bullet_list(config, missing)}")
-    else:
+    if len(missing_glyphs) > 0:
+        fail_or_warn = True
+        for glyphset_name, glyphs in missing_glyphs.items():
+            if glyphset_name is "GF_Latin_Core":
+                continue
+            missing = missing_encoded_glyphs(glyphs)
+            yield WARN,\
+                  Message("missing-codepoints",
+                          f"{glyphset_name} is almost fulfilled. Missing codepoints:\n\n"
+                          f"{bullet_list(config, missing)}")
+    if not fail_or_warn:
         yield PASS, "OK"
 
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1065,7 +1065,7 @@ def com_google_fonts_check_glyph_coverage(ttFont, font_codepoints, config):
     if len(missing_glyphs) > 0:
         fail_or_warn = True
         for glyphset_name, glyphs in missing_glyphs.items():
-            if glyphset_name is "GF_Latin_Core":
+            if glyphset_name == "GF_Latin_Core":
                 continue
             missing = missing_encoded_glyphs(glyphs)
             yield WARN,\

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -732,22 +732,22 @@ def test_check_vendor_id():
                 'with a good font.')
 
 
-def NOT_IMPLEMENTED__test_check_glyph_coverage():
+def test_check_glyph_coverage():
     """ Check glyph coverage. """
-    #check = CheckTester(googlefonts_profile,
-    #                    "com.google.fonts/check/glyph_coverage")
-    #TODO: Implement-me!
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/glyph_coverage")
 
-    ## Our reference Mada Regular is know to be bad here.
-    #ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-    #assert_results_contain(check(ttFont),
-    #                       FAIL, 'missing-codepoints',
-    #                       'with a bad font...')
-
-    ## Our reference Cabin Regular is know to be good here.
-    #ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf"))
-    #assert_PASS(check(ttFont),
-    #            'with a good font...')
+    # Our reference Cabin Regular is known to be bad here.
+    ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf"))
+    assert_results_contain(check(ttFont),
+                           FAIL, 'missing-codepoints',
+                           'GF_Latin_Core missing glyphs')
+    # Let's add some encoded glyphs so it passes
+    cmap = ttFont.getBestCmap()
+    cmap[0x01CD] = 0x01CD
+    cmap[0x01CE] = 0x01CE
+    assert_PASS(check(ttFont),
+                'with a good font.')
 
 
 def test_check_name_unwanted_chars():


### PR DESCRIPTION
## Description

Currently, we only check whether each font has all encoded glyphs defined in GF_Latin_Core. This PR expands this check so we can see which glyphsets are almost fulfilled. A WARN is raised if a font contains at least 80% of the encoded glyphs for each glyphset. Here's an example of Montserrat:

<img width="734" alt="Screenshot 2022-05-12 at 13 11 02" src="https://user-images.githubusercontent.com/7525512/168071719-ccc3f001-63d3-41f3-8c8e-fd8e5799b235.png">

I'll complete the todo if we're happy with this feature. Feel free to close if you don't want it.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

