### PR TITLE
[com.google.fonts/check/dotted_circle]: Fix ERROR on fonts without GlyphClassDef.classDefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,44 +6,45 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Noteworthy code-changes
   - Improve implementation of `is_italic` condition and provide an `is_bold` counterpart (issue #3693)
   - Nicer cancellation for terminal runner. (issue #3672)
-  - The CheckTester class now takes into account the check's own `conditions`. (pull #3766)
+  - The CheckTester class now takes into account the check's own `conditions`. (PR #3766)
   - Windows Terminal displays colors fine. We can now remove the win32 workaround. (issue #3779)
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)
-  - Improve rendering of bullet lists (issue #3691 & pull #3741)
+  - Improve rendering of bullet lists (issue #3691 & PR #3741)
   - fix crash on terminal reporter on specific Windows paths with backslashes (issue #3750)
 
 ### Changes to existing checks
 #### On the Universal Profile
+  - **[com.google.fonts/check/dotted_circle]:** Fix ERROR on fonts without GlyphClassDef.classDefs (issue #3736)
   - **[com.google.fonts/check/transformed_components]:** Check for any component transformation only if font is hinted, otherwise check only for flipped contour direction (one transformation dimension is flipped while the other isn't)
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)
-  - **[com.google.fonts/check/required_tables]:** CFF/CFF2 fonts are now checked instead of skipped. (pull #3742)
-  - **[com.google.fonts/check/family/win_ascent_and_descent]:** Fixed the parameter used in the FAIL message that is issued when the value of `usWinAscent` is too large. (pull #3745)
+  - **[com.google.fonts/check/required_tables]:** CFF/CFF2 fonts are now checked instead of skipped. (PR #3742)
+  - **[com.google.fonts/check/family/win_ascent_and_descent]:** Fixed the parameter used in the FAIL message that is issued when the value of `usWinAscent` is too large. (PR #3745)
   - **[com.google.fonts/check/fontbakery_version]:** A change introduced in #3432 made this check always be skipped; that's now fixed. (issue #3576)
-  - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check fails. (pull #3756)
+  - **[com.google.fonts/check/fontbakery_version]:** If the request to PyPI.org is not successful (due to host errors, or lack of internet connection), the check fails. (PR #3756)
   - **[com.google.fonts/check/os2_metrics_match_hhea]:** Included lineGap in comparison
   - **[com.google.fonts/check/family/vertical_metrics]:** Included hhea.lineGap in comparison
   - **[com.google.fonts/check/superfamily/vertical_metrics]:** Included hhea.lineGap in comparison
   - **[com.google.fonts/check/contour_count]:** U+0024 DOLLAR SIGN can also have 5 contours, to support glyphs with two strokes. (issue #3780)
 
 #### On the OpenType Profile
-  - **[com.google.fonts/check/name/match_familyname_fullfont]:** The check was completely rewritten; it now correctly compares full name and family name strings that are from the same platform, same encoding, and same language. (pull #3747)
+  - **[com.google.fonts/check/name/match_familyname_fullfont]:** The check was completely rewritten; it now correctly compares full name and family name strings that are from the same platform, same encoding, and same language. (PR #3747)
   - **[com.google.fonts/check/name/match_familyname_fullfont]:** Added rationale text contibuted by Adam Twardoch (issue #3754)
 
 #### On the Adobe Fonts Profile
-  - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (pull #3743)
-  - **[com.adobe.fonts/check/find_empty_letters]:** Was downgraded to WARN only for a specific set of Korean hangul syllable characters, which are known to be included in fonts as a workaround to undesired behavior from InDesign's Korean IME (Input Method Editor). More details available at issue #2894. (pull #3744)
-  - **[com.adobe.fonts/check/freetype_rasterizer]:** This check from the Universal profile is overridden to yield ERROR if FreeType is not installed, ensuring that the check isn't skipped. (pull #3745)
-  - **[com.google.fonts/check/family/win_ascent_and_descent]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (pull #3745)
-  - **[com.google.fonts/check/os2_metrics_match_hhea]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (pull #3745)
-  - **[com.google.fonts/check/fontbakery_version]:** This check from the Universal profile is overridden to be skipped instead of failing, when the user's internet connection isn't functional. (pull #3756)
+  - The profile was updated to exercise only an explicit set of checks, making it impossible for checks from imported profiles to sneak-in unnoticed. As a result, the set of checks that are run now is somewhat different from previous Font Bakery releases. For example, UFO- and designspace-related checks are no longer attempted; and outline and shaping checks are excluded as well. In addition to pairing down the set of checks inherited from the Universal profile, an effort was made to enable specific checks from other profiles such as Fontwerk, GoogleFonts, and Noto Fonts. (PR #3743)
+  - **[com.adobe.fonts/check/find_empty_letters]:** Was downgraded to WARN only for a specific set of Korean hangul syllable characters, which are known to be included in fonts as a workaround to undesired behavior from InDesign's Korean IME (Input Method Editor). More details available at issue #2894. (PR #3744)
+  - **[com.adobe.fonts/check/freetype_rasterizer]:** This check from the Universal profile is overridden to yield ERROR if FreeType is not installed, ensuring that the check isn't skipped. (PR #3745)
+  - **[com.google.fonts/check/family/win_ascent_and_descent]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (PR #3745)
+  - **[com.google.fonts/check/os2_metrics_match_hhea]:** This check from the Universal profile is now overridden to yield just WARN instead of FAIL. (PR #3745)
+  - **[com.google.fonts/check/fontbakery_version]:** This check from the Universal profile is overridden to be skipped instead of failing, when the user's internet connection isn't functional. (PR #3756)
 
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/license/OFL_copyright]:** Improve wording of log message to clarify its meaning. It was too easy to think that the displayed copyright string (read from the font binary and reported for reference) was an example of the actually expected string format. (issue #3674)
   - **[com.google.fonts/check/cjk_vertical_metrics_regressions]:** Round calculation of expected sTypoAscender and sTypoDescender values (issue #3645)
   - **[com.google.fonts/check/name/familyname]:** Don't validate localized name table entries compared to the expected English names derived from the font filename (issue #3089)
-  - **[com.google.fonts/check/glyph_coverage]:** Check all fonts against all glyphsets and report any glyphsets which are partially filled (pull #3775)
+  - **[com.google.fonts/check/glyph_coverage]:** Check all fonts against all glyphsets and report any glyphsets which are partially filled (PR #3775)
 
 #### On the Fontwerk Profile
   - Added a few more checks to the `CHECKS_NOT_TO_INCLUDE` list. These are checks (most of them from the Google Fonts profile) that Fontwerk is not interested in including in its vendor-specific profile.

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1586,9 +1586,11 @@ def com_google_fonts_check_dotted_circle(ttFont, config):
                                   iterate_lookup_list_with_extensions)
 
     mark_glyphs = []
-    if "GDEF" in ttFont and hasattr(ttFont["GDEF"].table, "GlyphClassDef"):
-      mark_glyphs = [k for k, v in ttFont["GDEF"].table.GlyphClassDef.classDefs.items()
-                     if v == 3]
+    if "GDEF" in ttFont and \
+       hasattr(ttFont["GDEF"].table, "GlyphClassDef") and \
+       hasattr(ttFont["GDEF"].table.GlyphClassDef, "classDefs"):
+        mark_glyphs = [k for k, v in ttFont["GDEF"].table.GlyphClassDef.classDefs.items()
+                       if v == 3]
 
     # Only check for encoded
     mark_glyphs = set(mark_glyphs) & set(ttFont.getBestCmap().values())


### PR DESCRIPTION
(issue #3736)