### PR TITLE
Read regression shaping files as UTF-8 text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - On the `Google Fonts` profile, the lists of exceptions for **Reserved Font Names (RFN)** and **CamelCased family names**, are now placed on separate txt files (`Lib/fontbakery/data/googlefonts/*_exceptions.txt`) to facilitate their future editing. (issue #3707)
   - The FontVal checks report will be written to a temporary directory now, making it safe to run the checks in parallel on multiple fonts.
   - Updated the Google Fonts metadata proto format.
+  - Always read regression shaping JSON files as UTF-8 text. Windows may otherwise use a different default encoding.
 
 ### BugFixes
   - Users reading markdown reports are now directed to the "stable" version of our ReadTheDocs documentation instead of the "latest" (git dev) one. (issue #3677)

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -166,7 +166,7 @@ def run_a_set_of_shaping_tests(config,
     for shaping_file in Path(shaping_basedir).glob("*.json"):
         shaping_file_found = True
         try:
-            shaping_input_doc = json.loads(shaping_file.read_text())
+            shaping_input_doc = json.loads(shaping_file.read_text(encoding="utf-8"))
         except Exception as e:
             yield FAIL,\
                   Message("shaping-invalid-json",


### PR DESCRIPTION
## Description
All text reading ops need to specify the expected encoding, because Windows may use weird legacy ones and then your text loading fails.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

