### PR TITLE
FontVal: save reports in temporary directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - The CheckTester class now takes into account the check's own `conditions`. (PR #3766)
   - Windows Terminal displays colors fine. We can now remove the win32 workaround. (issue #3779)
   - On the `Google Fonts` profile, the lists of exceptions for **Reserved Font Names (RFN)** and **CamelCased family names**, are now placed on separate txt files (`Lib/fontbakery/data/googlefonts/*_exceptions.txt`) to facilitate their future editing. (issue #3707)
+  - The FontVal checks report will be written to a temporary directory now, making it safe to run the checks in parallel on multiple fonts.
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)


### PR DESCRIPTION
## Description
This pull request changes the FontVal profile to save reports in a temporary directory, so it's safe to run the checks on multiple files in parallel.

@felipesanches :)

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

