### PR TITLE
Actually, Dave requested a WARN here instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
 #### On the Universal Profile
-  - **[com.google.fonts/check/name/rfn]:** Do not FAIL if an RFN is found but referencing a familyname that differs frmo the currently used name. Just emit an INFO message instead. (PR #3739)
+  - **[com.google.fonts/check/name/rfn]:** Do not FAIL if an RFN is found but referencing a familyname that differs frmo the currently used name. Just emit an WARN message instead, so that we're careful with font naming. (PR #3739)
   - **[com.google.fonts/check/varfont/unsupported_axes]:** Allow slnt axis (PR #3795)
   - **[com.google.fonts/check/dotted_circle]:** Fix ERROR on fonts without GlyphClassDef.classDefs (issue #3736)
   - **[com.google.fonts/check/transformed_components]:** Check for any component transformation only if font is hinted, otherwise check only for flipped contour direction (one transformation dimension is flipped while the other isn't)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4561,7 +4561,7 @@ def com_google_fonts_check_name_rfn(ttFont, familyname):
                               f'\n'
                               f'This is an error except in a few specific rare cases.')
             else:
-                yield INFO,\
+                yield WARN,\
                       Message("legacy-familyname",
                               f'Name table entry contains "Reserved Font Name" for a'
                               f' family name ({reserved_font_name}) that differs'

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -508,7 +508,7 @@ def test_check_name_rfn():
                            PlatformID.WINDOWS, WindowsEncodingID.UNICODE_BMP,
                            WindowsLanguageID.ENGLISH_USA)
     msg = assert_results_contain(check(ttFont),
-                                 INFO, 'legacy-familyname',
+                                 WARN, 'legacy-familyname',
                                  'with "Reserved Font Name" that references an older'
                                  ' familyname not being used in this font project...')
     assert "(FooBar)" in msg


### PR DESCRIPTION
@davelab6's request: https://github.com/googlefonts/fontbakery/issues/3739#issuecomment-1113636260
com.google.fonts/check/name/rfn (legacy-familyname)
(issue #3739)