### PR TITLE
Move exceptions to txt files to make them easier to edit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## Upcoming release: 0.8.9 (2022-May-??)
+## Upcoming release: 0.8.9 (2022-Jun-??)
 ### Noteworthy code-changes
   - Improve implementation of `is_italic` condition and provide an `is_bold` counterpart (issue #3693)
   - Nicer cancellation for terminal runner. (issue #3672)
   - The CheckTester class now takes into account the check's own `conditions`. (PR #3766)
   - Windows Terminal displays colors fine. We can now remove the win32 workaround. (issue #3779)
+  - On the `Google Fonts` profile, the lists of exceptions for **Reserved Font Names (RFN)** and **CamelCased family names**, are now placed on separate txt files (`Lib/fontbakery/data/googlefonts/*_exceptions.txt`) to facilitate their future editing. (issue #3707)
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)

--- a/Lib/fontbakery/data/googlefonts/camelcased_familyname_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/camelcased_familyname_exceptions.txt
@@ -1,0 +1,24 @@
+# In general, we would not like to have camel-cased
+# font family names in the Google Fonts collection
+# but there are a few exceptions to that rule,
+# that we keep listed here, for now.
+
+3D # seen in "Rock 3D"
+ABeeZee
+BenchNine
+BhuTuka # seen in "BhuTuka Expanded One"
+DotGothic # seen in "DotGothic16"
+DynaPuff
+FakeFont
+JetBrains # seen in "JetBrains Mono"
+McLaren
+MedievalSharp
+RocknRoll # seen in "RocknRoll One"
+BIZ UDGothic
+BIZ UDPGothic
+BIZ UDMincho
+BIZ UDPMincho
+UnifrakturCook
+UnifrakturMaguntia
+MonteCarlo
+WindSong

--- a/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
@@ -1,0 +1,9 @@
+# These are the very few font families where we accept usage of
+# a Reserved Font Name. These are typically fonts that had already
+# been published previously with an RFN, or fonts which benefit from
+# an agreement with Google Fonts.
+#
+# For now we'll leave this empty because the
+# actual long list of familynames we had here
+# still needs to be more carefully reviewed.
+# See https://github.com/googlefonts/fontbakery/issues/3612

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -449,29 +449,18 @@ def camelcased_familyname_exception(familyname):
        familynames but there are a few exceptions to that
        rule, that we keep listed here, for now.
     '''
-    for exception in [
-        "3D", # seen in "Rock 3D"
-        "ABeeZee",
-        "BenchNine",
-        "BhuTuka", # seen in "BhuTuka Expanded One"
-        "DotGothic", # seen in "DotGothic16"
-        "DynaPuff",
-        "FakeFont",
-        "JetBrains", # seen in "JetBrains Mono"
-        "McLaren",
-        "MedievalSharp",
-        "RocknRoll", # seen in "RocknRoll One"
-        "BIZ UDGothic",
-        "BIZ UDPGothic",
-        "BIZ UDMincho",
-        "BIZ UDPMincho",
-        "UnifrakturCook",
-        "UnifrakturMaguntia",
-        "MonteCarlo",
-        "WindSong",
-    ]:
+    from pkg_resources import resource_filename
+
+    camelcase_exceptions_txt = 'data/googlefonts/camelcased_familyname_exceptions.txt'
+    filename = resource_filename('fontbakery', camelcase_exceptions_txt)
+    for exception in open(filename, "r").readlines():
+        exception = exception.split('#')[0].strip()
+        if exception == "":
+            continue
+
         if exception in familyname:
             return True
+
 
 @condition
 def rfn_exception(familyname):
@@ -480,12 +469,15 @@ def rfn_exception(familyname):
        been published previously with an RFN, or fonts which benefit from
        an agreement with Google Fonts.
     '''
-    RNF_EXCEPTIONS = [] # For now we'll leave this empty because the
-                        # actual long list of familynames we had here
-                        # still needs to be more carefully reviewed.
-                        # See https://github.com/googlefonts/fontbakery/issues/3612
+    from pkg_resources import resource_filename
 
-    for exception in RNF_EXCEPTIONS:
+    rfn_exceptions_txt = 'data/googlefonts/reserved_font_name_exceptions.txt'
+    filename = resource_filename('fontbakery', rfn_exceptions_txt)
+    for exception in open(filename, "r").readlines():
+        exception = exception.split('#')[0].strip()
+        if exception == "":
+            continue
+
         if exception in familyname:
             return True
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
               'fontbakery.commands',
               'fontbakery.sphinx_extensions'
               ],
-    package_data={'fontbakery': ['data/*.cache']},
+    package_data={'fontbakery': ['data/*.cache',
+                                 'data/googlefonts/*_exceptions.txt']},
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',


### PR DESCRIPTION
(issue #3707)