### PR TITLE
Update fonts public proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Windows Terminal displays colors fine. We can now remove the win32 workaround. (issue #3779)
   - On the `Google Fonts` profile, the lists of exceptions for **Reserved Font Names (RFN)** and **CamelCased family names**, are now placed on separate txt files (`Lib/fontbakery/data/googlefonts/*_exceptions.txt`) to facilitate their future editing. (issue #3707)
   - The FontVal checks report will be written to a temporary directory now, making it safe to run the checks in parallel on multiple fonts.
+  - Updated the Google Fonts metadata proto format.
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)

--- a/Lib/fontbakery/fonts_public.proto
+++ b/Lib/fontbakery/fonts_public.proto
@@ -12,7 +12,7 @@ message FamilyProto {
   required string name = 1;
   required string designer = 2;
   required string license = 3;
-  required string category = 4;
+  repeated string category = 4;  // Only the LAST value is used by Google Fonts
   required string date_added = 5;
   repeated FontProto fonts = 6;
   repeated string aliases = 7;
@@ -24,9 +24,10 @@ message FamilyProto {
   optional bool is_noto = 13;
   repeated string languages = 14;
   repeated FamilyFallbackProto fallbacks = 15;
-  map<string, string> sample_glyphs = 16;
+  repeated GlyphGroupProto sample_glyphs = 16;
   optional SampleTextProto sample_text = 17;
   optional string display_name = 18;
+  optional FontType source_type = 19 [default = TYPE_TTF];
 
   // Next = 19
 }
@@ -53,6 +54,7 @@ message AxisSegmentProto {
 message SourceProto {
   optional string repository_url = 1;
   optional string commit = 2;
+  optional string archive_url = 3;
 }
 
 enum TargetTypeProto {
@@ -78,8 +80,55 @@ message FamilyFallbackProto {
   // Next = 6
 }
 
-// Corresponds to SampleTextProto in
-// java/com/google/fonts/backend/spanner/google_fonts_proto.proto
+//
+// LANG METADATA
+//
+
+// A region or territory as defined in the CLDR
+message RegionProto {
+  optional string id = 1;  // Region codes defined by CLDR
+  optional string name = 2;
+  optional int32 population = 3;
+  repeated string region_group = 4;
+
+  // Next = 5;
+}
+
+message ScriptProto {
+  optional string id = 1;  // Script codes defined by CLDR
+  optional string name = 2;
+
+  // Next = 3;
+}
+
+message LanguageProto {
+  optional string id = 1;  // Either ${lang} or ${lang}_${script}
+  optional string language = 2;  // BCP 47
+  optional string script = 3;
+  optional string name = 4;
+  optional string preferred_name = 5;
+  optional string autonym = 6;  // Name of language as written in that language
+  optional int32 population = 7;
+  repeated string region = 8;
+  optional ExemplarCharsProto exemplar_chars = 9;
+  optional SampleTextProto sample_text = 10;
+  optional bool historical = 11;
+
+  // Next = 12;
+}
+
+// Space-separated lists of characters representative of a given language.
+message ExemplarCharsProto {
+  optional string base = 1;
+  optional string auxiliary = 2;
+  optional string marks = 3;
+  optional string numerals = 4;
+  optional string punctuation = 5;
+  optional string index = 6;
+
+  // Next = 7;
+}
+
 message SampleTextProto {
   optional string masthead_full = 1;
   optional string masthead_partial = 2;
@@ -93,4 +142,19 @@ message SampleTextProto {
   optional string specimen_32 = 10;
   optional string specimen_21 = 11;
   optional string specimen_16 = 12;
+}
+
+message GlyphGroupProto {
+  optional string name = 1;
+  optional string glyphs = 2;
+}
+
+enum FontType {
+  TYPE_TTF = 0;
+  TYPE_EOT = 1;
+  TYPE_SVG = 2;
+  TYPE_WOFF = 3;
+  TYPE_WOFF2 = 5;
+  TYPE_SWF = 4;
+  TYPE_OTF = 6;
 }

--- a/Lib/fontbakery/fonts_public_pb2.py
+++ b/Lib/fontbakery/fonts_public_pb2.py
@@ -4,6 +4,7 @@
 """Generated protocol buffer code."""
 from google.protobuf.internal import enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -14,678 +15,40 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor.FileDescriptor(
-  name='fonts_public.proto',
-  package='google.fonts_public',
-  syntax='proto2',
-  serialized_options=b'\n\026com.google.fonts.protoB\013FontsPublic',
-  create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x12\x66onts_public.proto\x12\x13google.fonts_public\"\x8e\x06\n\x0b\x46\x61milyProto\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\x10\n\x08\x64\x65signer\x18\x02 \x02(\t\x12\x0f\n\x07license\x18\x03 \x02(\t\x12\x10\n\x08\x63\x61tegory\x18\x04 \x02(\t\x12\x12\n\ndate_added\x18\x05 \x02(\t\x12-\n\x05\x66onts\x18\x06 \x03(\x0b\x32\x1e.google.fonts_public.FontProto\x12\x0f\n\x07\x61liases\x18\x07 \x03(\t\x12\x0f\n\x07subsets\x18\x08 \x03(\t\x12\x19\n\x11ttf_autohint_args\x18\t \x01(\t\x12\x33\n\x04\x61xes\x18\n \x03(\x0b\x32%.google.fonts_public.AxisSegmentProto\x12\x62\n\x1aregistry_default_overrides\x18\x0b \x03(\x0b\x32>.google.fonts_public.FamilyProto.RegistryDefaultOverridesEntry\x12\x30\n\x06source\x18\x0c \x01(\x0b\x32 .google.fonts_public.SourceProto\x12\x0f\n\x07is_noto\x18\r \x01(\x08\x12\x11\n\tlanguages\x18\x0e \x03(\t\x12;\n\tfallbacks\x18\x0f \x03(\x0b\x32(.google.fonts_public.FamilyFallbackProto\x12I\n\rsample_glyphs\x18\x10 \x03(\x0b\x32\x32.google.fonts_public.FamilyProto.SampleGlyphsEntry\x12\x39\n\x0bsample_text\x18\x11 \x01(\x0b\x32$.google.fonts_public.SampleTextProto\x12\x14\n\x0c\x64isplay_name\x18\x12 \x01(\t\x1a?\n\x1dRegistryDefaultOverridesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02:\x02\x38\x01\x1a\x33\n\x11SampleGlyphsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x8a\x01\n\tFontProto\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\r\n\x05style\x18\x02 \x02(\t\x12\x0e\n\x06weight\x18\x03 \x02(\x05\x12\x10\n\x08\x66ilename\x18\x04 \x02(\t\x12\x18\n\x10post_script_name\x18\x05 \x02(\t\x12\x11\n\tfull_name\x18\x06 \x02(\t\x12\x11\n\tcopyright\x18\x07 \x01(\t\"Z\n\x10\x41xisSegmentProto\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x02\x12\x11\n\tmax_value\x18\x04 \x01(\x02J\x04\x08\x03\x10\x04R\rdefault_value\"5\n\x0bSourceProto\x12\x16\n\x0erepository_url\x18\x01 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x02 \x01(\t\"H\n\x0bTargetProto\x12\x39\n\x0btarget_type\x18\x01 \x01(\x0e\x32$.google.fonts_public.TargetTypeProto\"\xcc\x01\n\x13\x46\x61milyFallbackProto\x12:\n\x0b\x61xis_target\x18\x01 \x03(\x0b\x32%.google.fonts_public.AxisSegmentProto\x12\x30\n\x06target\x18\x02 \x03(\x0b\x32 .google.fonts_public.TargetProto\x12\x17\n\x0fsize_adjust_pct\x18\x03 \x01(\x02\x12\x1b\n\x13\x61scent_override_pct\x18\x05 \x01(\x02\x12\x11\n\tlocal_src\x18\x04 \x03(\t\"\x84\x02\n\x0fSampleTextProto\x12\x15\n\rmasthead_full\x18\x01 \x01(\t\x12\x18\n\x10masthead_partial\x18\x02 \x01(\t\x12\x0e\n\x06styles\x18\x03 \x01(\t\x12\x0e\n\x06tester\x18\x04 \x01(\t\x12\x11\n\tposter_sm\x18\x05 \x01(\t\x12\x11\n\tposter_md\x18\x06 \x01(\t\x12\x11\n\tposter_lg\x18\x07 \x01(\t\x12\x13\n\x0bspecimen_48\x18\x08 \x01(\t\x12\x13\n\x0bspecimen_36\x18\t \x01(\t\x12\x13\n\x0bspecimen_32\x18\n \x01(\t\x12\x13\n\x0bspecimen_21\x18\x0b \x01(\t\x12\x13\n\x0bspecimen_16\x18\x0c \x01(\t*\x92\x01\n\x0fTargetTypeProto\x12\x16\n\x12TARGET_UNSPECIFIED\x10\x00\x12\x15\n\x11TARGET_OS_WINDOWS\x10\x01\x12\x11\n\rTARGET_OS_MAC\x10\x02\x12\x13\n\x0fTARGET_OS_LINUX\x10\x03\x12\x15\n\x11TARGET_OS_ANDROID\x10\x04\x12\x11\n\rTARGET_OS_IOS\x10\x05\x42%\n\x16\x63om.google.fonts.protoB\x0b\x46ontsPublic'
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12\x66onts_public.proto\x12\x13google.fonts_public\"\x89\x06\n\x0b\x46\x61milyProto\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\x10\n\x08\x64\x65signer\x18\x02 \x02(\t\x12\x0f\n\x07license\x18\x03 \x02(\t\x12\x10\n\x08\x63\x61tegory\x18\x04 \x03(\t\x12\x12\n\ndate_added\x18\x05 \x02(\t\x12-\n\x05\x66onts\x18\x06 \x03(\x0b\x32\x1e.google.fonts_public.FontProto\x12\x0f\n\x07\x61liases\x18\x07 \x03(\t\x12\x0f\n\x07subsets\x18\x08 \x03(\t\x12\x19\n\x11ttf_autohint_args\x18\t \x01(\t\x12\x33\n\x04\x61xes\x18\n \x03(\x0b\x32%.google.fonts_public.AxisSegmentProto\x12\x62\n\x1aregistry_default_overrides\x18\x0b \x03(\x0b\x32>.google.fonts_public.FamilyProto.RegistryDefaultOverridesEntry\x12\x30\n\x06source\x18\x0c \x01(\x0b\x32 .google.fonts_public.SourceProto\x12\x0f\n\x07is_noto\x18\r \x01(\x08\x12\x11\n\tlanguages\x18\x0e \x03(\t\x12;\n\tfallbacks\x18\x0f \x03(\x0b\x32(.google.fonts_public.FamilyFallbackProto\x12;\n\rsample_glyphs\x18\x10 \x03(\x0b\x32$.google.fonts_public.GlyphGroupProto\x12\x39\n\x0bsample_text\x18\x11 \x01(\x0b\x32$.google.fonts_public.SampleTextProto\x12\x14\n\x0c\x64isplay_name\x18\x12 \x01(\t\x12<\n\x0bsource_type\x18\x13 \x01(\x0e\x32\x1d.google.fonts_public.FontType:\x08TYPE_TTF\x1a?\n\x1dRegistryDefaultOverridesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02:\x02\x38\x01\"\x8a\x01\n\tFontProto\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\r\n\x05style\x18\x02 \x02(\t\x12\x0e\n\x06weight\x18\x03 \x02(\x05\x12\x10\n\x08\x66ilename\x18\x04 \x02(\t\x12\x18\n\x10post_script_name\x18\x05 \x02(\t\x12\x11\n\tfull_name\x18\x06 \x02(\t\x12\x11\n\tcopyright\x18\x07 \x01(\t\"Z\n\x10\x41xisSegmentProto\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x02\x12\x11\n\tmax_value\x18\x04 \x01(\x02J\x04\x08\x03\x10\x04R\rdefault_value\"J\n\x0bSourceProto\x12\x16\n\x0erepository_url\x18\x01 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x02 \x01(\t\x12\x13\n\x0b\x61rchive_url\x18\x03 \x01(\t\"H\n\x0bTargetProto\x12\x39\n\x0btarget_type\x18\x01 \x01(\x0e\x32$.google.fonts_public.TargetTypeProto\"\xcc\x01\n\x13\x46\x61milyFallbackProto\x12:\n\x0b\x61xis_target\x18\x01 \x03(\x0b\x32%.google.fonts_public.AxisSegmentProto\x12\x30\n\x06target\x18\x02 \x03(\x0b\x32 .google.fonts_public.TargetProto\x12\x17\n\x0fsize_adjust_pct\x18\x03 \x01(\x02\x12\x1b\n\x13\x61scent_override_pct\x18\x05 \x01(\x02\x12\x11\n\tlocal_src\x18\x04 \x03(\t\"Q\n\x0bRegionProto\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x12\n\npopulation\x18\x03 \x01(\x05\x12\x14\n\x0cregion_group\x18\x04 \x03(\t\"\'\n\x0bScriptProto\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"\xa8\x02\n\rLanguageProto\x12\n\n\x02id\x18\x01 \x01(\t\x12\x10\n\x08language\x18\x02 \x01(\t\x12\x0e\n\x06script\x18\x03 \x01(\t\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x16\n\x0epreferred_name\x18\x05 \x01(\t\x12\x0f\n\x07\x61utonym\x18\x06 \x01(\t\x12\x12\n\npopulation\x18\x07 \x01(\x05\x12\x0e\n\x06region\x18\x08 \x03(\t\x12?\n\x0e\x65xemplar_chars\x18\t \x01(\x0b\x32\'.google.fonts_public.ExemplarCharsProto\x12\x39\n\x0bsample_text\x18\n \x01(\x0b\x32$.google.fonts_public.SampleTextProto\x12\x12\n\nhistorical\x18\x0b \x01(\x08\"z\n\x12\x45xemplarCharsProto\x12\x0c\n\x04\x62\x61se\x18\x01 \x01(\t\x12\x11\n\tauxiliary\x18\x02 \x01(\t\x12\r\n\x05marks\x18\x03 \x01(\t\x12\x10\n\x08numerals\x18\x04 \x01(\t\x12\x13\n\x0bpunctuation\x18\x05 \x01(\t\x12\r\n\x05index\x18\x06 \x01(\t\"\x84\x02\n\x0fSampleTextProto\x12\x15\n\rmasthead_full\x18\x01 \x01(\t\x12\x18\n\x10masthead_partial\x18\x02 \x01(\t\x12\x0e\n\x06styles\x18\x03 \x01(\t\x12\x0e\n\x06tester\x18\x04 \x01(\t\x12\x11\n\tposter_sm\x18\x05 \x01(\t\x12\x11\n\tposter_md\x18\x06 \x01(\t\x12\x11\n\tposter_lg\x18\x07 \x01(\t\x12\x13\n\x0bspecimen_48\x18\x08 \x01(\t\x12\x13\n\x0bspecimen_36\x18\t \x01(\t\x12\x13\n\x0bspecimen_32\x18\n \x01(\t\x12\x13\n\x0bspecimen_21\x18\x0b \x01(\t\x12\x13\n\x0bspecimen_16\x18\x0c \x01(\t\"/\n\x0fGlyphGroupProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06glyphs\x18\x02 \x01(\t*\x92\x01\n\x0fTargetTypeProto\x12\x16\n\x12TARGET_UNSPECIFIED\x10\x00\x12\x15\n\x11TARGET_OS_WINDOWS\x10\x01\x12\x11\n\rTARGET_OS_MAC\x10\x02\x12\x13\n\x0fTARGET_OS_LINUX\x10\x03\x12\x15\n\x11TARGET_OS_ANDROID\x10\x04\x12\x11\n\rTARGET_OS_IOS\x10\x05*o\n\x08\x46ontType\x12\x0c\n\x08TYPE_TTF\x10\x00\x12\x0c\n\x08TYPE_EOT\x10\x01\x12\x0c\n\x08TYPE_SVG\x10\x02\x12\r\n\tTYPE_WOFF\x10\x03\x12\x0e\n\nTYPE_WOFF2\x10\x05\x12\x0c\n\x08TYPE_SWF\x10\x04\x12\x0c\n\x08TYPE_OTF\x10\x06\x42%\n\x16\x63om.google.fonts.protoB\x0b\x46ontsPublic')
 
-_TARGETTYPEPROTO = _descriptor.EnumDescriptor(
-  name='TargetTypeProto',
-  full_name='google.fonts_public.TargetTypeProto',
-  filename=None,
-  file=DESCRIPTOR,
-  create_key=_descriptor._internal_create_key,
-  values=[
-    _descriptor.EnumValueDescriptor(
-      name='TARGET_UNSPECIFIED', index=0, number=0,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='TARGET_OS_WINDOWS', index=1, number=1,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='TARGET_OS_MAC', index=2, number=2,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='TARGET_OS_LINUX', index=3, number=3,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='TARGET_OS_ANDROID', index=4, number=4,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='TARGET_OS_IOS', index=5, number=5,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-  ],
-  containing_type=None,
-  serialized_options=None,
-  serialized_start=1661,
-  serialized_end=1807,
-)
-_sym_db.RegisterEnumDescriptor(_TARGETTYPEPROTO)
-
+_TARGETTYPEPROTO = DESCRIPTOR.enum_types_by_name['TargetTypeProto']
 TargetTypeProto = enum_type_wrapper.EnumTypeWrapper(_TARGETTYPEPROTO)
+_FONTTYPE = DESCRIPTOR.enum_types_by_name['FontType']
+FontType = enum_type_wrapper.EnumTypeWrapper(_FONTTYPE)
 TARGET_UNSPECIFIED = 0
 TARGET_OS_WINDOWS = 1
 TARGET_OS_MAC = 2
 TARGET_OS_LINUX = 3
 TARGET_OS_ANDROID = 4
 TARGET_OS_IOS = 5
+TYPE_TTF = 0
+TYPE_EOT = 1
+TYPE_SVG = 2
+TYPE_WOFF = 3
+TYPE_WOFF2 = 5
+TYPE_SWF = 4
+TYPE_OTF = 6
 
 
-
-_FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY = _descriptor.Descriptor(
-  name='RegistryDefaultOverridesEntry',
-  full_name='google.fonts_public.FamilyProto.RegistryDefaultOverridesEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='google.fonts_public.FamilyProto.RegistryDefaultOverridesEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='google.fonts_public.FamilyProto.RegistryDefaultOverridesEntry.value', index=1,
-      number=2, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=b'8\001',
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=710,
-  serialized_end=773,
-)
-
-_FAMILYPROTO_SAMPLEGLYPHSENTRY = _descriptor.Descriptor(
-  name='SampleGlyphsEntry',
-  full_name='google.fonts_public.FamilyProto.SampleGlyphsEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='google.fonts_public.FamilyProto.SampleGlyphsEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='google.fonts_public.FamilyProto.SampleGlyphsEntry.value', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=b'8\001',
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=775,
-  serialized_end=826,
-)
-
-_FAMILYPROTO = _descriptor.Descriptor(
-  name='FamilyProto',
-  full_name='google.fonts_public.FamilyProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='google.fonts_public.FamilyProto.name', index=0,
-      number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='designer', full_name='google.fonts_public.FamilyProto.designer', index=1,
-      number=2, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='license', full_name='google.fonts_public.FamilyProto.license', index=2,
-      number=3, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='category', full_name='google.fonts_public.FamilyProto.category', index=3,
-      number=4, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='date_added', full_name='google.fonts_public.FamilyProto.date_added', index=4,
-      number=5, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='fonts', full_name='google.fonts_public.FamilyProto.fonts', index=5,
-      number=6, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='aliases', full_name='google.fonts_public.FamilyProto.aliases', index=6,
-      number=7, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='subsets', full_name='google.fonts_public.FamilyProto.subsets', index=7,
-      number=8, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='ttf_autohint_args', full_name='google.fonts_public.FamilyProto.ttf_autohint_args', index=8,
-      number=9, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='axes', full_name='google.fonts_public.FamilyProto.axes', index=9,
-      number=10, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='registry_default_overrides', full_name='google.fonts_public.FamilyProto.registry_default_overrides', index=10,
-      number=11, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='source', full_name='google.fonts_public.FamilyProto.source', index=11,
-      number=12, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='is_noto', full_name='google.fonts_public.FamilyProto.is_noto', index=12,
-      number=13, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='languages', full_name='google.fonts_public.FamilyProto.languages', index=13,
-      number=14, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='fallbacks', full_name='google.fonts_public.FamilyProto.fallbacks', index=14,
-      number=15, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='sample_glyphs', full_name='google.fonts_public.FamilyProto.sample_glyphs', index=15,
-      number=16, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='sample_text', full_name='google.fonts_public.FamilyProto.sample_text', index=16,
-      number=17, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='display_name', full_name='google.fonts_public.FamilyProto.display_name', index=17,
-      number=18, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[_FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY, _FAMILYPROTO_SAMPLEGLYPHSENTRY, ],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=44,
-  serialized_end=826,
-)
-
-
-_FONTPROTO = _descriptor.Descriptor(
-  name='FontProto',
-  full_name='google.fonts_public.FontProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='google.fonts_public.FontProto.name', index=0,
-      number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='style', full_name='google.fonts_public.FontProto.style', index=1,
-      number=2, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='weight', full_name='google.fonts_public.FontProto.weight', index=2,
-      number=3, type=5, cpp_type=1, label=2,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='filename', full_name='google.fonts_public.FontProto.filename', index=3,
-      number=4, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='post_script_name', full_name='google.fonts_public.FontProto.post_script_name', index=4,
-      number=5, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='full_name', full_name='google.fonts_public.FontProto.full_name', index=5,
-      number=6, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='copyright', full_name='google.fonts_public.FontProto.copyright', index=6,
-      number=7, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=829,
-  serialized_end=967,
-)
-
-
-_AXISSEGMENTPROTO = _descriptor.Descriptor(
-  name='AxisSegmentProto',
-  full_name='google.fonts_public.AxisSegmentProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='tag', full_name='google.fonts_public.AxisSegmentProto.tag', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='min_value', full_name='google.fonts_public.AxisSegmentProto.min_value', index=1,
-      number=2, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='max_value', full_name='google.fonts_public.AxisSegmentProto.max_value', index=2,
-      number=4, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=969,
-  serialized_end=1059,
-)
-
-
-_SOURCEPROTO = _descriptor.Descriptor(
-  name='SourceProto',
-  full_name='google.fonts_public.SourceProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='repository_url', full_name='google.fonts_public.SourceProto.repository_url', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='commit', full_name='google.fonts_public.SourceProto.commit', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1061,
-  serialized_end=1114,
-)
-
-
-_TARGETPROTO = _descriptor.Descriptor(
-  name='TargetProto',
-  full_name='google.fonts_public.TargetProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='target_type', full_name='google.fonts_public.TargetProto.target_type', index=0,
-      number=1, type=14, cpp_type=8, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1116,
-  serialized_end=1188,
-)
-
-
-_FAMILYFALLBACKPROTO = _descriptor.Descriptor(
-  name='FamilyFallbackProto',
-  full_name='google.fonts_public.FamilyFallbackProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='axis_target', full_name='google.fonts_public.FamilyFallbackProto.axis_target', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='target', full_name='google.fonts_public.FamilyFallbackProto.target', index=1,
-      number=2, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='size_adjust_pct', full_name='google.fonts_public.FamilyFallbackProto.size_adjust_pct', index=2,
-      number=3, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='ascent_override_pct', full_name='google.fonts_public.FamilyFallbackProto.ascent_override_pct', index=3,
-      number=5, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='local_src', full_name='google.fonts_public.FamilyFallbackProto.local_src', index=4,
-      number=4, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1191,
-  serialized_end=1395,
-)
-
-
-_SAMPLETEXTPROTO = _descriptor.Descriptor(
-  name='SampleTextProto',
-  full_name='google.fonts_public.SampleTextProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='masthead_full', full_name='google.fonts_public.SampleTextProto.masthead_full', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='masthead_partial', full_name='google.fonts_public.SampleTextProto.masthead_partial', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='styles', full_name='google.fonts_public.SampleTextProto.styles', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='tester', full_name='google.fonts_public.SampleTextProto.tester', index=3,
-      number=4, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='poster_sm', full_name='google.fonts_public.SampleTextProto.poster_sm', index=4,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='poster_md', full_name='google.fonts_public.SampleTextProto.poster_md', index=5,
-      number=6, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='poster_lg', full_name='google.fonts_public.SampleTextProto.poster_lg', index=6,
-      number=7, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='specimen_48', full_name='google.fonts_public.SampleTextProto.specimen_48', index=7,
-      number=8, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='specimen_36', full_name='google.fonts_public.SampleTextProto.specimen_36', index=8,
-      number=9, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='specimen_32', full_name='google.fonts_public.SampleTextProto.specimen_32', index=9,
-      number=10, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='specimen_21', full_name='google.fonts_public.SampleTextProto.specimen_21', index=10,
-      number=11, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='specimen_16', full_name='google.fonts_public.SampleTextProto.specimen_16', index=11,
-      number=12, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1398,
-  serialized_end=1658,
-)
-
-_FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY.containing_type = _FAMILYPROTO
-_FAMILYPROTO_SAMPLEGLYPHSENTRY.containing_type = _FAMILYPROTO
-_FAMILYPROTO.fields_by_name['fonts'].message_type = _FONTPROTO
-_FAMILYPROTO.fields_by_name['axes'].message_type = _AXISSEGMENTPROTO
-_FAMILYPROTO.fields_by_name['registry_default_overrides'].message_type = _FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY
-_FAMILYPROTO.fields_by_name['source'].message_type = _SOURCEPROTO
-_FAMILYPROTO.fields_by_name['fallbacks'].message_type = _FAMILYFALLBACKPROTO
-_FAMILYPROTO.fields_by_name['sample_glyphs'].message_type = _FAMILYPROTO_SAMPLEGLYPHSENTRY
-_FAMILYPROTO.fields_by_name['sample_text'].message_type = _SAMPLETEXTPROTO
-_TARGETPROTO.fields_by_name['target_type'].enum_type = _TARGETTYPEPROTO
-_FAMILYFALLBACKPROTO.fields_by_name['axis_target'].message_type = _AXISSEGMENTPROTO
-_FAMILYFALLBACKPROTO.fields_by_name['target'].message_type = _TARGETPROTO
-DESCRIPTOR.message_types_by_name['FamilyProto'] = _FAMILYPROTO
-DESCRIPTOR.message_types_by_name['FontProto'] = _FONTPROTO
-DESCRIPTOR.message_types_by_name['AxisSegmentProto'] = _AXISSEGMENTPROTO
-DESCRIPTOR.message_types_by_name['SourceProto'] = _SOURCEPROTO
-DESCRIPTOR.message_types_by_name['TargetProto'] = _TARGETPROTO
-DESCRIPTOR.message_types_by_name['FamilyFallbackProto'] = _FAMILYFALLBACKPROTO
-DESCRIPTOR.message_types_by_name['SampleTextProto'] = _SAMPLETEXTPROTO
-DESCRIPTOR.enum_types_by_name['TargetTypeProto'] = _TARGETTYPEPROTO
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
+_FAMILYPROTO = DESCRIPTOR.message_types_by_name['FamilyProto']
+_FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY = _FAMILYPROTO.nested_types_by_name['RegistryDefaultOverridesEntry']
+_FONTPROTO = DESCRIPTOR.message_types_by_name['FontProto']
+_AXISSEGMENTPROTO = DESCRIPTOR.message_types_by_name['AxisSegmentProto']
+_SOURCEPROTO = DESCRIPTOR.message_types_by_name['SourceProto']
+_TARGETPROTO = DESCRIPTOR.message_types_by_name['TargetProto']
+_FAMILYFALLBACKPROTO = DESCRIPTOR.message_types_by_name['FamilyFallbackProto']
+_REGIONPROTO = DESCRIPTOR.message_types_by_name['RegionProto']
+_SCRIPTPROTO = DESCRIPTOR.message_types_by_name['ScriptProto']
+_LANGUAGEPROTO = DESCRIPTOR.message_types_by_name['LanguageProto']
+_EXEMPLARCHARSPROTO = DESCRIPTOR.message_types_by_name['ExemplarCharsProto']
+_SAMPLETEXTPROTO = DESCRIPTOR.message_types_by_name['SampleTextProto']
+_GLYPHGROUPPROTO = DESCRIPTOR.message_types_by_name['GlyphGroupProto']
 FamilyProto = _reflection.GeneratedProtocolMessageType('FamilyProto', (_message.Message,), {
 
   'RegistryDefaultOverridesEntry' : _reflection.GeneratedProtocolMessageType('RegistryDefaultOverridesEntry', (_message.Message,), {
@@ -694,20 +57,12 @@ FamilyProto = _reflection.GeneratedProtocolMessageType('FamilyProto', (_message.
     # @@protoc_insertion_point(class_scope:google.fonts_public.FamilyProto.RegistryDefaultOverridesEntry)
     })
   ,
-
-  'SampleGlyphsEntry' : _reflection.GeneratedProtocolMessageType('SampleGlyphsEntry', (_message.Message,), {
-    'DESCRIPTOR' : _FAMILYPROTO_SAMPLEGLYPHSENTRY,
-    '__module__' : 'fonts_public_pb2'
-    # @@protoc_insertion_point(class_scope:google.fonts_public.FamilyProto.SampleGlyphsEntry)
-    })
-  ,
   'DESCRIPTOR' : _FAMILYPROTO,
   '__module__' : 'fonts_public_pb2'
   # @@protoc_insertion_point(class_scope:google.fonts_public.FamilyProto)
   })
 _sym_db.RegisterMessage(FamilyProto)
 _sym_db.RegisterMessage(FamilyProto.RegistryDefaultOverridesEntry)
-_sym_db.RegisterMessage(FamilyProto.SampleGlyphsEntry)
 
 FontProto = _reflection.GeneratedProtocolMessageType('FontProto', (_message.Message,), {
   'DESCRIPTOR' : _FONTPROTO,
@@ -744,6 +99,34 @@ FamilyFallbackProto = _reflection.GeneratedProtocolMessageType('FamilyFallbackPr
   })
 _sym_db.RegisterMessage(FamilyFallbackProto)
 
+RegionProto = _reflection.GeneratedProtocolMessageType('RegionProto', (_message.Message,), {
+  'DESCRIPTOR' : _REGIONPROTO,
+  '__module__' : 'fonts_public_pb2'
+  # @@protoc_insertion_point(class_scope:google.fonts_public.RegionProto)
+  })
+_sym_db.RegisterMessage(RegionProto)
+
+ScriptProto = _reflection.GeneratedProtocolMessageType('ScriptProto', (_message.Message,), {
+  'DESCRIPTOR' : _SCRIPTPROTO,
+  '__module__' : 'fonts_public_pb2'
+  # @@protoc_insertion_point(class_scope:google.fonts_public.ScriptProto)
+  })
+_sym_db.RegisterMessage(ScriptProto)
+
+LanguageProto = _reflection.GeneratedProtocolMessageType('LanguageProto', (_message.Message,), {
+  'DESCRIPTOR' : _LANGUAGEPROTO,
+  '__module__' : 'fonts_public_pb2'
+  # @@protoc_insertion_point(class_scope:google.fonts_public.LanguageProto)
+  })
+_sym_db.RegisterMessage(LanguageProto)
+
+ExemplarCharsProto = _reflection.GeneratedProtocolMessageType('ExemplarCharsProto', (_message.Message,), {
+  'DESCRIPTOR' : _EXEMPLARCHARSPROTO,
+  '__module__' : 'fonts_public_pb2'
+  # @@protoc_insertion_point(class_scope:google.fonts_public.ExemplarCharsProto)
+  })
+_sym_db.RegisterMessage(ExemplarCharsProto)
+
 SampleTextProto = _reflection.GeneratedProtocolMessageType('SampleTextProto', (_message.Message,), {
   'DESCRIPTOR' : _SAMPLETEXTPROTO,
   '__module__' : 'fonts_public_pb2'
@@ -751,8 +134,47 @@ SampleTextProto = _reflection.GeneratedProtocolMessageType('SampleTextProto', (_
   })
 _sym_db.RegisterMessage(SampleTextProto)
 
+GlyphGroupProto = _reflection.GeneratedProtocolMessageType('GlyphGroupProto', (_message.Message,), {
+  'DESCRIPTOR' : _GLYPHGROUPPROTO,
+  '__module__' : 'fonts_public_pb2'
+  # @@protoc_insertion_point(class_scope:google.fonts_public.GlyphGroupProto)
+  })
+_sym_db.RegisterMessage(GlyphGroupProto)
 
-DESCRIPTOR._options = None
-_FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY._options = None
-_FAMILYPROTO_SAMPLEGLYPHSENTRY._options = None
+if _descriptor._USE_C_DESCRIPTORS == False:
+
+  DESCRIPTOR._options = None
+  DESCRIPTOR._serialized_options = b'\n\026com.google.fonts.protoB\013FontsPublic'
+  _FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY._options = None
+  _FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY._serialized_options = b'8\001'
+  _TARGETTYPEPROTO._serialized_start=2273
+  _TARGETTYPEPROTO._serialized_end=2419
+  _FONTTYPE._serialized_start=2421
+  _FONTTYPE._serialized_end=2532
+  _FAMILYPROTO._serialized_start=44
+  _FAMILYPROTO._serialized_end=821
+  _FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY._serialized_start=758
+  _FAMILYPROTO_REGISTRYDEFAULTOVERRIDESENTRY._serialized_end=821
+  _FONTPROTO._serialized_start=824
+  _FONTPROTO._serialized_end=962
+  _AXISSEGMENTPROTO._serialized_start=964
+  _AXISSEGMENTPROTO._serialized_end=1054
+  _SOURCEPROTO._serialized_start=1056
+  _SOURCEPROTO._serialized_end=1130
+  _TARGETPROTO._serialized_start=1132
+  _TARGETPROTO._serialized_end=1204
+  _FAMILYFALLBACKPROTO._serialized_start=1207
+  _FAMILYFALLBACKPROTO._serialized_end=1411
+  _REGIONPROTO._serialized_start=1413
+  _REGIONPROTO._serialized_end=1494
+  _SCRIPTPROTO._serialized_start=1496
+  _SCRIPTPROTO._serialized_end=1535
+  _LANGUAGEPROTO._serialized_start=1538
+  _LANGUAGEPROTO._serialized_end=1834
+  _EXEMPLARCHARSPROTO._serialized_start=1836
+  _EXEMPLARCHARSPROTO._serialized_end=1958
+  _SAMPLETEXTPROTO._serialized_start=1961
+  _SAMPLETEXTPROTO._serialized_end=2221
+  _GLYPHGROUPPROTO._serialized_start=2223
+  _GLYPHGROUPPROTO._serialized_end=2270
 # @@protoc_insertion_point(module_scope)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -797,16 +797,16 @@ def com_google_fonts_check_metadata_category(family_metadata):
     """Ensure METADATA.pb category field is valid."""
     ok = True
     for category in family_metadata.category:
-      if category not in ["MONOSPACE",
-                          "SANS_SERIF",
-                          "SERIF",
-                          "DISPLAY",
-                          "HANDWRITING"]:
-        ok = False
-        yield FAIL,\
-              Message('bad-value',
-                      f'The field category has "{category}"'
-                      f' which is not valid.')
+        if category not in ["MONOSPACE",
+                            "SANS_SERIF",
+                            "SERIF",
+                            "DISPLAY",
+                            "HANDWRITING"]:
+            ok = False
+            yield FAIL,\
+                Message('bad-value',
+                        f'The field category has "{category}"'
+                        f' which is not valid.')
     if ok:
         yield PASS, "OK!"
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -795,17 +795,19 @@ def com_google_fonts_check_metadata_undeclared_fonts(family_metadata, family_dir
 )
 def com_google_fonts_check_metadata_category(family_metadata):
     """Ensure METADATA.pb category field is valid."""
+    ok = True
     for category in family_metadata.category:
       if category not in ["MONOSPACE",
                           "SANS_SERIF",
                           "SERIF",
                           "DISPLAY",
                           "HANDWRITING"]:
+        ok = False
         yield FAIL,\
               Message('bad-value',
                       f'The field category has "{category}"'
                       f' which is not valid.')
-    else:
+    if ok:
         yield PASS, "OK!"
 
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -804,9 +804,9 @@ def com_google_fonts_check_metadata_category(family_metadata):
                             "HANDWRITING"]:
             ok = False
             yield FAIL,\
-                Message('bad-value',
-                        f'The field category has "{category}"'
-                        f' which is not valid.')
+                  Message('bad-value',
+                          f'The field category has "{category}"'
+                          f' which is not valid.')
     if ok:
         yield PASS, "OK!"
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -6336,13 +6336,13 @@ def com_google_fonts_check_metadata_can_render_samples(ttFont, family_metadata):
              Message('no-samples',
                      'No sample_glyphs on METADATA.pb')
     else:
-        for name, glyphs in family_metadata.sample_glyphs.items():
-            if not can_shape(ttFont, glyphs):
+        for item in family_metadata.sample_glyphs:
+            if not can_shape(ttFont, item.glyphs):
                 passed = False
                 yield FAIL,\
                       Message('sample-glyphs',
                               f"Font can't render the following sample glyphs:\n"
-                              f"'{name}': '{glyphs}'")
+                              f"'{item.name}': '{item.glyphs}'")
 
     languages = LoadLanguages()
     for lang in family_metadata.languages:

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -795,14 +795,15 @@ def com_google_fonts_check_metadata_undeclared_fonts(family_metadata, family_dir
 )
 def com_google_fonts_check_metadata_category(family_metadata):
     """Ensure METADATA.pb category field is valid."""
-    if family_metadata.category[-1] not in ["MONOSPACE",
-                                        "SANS_SERIF",
-                                        "SERIF",
-                                        "DISPLAY",
-                                        "HANDWRITING"]:
+    for category in family_metadata.category:
+      if category not in ["MONOSPACE",
+                          "SANS_SERIF",
+                          "SERIF",
+                          "DISPLAY",
+                          "HANDWRITING"]:
         yield FAIL,\
               Message('bad-value',
-                      f'The field category has "{family_metadata.category}"'
+                      f'The field category has "{category}"'
                       f' which is not valid.')
     else:
         yield PASS, "OK!"
@@ -6403,7 +6404,7 @@ def com_google_fonts_check_metadata_category_hint(family_metadata):
                 break
 
     if (inferred_category is not None and
-        not family_metadata.category[-1] == inferred_category):
+        not inferred_category in family_metadata.category):
        yield WARN,\
              Message('inferred-category',
                      f'Familyname seems to hint at "{inferred_category}" but'

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -795,7 +795,7 @@ def com_google_fonts_check_metadata_undeclared_fonts(family_metadata, family_dir
 )
 def com_google_fonts_check_metadata_category(family_metadata):
     """Ensure METADATA.pb category field is valid."""
-    if family_metadata.category not in ["MONOSPACE",
+    if family_metadata.category[-1] not in ["MONOSPACE",
                                         "SANS_SERIF",
                                         "SERIF",
                                         "DISPLAY",
@@ -6403,7 +6403,7 @@ def com_google_fonts_check_metadata_category_hint(family_metadata):
                 break
 
     if (inferred_category is not None and
-        not family_metadata.category == inferred_category):
+        not family_metadata.category[-1] == inferred_category):
        yield WARN,\
              Message('inferred-category',
                      f'Familyname seems to hint at "{inferred_category}" but'

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2398,7 +2398,7 @@ def test_check_metadata_category():
     font = TEST_FILE("cabin/Cabin-Regular.ttf")
     check(font)
     md = check["family_metadata"]
-    assert md.category == "SANS_SERIF" # ...is known to be good ;-)
+    assert md.category == ["SANS_SERIF"] # ...is known to be good ;-)
     assert_PASS(check(font),
                 "with a good METADATA.pb...")
 
@@ -2407,7 +2407,7 @@ def test_check_metadata_category():
                       "MONO_SPACE",
                       "sans_serif",
                       "monospace"]:
-        md.category = bad_value
+        md.category[:] = [bad_value]
         assert_results_contain(check(font, {"family_metadata": md}),
                                FAIL, 'bad-value',
                                f'with a bad category "{bad_value}"...')
@@ -2418,7 +2418,7 @@ def test_check_metadata_category():
                        "SERIF",
                        "DISPLAY",
                        "HANDWRITING"]:
-        md.category = good_value
+        md.category[:] = [good_value]
         assert_PASS(check(font, {"family_metadata": md}),
                     f'with "{good_value}"...')
 
@@ -4224,23 +4224,23 @@ def test_check_metadata_category_hints():
 
     md = check["family_metadata"]
     md.name = "Seaweed Script"
-    md.category = "DISPLAY"
+    md.category[:] = ["DISPLAY"]
     assert_results_contain(check(font, {"family_metadata": md}),
                            WARN, 'inferred-category',
                            f'with a bad category "{md.category}" for familyname "{md.name}"...')
 
     md.name = "Red Hat Display"
-    md.category = "SANS_SERIF"
+    md.category[:] = ["SANS_SERIF"]
     assert_results_contain(check(font, {"family_metadata": md}),
                            WARN, 'inferred-category',
                            f'with a bad category "{md.category}" for familyname "{md.name}"...')
 
     md.name = "Seaweed Script"
-    md.category = "HANDWRITING"
+    md.category[:] = ["HANDWRITING"]
     assert_PASS(check(font, {"family_metadata": md}),
                 f'with a good category "{md.category}" for familyname "{md.name}"...')
 
     md.name = "Red Hat Display"
-    md.category = "DISPLAY"
+    md.category[:] = ["DISPLAY"]
     assert_PASS(check(font, {"family_metadata": md}),
                 f'with a good category "{md.category}" for familyname "{md.name}"...')

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4167,11 +4167,18 @@ def test_check_metadata_can_render_samples():
     # We add a small set of latin glyphs
     # that we're sure Cabin supports:
     md = check["family_metadata"]
-    md.sample_glyphs["Letters"] = "abcdefghijklmnopqrstuvyz0123456789"
+    from fontbakery.fonts_public_pb2 import GlyphGroupProto
+    gg = GlyphGroupProto()
+    gg.name = "Letters"
+    gg.glyphs = "abcdefghijklmnopqrstuvyz0123456789"
+    md.sample_glyphs.append(gg)
     assert_PASS(check(metadata_file, {"family_metadata": md}))
 
     # And now with Tamil glyphs that Cabin lacks:
-    md.sample_glyphs["Numbers"] = "𑿀 𑿁 𑿂 𑿃 𑿄 𑿅 𑿆 𑿇 𑿈 𑿉 𑿊 𑿋 𑿌 𑿍 𑿎 𑿏 𑿐 𑿑 𑿒 𑿓 𑿔"
+    gg = GlyphGroupProto()
+    gg.name = "Numbers"
+    gg.glyphs = "𑿀 𑿁 𑿂 𑿃 𑿄 𑿅 𑿆 𑿇 𑿈 𑿉 𑿊 𑿋 𑿌 𑿍 𑿎 𑿏 𑿐 𑿑 𑿒 𑿓 𑿔"
+    md.sample_glyphs.append(gg)
     assert_results_contain(check(metadata_file, {"family_metadata": md}),
                            FAIL, 'sample-glyphs')
 


### PR DESCRIPTION
## Description

gftools-builder now generates `METADATA.pb` files which may have an `archive_url` field for sources. Currently fontbakery fails these METADATA.pb files as its proto files are out of date. This updates them to the current versions used in gftools.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

