### PR TITLE
New check: com.adobe.fonts/check/stat_has_axis_value_tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/cmap/alien_codepoints]:** Checks that there are no surrogate pair or private use area codepoints encoded in the cmap table. (PR #3681)
 
 #### Added to the OpenType Profile
+  - **[com.adobe.fonts/check/stat_has_axis_value_tables]:** Validates that STAT table has Axis Value tables. (issue #3090)
   - **[com.adobe.fonts/check/varfont/valid_axis_nameid]:** Validates that the value of axisNameID used by each VariationAxisRecord is greater than 255 and less than 32768. (issue #3702)
   - **[com.adobe.fonts/check/varfont/valid_subfamily_nameid]:** Validates that the value of subfamilyNameID used by each InstanceRecord is 2, 17, or greater than 255 and less than 32768. (issue #3703)
   - **[com.adobe.fonts/check/varfont/valid_postscript_nameid]:** Validates that the value of postScriptNameID used by each InstanceRecord is 6, 0xFFFF, or greater than 255 and less than 32768. (issue #3704)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -170,6 +170,7 @@ SET_EXPLICIT_CHECKS = {
     # =======================================
     # From stat.py
     "com.google.fonts/check/varfont/stat_axis_record_for_each_axis",
+    "com.adobe.fonts/check/stat_has_axis_value_tables",
     #
     # =======================================
     # From universal.py

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -84,6 +84,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/varfont/valid_default_instance_nameids',
     'com.adobe.fonts/check/varfont/same_size_instance_records',
     'com.adobe.fonts/check/varfont/distinct_instance_records',
+    'com.adobe.fonts/check/stat_has_axis_value_tables',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -31,6 +31,7 @@ def are_ttf(ttFonts):
 def is_cff(ttFont):
     return 'CFF ' in ttFont
 
+
 @condition
 def is_cff2(ttFont):
     return 'CFF2' in ttFont
@@ -39,6 +40,11 @@ def is_cff2(ttFont):
 @condition
 def has_name_table(ttFont):
     return "name" in ttFont.keys()
+
+
+@condition
+def has_STAT_table(ttFont):
+    return "STAT" in ttFont
 
 
 @condition

--- a/Lib/fontbakery/profiles/stat.py
+++ b/Lib/fontbakery/profiles/stat.py
@@ -1,34 +1,36 @@
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS
 from fontbakery.message import Message
-# used to inform get_module_profile whether and how to create a profile
-from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import
+from fontbakery.status import FAIL, PASS
 
-profile_imports = [
-    ('.shared_conditions', ('is_variable_font',))
-]
+# used to inform get_module_profile whether and how to create a profile
+from fontbakery.fonts_profile import (  # NOQA pylint: disable=unused-import
+    profile_factory,
+)
+
+profile_imports = [(".shared_conditions", ("is_variable_font",))]
+
 
 @check(
-    id = 'com.google.fonts/check/varfont/stat_axis_record_for_each_axis',
-    rationale = """
+    id="com.google.fonts/check/varfont/stat_axis_record_for_each_axis",
+    rationale="""
         According to the OpenType spec, there must be an Axis Record
         for every axis defined in the fvar table.
 
         https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-records
     """,
-    conditions = ['is_variable_font'],
-    proposal = 'https://github.com/googlefonts/fontbakery/pull/3017'
+    conditions=["is_variable_font"],
+    proposal="https://github.com/googlefonts/fontbakery/pull/3017",
 )
 def com_google_fonts_check_varfont_stat_axis_record_for_each_axis(ttFont):
-    """ All fvar axes have a correspondent Axis Record on STAT table? """
-    fvar_axes = set(a.axisTag for a in ttFont['fvar'].axes)
-    stat_axes = set(a.AxisTag for a in ttFont['STAT'].table.DesignAxisRecord.Axis)
+    """All fvar axes have a correspondent Axis Record on STAT table?"""
+    fvar_axes = set(a.axisTag for a in ttFont["fvar"].axes)
+    stat_axes = set(a.AxisTag for a in ttFont["STAT"].table.DesignAxisRecord.Axis)
     missing_axes = fvar_axes - stat_axes
     if len(missing_axes) > 0:
-        yield FAIL,\
-              Message("missing-axis-records",
-                      f"STAT table is missing Axis Records for"
-                      f" the following axes: {missing_axes}")
+        yield FAIL, Message(
+            "missing-axis-records",
+            f"STAT table is missing Axis Records for"
+            f" the following axes: {missing_axes}",
+        )
     else:
         yield PASS, "STAT table has all necessary Axis Records"
-

--- a/Lib/fontbakery/profiles/stat.py
+++ b/Lib/fontbakery/profiles/stat.py
@@ -8,7 +8,7 @@ from fontbakery.fonts_profile import (  # NOQA pylint: disable=unused-import
     profile_factory,
 )
 
-profile_imports = [(".shared_conditions", ("is_variable_font",))]
+profile_imports = ((".", ("shared_conditions",)),)
 
 
 @check(
@@ -35,3 +35,74 @@ def com_google_fonts_check_varfont_stat_axis_record_for_each_axis(ttFont, config
         )
     else:
         yield PASS, "STAT table has all necessary Axis Records."
+
+
+@check(
+    id="com.adobe.fonts/check/stat_has_axis_value_tables",
+    rationale="""
+        According to the OpenType spec, in a variable font, it is strongly recommended
+        that axis value tables be included for every element of typographic subfamily
+        names for all of the named instances defined in the 'fvar' table.
+
+        Axis value tables are particularly important for variable fonts, but can also
+        be used in non-variable fonts. When used in non-variable fonts, axis value
+        tables for particular values should be implemented consistently across fonts
+        in the family.
+
+        https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables
+    """,
+    conditions=["has_STAT_table"],
+    proposal="https://github.com/googlefonts/fontbakery/issues/3090",
+)
+def com_adobe_fonts_check_stat_has_axis_value_tables(ttFont, is_variable_font):
+    """STAT table has Axis Value tables?"""
+    passed = True
+    stat_table = ttFont["STAT"].table
+
+    if len(stat_table.AxisValueArray.AxisValue) == 0:
+        yield FAIL, Message(
+            "no-axis-value-tables",
+            "STAT table has no Axis Value tables.",
+        )
+        passed = False
+
+    if is_variable_font:
+        # Collect all the values defined for each design axis in the STAT table.
+        stat_axes_values = {}
+        for axis_index, axis in enumerate(stat_table.DesignAxisRecord.Axis):
+            axis_tag = axis.AxisTag
+            axis_values = set()
+
+            # Iterate over Axis Value tables.
+            for axis_value in stat_table.AxisValueArray.AxisValue:
+                if axis_value.AxisIndex != axis_index:
+                    # Not the axis we're collecting for, skip.
+                    continue
+
+                axis_value_format = axis_value.Format
+                if axis_value_format == 2:
+                    axis_values.add(axis_value.NominalValue)
+                else:
+                    axis_values.add(axis_value.Value)
+
+            stat_axes_values[axis_tag] = axis_values
+
+        # Iterate over the 'fvar' named instances, and confirm that every coordinate
+        # can be represented by the STAT table Axis Value tables.
+        for inst in ttFont["fvar"].instances:
+            for coord_axis_tag, coord_axis_value in inst.coordinates.items():
+                if (
+                    coord_axis_tag in stat_axes_values
+                    and coord_axis_value in stat_axes_values[coord_axis_tag]
+                ):
+                    continue
+
+                yield FAIL, Message(
+                    "missing-axis-value-table",
+                    f"STAT table is missing Axis Value for"
+                    f" {coord_axis_tag!r} value '{coord_axis_value}'",
+                )
+                passed = False
+
+    if passed:
+        yield PASS, "STAT table has Axis Value tables."

--- a/Lib/fontbakery/profiles/stat.py
+++ b/Lib/fontbakery/profiles/stat.py
@@ -1,6 +1,7 @@
 from fontbakery.callable import check
 from fontbakery.message import Message
 from fontbakery.status import FAIL, PASS
+from fontbakery.utils import bullet_list
 
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import (  # NOQA pylint: disable=unused-import
@@ -21,7 +22,7 @@ profile_imports = [(".shared_conditions", ("is_variable_font",))]
     conditions=["is_variable_font"],
     proposal="https://github.com/googlefonts/fontbakery/pull/3017",
 )
-def com_google_fonts_check_varfont_stat_axis_record_for_each_axis(ttFont):
+def com_google_fonts_check_varfont_stat_axis_record_for_each_axis(ttFont, config):
     """All fvar axes have a correspondent Axis Record on STAT table?"""
     fvar_axes = set(a.axisTag for a in ttFont["fvar"].axes)
     stat_axes = set(a.AxisTag for a in ttFont["STAT"].table.DesignAxisRecord.Axis)
@@ -29,8 +30,8 @@ def com_google_fonts_check_varfont_stat_axis_record_for_each_axis(ttFont):
     if len(missing_axes) > 0:
         yield FAIL, Message(
             "missing-axis-records",
-            f"STAT table is missing Axis Records for"
-            f" the following axes: {missing_axes}",
+            f"STAT table is missing Axis Records for the following axes:\n\n"
+            f"{bullet_list(config, sorted(missing_axes))}",
         )
     else:
-        yield PASS, "STAT table has all necessary Axis Records"
+        yield PASS, "STAT table has all necessary Axis Records."

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -687,14 +687,9 @@ def com_google_fonts_check_unwanted_tables(ttFont):
         yield PASS, "There are no unwanted tables."
 
 
-@condition
-def STAT_table(ttFont):
-    return "STAT" in ttFont
-
-
 @check(
     id = 'com.google.fonts/check/STAT_strings',
-    conditions = ["STAT_table"],
+    conditions = ["has_STAT_table"],
     rationale = """
         On the STAT table, the "Italic" keyword must not be used on AxisValues
         for variation axes other than 'ital'.

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -53,7 +53,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 79
+    assert len(SET_EXPLICIT_CHECKS) == 80
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/stat_test.py
+++ b/tests/profiles/stat_test.py
@@ -22,15 +22,14 @@ def test_check_varfont_stat_axis_record_for_each_axis():
     ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
 
     # So the check must PASS
-    assert_PASS(check(ttFont), "with all necessary Axis Records...")
+    msg = assert_PASS(check(ttFont))
+    assert msg == "STAT table has all necessary Axis Records."
 
     # We then remove its first Axis Record (`wdth`):
     ttFont["STAT"].table.DesignAxisRecord.Axis.pop(0)
 
     # And now the problem should be detected::
-    assert_results_contain(
-        check(ttFont),
-        FAIL,
-        "missing-axis-records",
-        "with a missing Axis Record: (wght)...",
+    msg = assert_results_contain(check(ttFont), FAIL, "missing-axis-records")
+    assert msg == (
+        f"STAT table is missing Axis Records for the following axes:\n\n\t- wdth"
     )

--- a/tests/profiles/stat_test.py
+++ b/tests/profiles/stat_test.py
@@ -1,6 +1,6 @@
 from fontTools.ttLib import TTFont
 
-from fontbakery.checkrunner import FAIL
+from fontbakery.checkrunner import FAIL, SKIP
 from fontbakery.codetesting import (
     assert_PASS,
     assert_results_contain,
@@ -28,8 +28,58 @@ def test_check_varfont_stat_axis_record_for_each_axis():
     # We then remove its first Axis Record (`wdth`):
     ttFont["STAT"].table.DesignAxisRecord.Axis.pop(0)
 
-    # And now the problem should be detected::
+    # And now the problem should be detected:
     msg = assert_results_contain(check(ttFont), FAIL, "missing-axis-records")
     assert msg == (
-        f"STAT table is missing Axis Records for the following axes:\n\n\t- wdth"
+        "STAT table is missing Axis Records for the following axes:\n\n\t- wdth"
     )
+
+    # Now use a stactic font.
+    # The check should be skipped due to an unfulfilled condition.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/TTF/SourceSansPro-Black.ttf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: is_variable_font"
+
+
+def test_check_stat_has_axis_value_tables():
+    """Check the STAT table has at least one Axis Value table."""
+    check = CheckTester(
+        opentype_profile,
+        "com.adobe.fonts/check/stat_has_axis_value_tables",
+    )
+
+    # Our reference Cabin[wdth,wght].ttf variable font has Axis Value tables.
+    # So the check must PASS.
+    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
+    msg = assert_PASS(check(ttFont))
+    assert msg == "STAT table has Axis Value tables."
+
+    # Remove the 4th Axis Value table (index 3), belonging to 'Medium' weight.
+    # The check should FAIL.
+    ttFont["STAT"].table.AxisValueArray.AxisValue.pop(3)
+    msg = assert_results_contain(check(ttFont), FAIL, "missing-axis-value-table")
+    assert msg == "STAT table is missing Axis Value for 'wght' value '500.0'"
+
+    # Now remove all Axis Value tables by emptying the AxisValueArray.
+    # The check should FAIL.
+    ttFont["STAT"].table.AxisValueArray.AxisValue = []
+    msg = assert_results_contain(check(ttFont), FAIL, "no-axis-value-tables")
+    assert msg == "STAT table has no Axis Value tables."
+
+    # Most of the Axis Value tables in Cabin[wdth,wght].ttf are format 1.
+    # Now test with SourceSansVariable-Italic.ttf whose tables are mostly format 2.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.ttf"))
+    msg = assert_PASS(check(ttFont))
+    assert msg == "STAT table has Axis Value tables."
+
+    # Remove the 2nd Axis Value table (index 1), belonging to 'Light' weight.
+    # The check should FAIL.
+    ttFont["STAT"].table.AxisValueArray.AxisValue.pop(1)
+    msg = assert_results_contain(check(ttFont), FAIL, "missing-axis-value-table")
+    assert msg == "STAT table is missing Axis Value for 'wght' value '300.0'"
+
+    # Now use a font that has no STAT table.
+    # The check should be skipped due to an unfulfilled condition.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/TTF/SourceSansPro-Black.ttf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: has_STAT_table"

--- a/tests/profiles/stat_test.py
+++ b/tests/profiles/stat_test.py
@@ -1,30 +1,36 @@
 from fontTools.ttLib import TTFont
 
 from fontbakery.checkrunner import FAIL
-from fontbakery.codetesting import (assert_PASS,
-                                    assert_results_contain,
-                                    CheckTester,
-                                    TEST_FILE)
+from fontbakery.codetesting import (
+    assert_PASS,
+    assert_results_contain,
+    CheckTester,
+    TEST_FILE,
+)
 from fontbakery.profiles import opentype as opentype_profile
 
 
 def test_check_varfont_stat_axis_record_for_each_axis():
-    """ Check the STAT table has an Axis Record for every axis in the font. """
-    check = CheckTester(opentype_profile,
-                        "com.google.fonts/check/varfont/stat_axis_record_for_each_axis")
+    """Check the STAT table has an Axis Record for every axis in the font."""
+    check = CheckTester(
+        opentype_profile,
+        "com.google.fonts/check/varfont/stat_axis_record_for_each_axis",
+    )
 
     # Our reference Cabin[wdth,wght].ttf variable font
     # has all necessary Axis Records
     ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
 
     # So the check must PASS
-    assert_PASS(check(ttFont),
-                'with all necessary Axis Records...')
+    assert_PASS(check(ttFont), "with all necessary Axis Records...")
 
     # We then remove its first Axis Record (`wdth`):
-    ttFont['STAT'].table.DesignAxisRecord.Axis.pop(0)
+    ttFont["STAT"].table.DesignAxisRecord.Axis.pop(0)
 
     # And now the problem should be detected::
-    assert_results_contain(check(ttFont),
-                           FAIL, 'missing-axis-records',
-                           'with a missing Axis Record: (wght)...')
+    assert_results_contain(
+        check(ttFont),
+        FAIL,
+        "missing-axis-records",
+        "with a missing Axis Record: (wght)...",
+    )


### PR DESCRIPTION
Added to the OpenType profile
Validates that STAT table has Axis Value tables.
(issue #3090)