### PR TITLE
Relax com.adobe.fonts/check/varfont/valid_default_instance_nameids check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### BugFixes
   - fixed bug on fontbakery_version check so that it now understands that v0.x.9 is older than v0.x.10 (issue #3813)
 
+### Changes to existing checks
+#### On the Universal Profile
+  - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Relaxed the implementation to compare name values, not strictly IDs. (PR #3821)
 
 ## 0.8.9 (2022-Jun-16)
 ### Noteworthy code-changes

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -467,7 +467,7 @@ def com_adobe_fonts_check_varfont_valid_default_instance_nameids(ttFont,
                 yield FAIL, Message(
                     f"invalid-default-instance-subfamily-nameid:{subfam_nameid}",
                     f"{inst_name!r} instance has the same coordinates as the default"
-                    f" instance; its subfamily name should be {name2}"
+                    f" instance; its subfamily name should be '{name2}'"
                 )
                 passed = False
 
@@ -477,8 +477,8 @@ def com_adobe_fonts_check_varfont_valid_default_instance_nameids(ttFont,
                 yield FAIL, Message(
                     f"invalid-default-instance-postscript-nameid:{postscript_nameid}",
                     f"{inst_name!r} instance has the same coordinates as the default"
-                    f" instance; its postscript name should be {name6}, instead of"
-                    f" {postscript_name}.",
+                    f" instance; its postscript name should be '{name6}', instead of"
+                    f" '{postscript_name}'.",
                 )
                 passed = False
 

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -291,18 +291,16 @@ def com_adobe_fonts_check_varfont_valid_axis_nameid(ttFont, has_name_table):
     is greater than 255 and less than 32768."""
 
     passed = True
-    name_table = ttFont["name"] if has_name_table else None
+    if not has_name_table:
+        return FAIL, Message("no-name", "Font has no name table")
+
+    name_table = ttFont["name"]
 
     font_axis_nameids = [axis.axisNameID for axis in ttFont["fvar"].axes]
     invalid_axis_nameids = [val for val in font_axis_nameids if not (255 < val < 32768)]
 
     for nameid in invalid_axis_nameids:
-        inst_name = None
-        if name_table is not None:
-            inst_name = name_table.getDebugName(nameid)
-
-        if inst_name is None:
-            inst_name = "Unnamed"
+        inst_name = name_table.getDebugName(nameid) or "Unnamed"
 
         yield FAIL, Message(
             f"invalid-axis-nameid:{nameid}",
@@ -335,7 +333,10 @@ def com_adobe_fonts_check_varfont_valid_subfamily_nameid(ttFont, has_name_table)
     is 2, 17, or greater than 255 and less than 32768."""
 
     passed = True
-    name_table = ttFont["name"] if has_name_table else None
+    if not has_name_table:
+        return FAIL, Message("no-name", "Font has no name table")
+
+    name_table = ttFont["name"]
 
     font_subfam_nameids = [inst.subfamilyNameID for inst in ttFont["fvar"].instances]
     invalid_subfam_nameids = [
@@ -345,12 +346,7 @@ def com_adobe_fonts_check_varfont_valid_subfamily_nameid(ttFont, has_name_table)
     ]
 
     for nameid in invalid_subfam_nameids:
-        inst_name = None
-        if name_table is not None:
-            inst_name = name_table.getDebugName(nameid)
-
-        if inst_name is None:
-            inst_name = "Unnamed"
+        inst_name = name_table.getDebugName(nameid) or "Unnamed"
 
         yield FAIL, Message(
             f"invalid-subfamily-nameid:{nameid}",
@@ -383,7 +379,9 @@ def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont, has_name_table
     is 6, 0xFFFF, or greater than 255 and less than 32768."""
 
     passed = True
-    name_table = ttFont["name"] if has_name_table else None
+    if not has_name_table:
+        return FAIL, Message("no-name", "Font has no name table")
+    name_table = ttFont["name"]
 
     font_postscript_nameids = [
         inst.postscriptNameID for inst in ttFont["fvar"].instances
@@ -395,12 +393,7 @@ def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont, has_name_table
     ]
 
     for nameid in invalid_postscript_nameids:
-        inst_name = None
-        if name_table is not None:
-            inst_name = name_table.getDebugName(nameid)
-
-        if inst_name is None:
-            inst_name = "Unnamed"
+        inst_name = name_table.getDebugName(nameid) or "Unnamed"
 
         yield FAIL, Message(
             f"invalid-postscript-nameid:{nameid}",
@@ -443,9 +436,7 @@ def com_adobe_fonts_check_varfont_valid_default_instance_nameids(ttFont,
 
     passed = True
     if not has_name_table:
-      yield SKIP, "Font has no name table"
-      # Isn't that a required table? o_O
-      return
+        return FAIL, Message("no-name", "Font has no name table")
 
     name_table = ttFont["name"]
     fvar_table = ttFont["fvar"]
@@ -547,7 +538,10 @@ def com_adobe_fonts_check_varfont_distinct_instance_records(ttFont, has_name_tab
     """Validates that all of the instance records in a given font have distinct data."""
 
     passed = True
-    name_table = ttFont["name"] if has_name_table else None
+    if not has_name_table:
+        return FAIL, Message("no-name", "Font has no name table")
+
+    name_table = ttFont["name"]
 
     unique_inst_recs = set()
 
@@ -561,9 +555,7 @@ def com_adobe_fonts_check_varfont_distinct_instance_records(ttFont, has_name_tab
             unique_inst_recs.add(inst_data)
 
         else:  # non-unique instance was found
-            inst_name = None
-            if name_table is not None:
-                inst_name = name_table.getDebugName(inst_subfam_nameid)
+            inst_name = name_table.getDebugName(inst_subfam_nameid)
 
             if inst_name is None:
                 inst_name = f"Instance #{i}"

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -487,7 +487,7 @@ def test_check_varfont_valid_default_instance_nameids():
     )
     assert msg == (
         "'Version 3.001' instance has the same coordinates as the default instance;"
-        " its subfamily name should be Regular"
+        " its subfamily name should be 'Regular'"
     )
 
     # Put it back
@@ -503,7 +503,7 @@ def test_check_varfont_valid_default_instance_nameids():
     )
     assert msg == (
         "'Regular' instance has the same coordinates as the default instance;"
-        " its postscript name should be Cabin-Regular, instead of None."
+        " its postscript name should be 'Cabin-Regular', instead of 'None'."
     )
 
     # Change postScriptNameID value of the default instance to a valid value
@@ -520,7 +520,7 @@ def test_check_varfont_valid_default_instance_nameids():
     )
     assert msg == (
         "'Regular' instance has the same coordinates as the default instance; "
-        "its postscript name should be Cabin-Regular, instead of Pablo Impallari. http://www.impallari.com Igino Marini. http://www.ikern.com."
+        "its postscript name should be 'Cabin-Regular', instead of 'Pablo Impallari. http://www.impallari.com Igino Marini. http://www.ikern.com'."
     )
 
 

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -467,27 +467,31 @@ def test_check_varfont_valid_default_instance_nameids():
     )
 
     # The 'Regular' instance record in the reference varfont has the same coordinates
-    # as the default instance, but it doesn't use the correct nameID.
+    # as the default instance, and the same text
     ttFont = TTFont("data/test/cabinvf/Cabin[wdth,wght].ttf")
-    msg = assert_results_contain(
-        check(ttFont), FAIL, "invalid-default-instance-subfamily-nameid:258"
-    )
-    assert msg == (
-        "'Regular' instance has the same coordinates as the default instance;"
-        " its subfamilyNameID should be either 2 or 17, instead of 258."
-    )
-
-    # Correct the subfamilyNameID value of the default instance
-    fvar_table = ttFont["fvar"]
-    dflt_inst = fvar_table.instances[0]
-    dflt_inst.subfamilyNameID = 2
     msg = assert_PASS(check(ttFont), "with a good varfont...")
     assert msg == "All default instance nameID values are valid."
 
     # Change subfamilyNameID value of the default instance to another valid value
+    fvar_table = ttFont["fvar"]
+    dflt_inst = fvar_table.instances[0]
     dflt_inst.subfamilyNameID = 17
     msg = assert_PASS(check(ttFont), "with a good varfont...")
     assert msg == "All default instance nameID values are valid."
+
+    # Change the subfamilyNameID value of the default instance to something stupid
+    dflt_inst.subfamilyNameID = 5
+
+    msg = assert_results_contain(
+        check(ttFont), FAIL, "invalid-default-instance-subfamily-nameid:5"
+    )
+    assert msg == (
+        "'Version 3.001' instance has the same coordinates as the default instance;"
+        " its subfamily name should be Regular"
+    )
+
+    # Put it back
+    dflt_inst.subfamilyNameID = 258
 
     # The value of postScriptNameID is 0xFFFF for all the instance records in the
     # reference varfont. Change one of them, to make the check validate the
@@ -498,8 +502,8 @@ def test_check_varfont_valid_default_instance_nameids():
         check(ttFont), FAIL, "invalid-default-instance-postscript-nameid:0xFFFF"
     )
     assert msg == (
-        "'Instance #1' instance has the same coordinates as the default instance;"
-        " its postScriptNameID should be 6, instead of 0xFFFF."
+        "'Regular' instance has the same coordinates as the default instance;"
+        " its postscript name should be Cabin-Regular, instead of None."
     )
 
     # Change postScriptNameID value of the default instance to a valid value
@@ -515,8 +519,8 @@ def test_check_varfont_valid_default_instance_nameids():
         check(ttFont), FAIL, "invalid-default-instance-postscript-nameid:8"
     )
     assert msg == (
-        "'Instance #1' instance has the same coordinates as the default instance;"
-        " its postScriptNameID should be 6, instead of 8."
+        "'Regular' instance has the same coordinates as the default instance; "
+        "its postscript name should be Cabin-Regular, instead of Pablo Impallari. http://www.impallari.com Igino Marini. http://www.ikern.com."
     )
 
 


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #3708. The implementation of this check was based on a strict reading of a sloppily-worded recommendation about which name IDs to use; the discussion in MicrosoftDocs/typography-issues#946 makes it clear the important thing is name *values* not their precise IDs. This will be cleaned up in OTspec1.9.1.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

