### PR TITLE
New check: com.adobe.fonts/check/sfnt_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### Added to the Universal Profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Checks that the font can be rasterized by FreeType. (issue #3642)
+  - **[com.adobe.fonts/check/sfnt_version]:** Ensures the font has the proper sfntVersion value. (issue #3388)
 
 
 ## 0.8.8 (2022-Mar-23)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -199,6 +199,7 @@ SET_EXPLICIT_CHECKS = {
     # "com.google.fonts/check/dotted_circle",
     "com.google.fonts/check/gpos7",
     "com.adobe.fonts/check/freetype_rasterizer",
+    "com.adobe.fonts/check/sfnt_version",
 }
 
 CHECKS_IN_THIS_FILE = [

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -64,6 +64,7 @@ UNIVERSAL_PROFILE_CHECKS = \
         'com.google.fonts/check/dotted_circle',
         'com.google.fonts/check/gpos7',
         'com.adobe.fonts/check/freetype_rasterizer',
+        'com.adobe.fonts/check/sfnt_version',
     ]
 
 
@@ -1708,6 +1709,42 @@ def com_adobe_fonts_check_freetype_rasterizer(font):
         )
     else:
         return PASS, "Font can be rasterized by FreeType."
+
+
+@check(
+    id="com.adobe.fonts/check/sfnt_version",
+    severity=10,
+    rationale="""
+        OpenType fonts that contain TrueType outlines should use the value of 0x00010000
+        for the sfntVersion. OpenType fonts containing CFF data (version 1 or 2) should
+        use 0x4F54544F ('OTTO', when re-interpreted as a Tag) for sfntVersion.
+
+        Fonts with the wrong sfntVersion value are rejected by FreeType.
+
+        https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory
+    """,
+    proposal="https://github.com/googlefonts/fontbakery/issues/3388",
+)
+def com_adobe_fonts_check_sfnt_version(ttFont, is_ttf, is_cff, is_cff2):
+    """Font has the proper sfntVersion value?"""
+    sfnt_version = ttFont.sfntVersion
+
+    if is_ttf and sfnt_version != "\x00\x01\x00\x00":
+        return FAIL, Message(
+            "wrong-sfnt-version-ttf",
+            "Font with TrueType outlines has incorrect sfntVersion value:"
+            f" '{sfnt_version}'",
+        )
+
+    elif (is_cff or is_cff2) and sfnt_version != "OTTO":
+        return FAIL, Message(
+            "wrong-sfnt-version-cff",
+            "Font with CFF data has incorrect sfntVersion value:"
+            f" '{sfnt_version}'",
+        )
+
+    else:
+        return PASS, "Font has the correct sfntVersion value."
 
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -2,7 +2,7 @@ import os
 
 from fontbakery.status import PASS, FAIL, WARN, INFO, SKIP
 from fontbakery.section import Section
-from fontbakery.callable import condition, check, disable
+from fontbakery.callable import check, disable
 from fontbakery.message import Message
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.profiles.opentype import OPENTYPE_PROFILE_CHECKS
@@ -10,12 +10,10 @@ from fontbakery.profiles.outline import OUTLINE_PROFILE_CHECKS
 from fontbakery.profiles.shaping import SHAPING_PROFILE_CHECKS
 from fontbakery.profiles.ufo_sources import UFO_PROFILE_CHECKS
 
-profile_imports = ('fontbakery.profiles.opentype',
-                   'fontbakery.profiles.outline',
-                   'fontbakery.profiles.shaping',
-                   'fontbakery.profiles.ufo_sources')
+profile_imports = (
+    (".", ("shared_conditions", "opentype", "outline", "shaping", "ufo_sources")),
+)
 profile = profile_factory(default_section=Section("Universal"))
-from .shared_conditions import * # pylint: disable=wildcard-import,unused-wildcard-import
 
 THIRDPARTY_CHECKS = [
     'com.google.fonts/check/ots',
@@ -1522,7 +1520,7 @@ def com_google_fonts_check_cjk_chws_feature(ttFont):
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2011',
 )
-def com_google_fonts_check_transformed_components(ttFont):
+def com_google_fonts_check_transformed_components(ttFont, is_hinted):
     """Ensure component transforms do not perform scaling or rotation."""
     failures = ""
     for glyph_name in ttFont.getGlyphOrder():
@@ -1533,7 +1531,7 @@ def com_google_fonts_check_transformed_components(ttFont):
             comp_name, transform = component.getComponentInfo()
 
             # Font is hinted, complain about *any* transformations
-            if is_hinted(ttFont):
+            if is_hinted:
                 if transform[0:4] != (1, 0, 0, 1):
                     failures += f"* {glyph_name} (component {comp_name})\n"
             # Font is unhinted, complain only about transformations where

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -53,7 +53,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 80
+    assert len(SET_EXPLICIT_CHECKS) == 81
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1076,7 +1076,7 @@ def test_check_gpos7():
                            WARN, "has-gpos7")
 
 
-def test_freetype_rasterizer():
+def test_check_freetype_rasterizer():
     """Ensure that the font can be rasterized by FreeType."""
     check = CheckTester(universal_profile, "com.adobe.fonts/check/freetype_rasterizer")
 
@@ -1091,3 +1091,41 @@ def test_freetype_rasterizer():
     font = TEST_FILE("rubik/Rubik-Italic.ttf")
     msg = assert_results_contain(check(font), FAIL, "freetype-crash")
     assert "FT_Exception:  (stack overflow)" in msg
+
+
+def test_check_sfnt_version():
+    """Ensure that the font has the proper sfntVersion value."""
+    check = CheckTester(universal_profile, "com.adobe.fonts/check/sfnt_version")
+
+    # Valid TrueType font; the check must PASS.
+    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
+    msg = assert_PASS(check(ttFont))
+    assert msg == "Font has the correct sfntVersion value."
+
+    # Change the sfntVersion to an improper value for TrueType fonts.
+    # The check should FAIL.
+    ttFont.sfntVersion = "OTTO"
+    msg = assert_results_contain(check(ttFont), FAIL, "wrong-sfnt-version-ttf")
+    assert msg == "Font with TrueType outlines has incorrect sfntVersion value: 'OTTO'"
+
+    # Valid CFF font; the check must PASS.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
+    msg = assert_PASS(check(ttFont))
+    assert msg == "Font has the correct sfntVersion value."
+
+    # Change the sfntVersion to an improper value for CFF fonts. The check should FAIL.
+    ttFont.sfntVersion = "\x00\x01\x00\x00"
+    msg = assert_results_contain(check(ttFont), FAIL, "wrong-sfnt-version-cff")
+    assert msg == (
+        "Font with CFF data has incorrect sfntVersion value: '\x00\x01\x00\x00'")
+
+    # Valid CFF2 font; the check must PASS.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Roman.otf"))
+    msg = assert_PASS(check(ttFont))
+    assert msg == "Font has the correct sfntVersion value."
+
+    # Change the sfntVersion to an improper value for CFF fonts. The check should FAIL.
+    ttFont.sfntVersion = "\x00\x01\x00\x00"
+    msg = assert_results_contain(check(ttFont), FAIL, "wrong-sfnt-version-cff")
+    assert msg == (
+        "Font with CFF data has incorrect sfntVersion value: '\x00\x01\x00\x00'")


### PR DESCRIPTION
Added to the Universal profile.
Ensures the font has the proper sfntVersion value.
(issue #3388)