### PR TITLE
Reduce Noto PR noise

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -402,7 +402,7 @@ def description_html (description):
 
 @check(
     id = 'com.google.fonts/check/description/git_url',
-    conditions = ['description_html'],
+    conditions = ['description_html', 'not is_noto'],
     rationale = """
         The contents of the DESCRIPTION.en-us.html file are displayed on the
         Google Fonts website in the about section of each font family specimen page.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5905,7 +5905,7 @@ def com_google_fonts_check_metadata_designer_profiles(family_metadata):
                           " Designer webpage links should, for now, be placed"
                           " directly on the bio.html file.")
 
-        if not info.avatar.file_name:
+        if not info.avatar.file_name and designer != "Google":
             passed = False
             yield FAIL,\
                   Message("missing-avatar",

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -701,3 +701,8 @@ def upstream_yaml(family_directory):
     if not os.path.isfile(fp):
         return None
     return yaml.load(open(fp, "r"), yaml.FullLoader)
+
+
+@condition
+def is_noto(font_familyname):
+    return font_familyname.startswith("Noto ")


### PR DESCRIPTION
Noto fonts do things *slightly* differently and so there is some noise in the fontbakery results when they are PRd:

* The "avatar" check for the "Google" designer is unnecessary
* Checking for Git URLs in the description files is unnecessary as rendering the description is handled by a different bit of the website.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

