### PR TITLE
check/varfont/unsupported_axes: allow slnt axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
 #### On the Universal Profile
+  - **[com.google.fonts/check/varfont/unsupported_axes]:** Allow slnt axis (PR #3795)
   - **[com.google.fonts/check/dotted_circle]:** Fix ERROR on fonts without GlyphClassDef.classDefs (issue #3736)
   - **[com.google.fonts/check/transformed_components]:** Check for any component transformation only if font is hinted, otherwise check only for flipped contour direction (one transformation dimension is flipped while the other isn't)
   - **[com.google.fonts/check/gpos7]:** Previously we checked for the existence of GSUB 5 lookups in the erroneous belief that they were not supported; GPOS 7 lookups are not supported in CoreText, but GSUB 5 lookups are fine. (issue #3689)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5361,10 +5361,10 @@ def com_google_fonts_check_varfont_duplicate_instance_names(ttFont):
 @check(
     id = 'com.google.fonts/check/varfont/unsupported_axes',
     rationale = """
-        The 'ital' and 'slnt' axes are not supported yet in Google Chrome.
+        The 'ital' axis is not supported yet in Google Chrome.
 
-        For the time being, we need to ensure that VFs do not contain either of
-        these axes. Once browser support is better, we can deprecate this check.
+        For the time being, we need to ensure that VFs do not contain this axis.
+        Once browser support is better, we can deprecate this check.
 
         For more info regarding browser support, see:
         https://arrowtype.github.io/vf-slnt-test/
@@ -5373,16 +5373,12 @@ def com_google_fonts_check_varfont_duplicate_instance_names(ttFont):
     proposal = 'https://github.com/googlefonts/fontbakery/issues/2866'
 )
 def com_google_fonts_check_varfont_unsupported_axes(ttFont):
-    """ Ensure VFs do not contain slnt or ital axes. """
-    from fontbakery.profiles.shared_conditions import slnt_axis, ital_axis
+    """ Ensure VFs do not contain the ital axis. """
+    from fontbakery.profiles.shared_conditions import ital_axis
     if ital_axis(ttFont):
         yield FAIL,\
               Message("unsupported-ital",
                       'The "ital" axis is not yet well supported on Google Chrome.')
-    elif slnt_axis(ttFont):
-        yield FAIL,\
-              Message("unsupported-slnt",
-                      'The "slnt" axis is not yet well supported on Google Chrome.')
     else:
         yield PASS, "Looks good!"
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3771,15 +3771,6 @@ def test_check_varfont_unsupported_axes():
     assert_results_contain(check(ttFont),
                            FAIL, 'unsupported-ital')
 
-    # Then we reload the font and add 'opsz'
-    # so it must also FAIL:
-    ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
-    new_axis = Axis()
-    new_axis.axisTag = "slnt"
-    ttFont["fvar"].axes.append(new_axis)
-    assert_results_contain(check(ttFont),
-                           FAIL, 'unsupported-slnt')
-
 
 def test_check_varfont_grade_reflow():
     """ Ensure VFs with the GRAD axis do not vary horizontal advance. """


### PR DESCRIPTION
## Description

slnt is now allowed. Here's some recent google/fonts prs which have it (they were blocked previously):

https://github.com/google/fonts/pull/4716
https://github.com/google/fonts/pull/4695


## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review


cc @RosaWagner 