### PR TITLE
check_valid_glyphnames: ignore colored .notdef glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
 #### On the Universal Profile
+  - **[com.google.fonts/check/valid_glyphnames]:** Ignore colored .notdef glyphs (PR #3807)
   - **[com.google.fonts/check/varfont/unsupported_axes]:** Allow slnt axis (PR #3795)
   - **[com.google.fonts/check/dotted_circle]:** Fix ERROR on fonts without GlyphClassDef.classDefs (issue #3736)
   - **[com.google.fonts/check/transformed_components]:** Check for any component transformation only if font is hinted, otherwise check only for flipped contour direction (one transformation dimension is flipped while the other isn't)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -772,7 +772,7 @@ def com_google_fonts_check_valid_glyphnames(ttFont, config):
         bad_names = []
         warn_names = []
         for _, glyphName in enumerate(ttFont.getGlyphOrder()):
-            if glyphName in [".null", ".notdef", ".ttfautohint"]:
+            if glyphName.startswith((".null", ".notdef", ".ttfautohint")):
                 # These 2 names are explicit exceptions
                 # in the glyph naming rules
                 continue

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -90,17 +90,21 @@ def test_check_valid_glyphnames():
 
     # Nowadays, it seems most implementations can deal with
     # up to 63 char glyph names:
-    good_name = "b" * 63
+    good_name1 = "b" * 63
+    # colr font may have a color layer in .notdef so allow these layers
+    good_name2 = ".notdef.color0"
     bad_name1 = "a" * 64
     bad_name2 = "3cents"
     bad_name3 = ".threecents"
     ttFont.glyphOrder[2] = bad_name1
     ttFont.glyphOrder[3] = bad_name2
     ttFont.glyphOrder[4] = bad_name3
-    ttFont.glyphOrder[5] = good_name
+    ttFont.glyphOrder[5] = good_name1
+    ttFont.glyphOrder[6] = good_name2
     message = assert_results_contain(check(ttFont),
                                      FAIL, 'found-invalid-names')
-    assert good_name not in message
+    assert good_name1 not in message
+    assert good_name2 not in message
     assert bad_name1 in message
     assert bad_name2 in message
     assert bad_name3 in message


### PR DESCRIPTION
## Description

I just made a pull request for Cairo Play which is a colr font, https://github.com/google/fonts/pull/4786. The FB reports says that  glyph ".notdef.color0" isn't valid. However, this particular glyph is used as a color layer in the .notdef glyph. Any glyph which has the suffix ".colorX" is being used as a layer in another glyph. For all other glyphs which have this suffix, they pass just fine (as they should).

I'm wondering how valid AGL names even are these days? the lists haven't been updated since 2008. Does any modern app/pdf reader even care about them anymore?

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

