### PR TITLE
Windows Terminal displays colors fine. We can now remove the win32 workaround.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Improve implementation of `is_italic` condition and provide an `is_bold` counterpart (issue #3693)
   - Nicer cancellation for terminal runner. (issue #3672)
   - The CheckTester class now takes into account the check's own `conditions`. (pull #3766)
+  - Windows Terminal displays colors fine. We can now remove the win32 workaround. (issue #3779)
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -131,15 +131,14 @@ def ArgumentParser(profile, profile_arg=True):
                                  help='This is a slightly more compact and succint'
                                       ' output layout.')
 
-    if sys.platform != "win32":
-        argument_parser.add_argument('-n', '--no-progress',
-                                     action='store_true',
-                                     help='In a tty as stdout, don\'t'
-                                          ' render the progress indicators.')
+    argument_parser.add_argument('-n', '--no-progress',
+                                 action='store_true',
+                                 help='In a tty as stdout, don\'t'
+                                      ' render the progress indicators.')
 
-        argument_parser.add_argument('-C', '--no-colors',
-                                     action='store_true',
-                                     help='No colors for tty output.')
+    argument_parser.add_argument('-C', '--no-colors',
+                                 action='store_true',
+                                 help='No colors for tty output.')
 
     argument_parser.add_argument('-S', '--show-sections', default=False, action='store_true',
                                  help='Show section summaries.')
@@ -271,11 +270,8 @@ def main(profile=None, values=None):
         argument_parser.print_usage()
         sys.exit(1)
 
-    # The default Windows Terminal just displays the escape codes. The argument
-    # parser above therefore has these options disabled.
-    if sys.platform == "win32":
-        args.no_progress = True
-        args.no_colors = True
+    args.no_progress = True
+    args.no_colors = True
 
     theme = get_theme(args)
     # the most verbose loglevel wins


### PR DESCRIPTION
(issue #3779)