### PR TITLE
fix crash on terminal reporter on specific Windows paths with backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)
   - Improve rendering of bullet lists (issue #3691 & pull #3741)
+  - fix crash on terminal reporter on specific Windows paths with backslashes (issue #3750)
 
 ### Changes to existing checks
 #### On the Universal Profile

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -595,7 +595,7 @@ def parse_md(md):
         console.print(Markdown(md))
     formated_text = capture.get()
     for i in range(len(tables)):
-        formated_text = re.sub('<#MD-TABLE-'+str(i)+'#>', tables[i], formated_text)
+        formated_text = formated_text.replace(f'<#MD-TABLE-{i}#>', tables[i], 1)
     return re.sub(r'<br/?>', r'\n', formated_text).strip()
 
 def parse_md_table(match, tables_memo):


### PR DESCRIPTION
(issue #3750)