### PR TITLE
Deprecate DESCRIPTION.en_us.html max-length check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal Profile
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Relaxed the implementation to compare name values, not strictly IDs. (PR #3821)
 
+### Deprecated Checks
+#### Removed from the Google Fonts Profile
+  - **[com.google.fonts/check/description_max_length]**: Recent requirement from GF marketing team is to remove character limit on description. GF specimen page has been updated to allow bigger description text from designers. (issue #3829)
+
+
 ## 0.8.9 (2022-Jun-16)
 ### Noteworthy code-changes
   - Improve implementation of `is_italic` condition and provide an `is_bold` counterpart (issue #3693)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -87,7 +87,6 @@ DESCRIPTION_CHECKS = [
     'com.google.fonts/check/description/broken_links',
     'com.google.fonts/check/description/valid_html',
     'com.google.fonts/check/description/min_length',
-    'com.google.fonts/check/description/max_length',
     'com.google.fonts/check/description/git_url',
     'com.google.fonts/check/description/eof_linebreak',
     'com.google.fonts/check/description/family_update',
@@ -505,32 +504,6 @@ def com_google_fonts_check_description_min_length(description):
                       " have size larger than 200 bytes.")
     else:
         yield PASS, "DESCRIPTION.en_us.html is larger than 200 bytes."
-
-
-@check(
-    id = 'com.google.fonts/check/description/max_length',
-    conditions = ['description'],
-    rationale = """
-        The fonts.google.com catalog specimen pages 2016 to 2020 were placed in a
-        narrow area of the page. That meant a maximum limit of 1,000 characters was
-        good, so that the narrow column did not extent that section of the page to
-        be too long.
-        
-        But with the "v4" redesign of 2020, the specimen pages allow for longer
-        texts without upsetting the balance of the page. So currently the limit
-        before warning is 2,000 characters.
-    """,
-    proposal = 'legacy:check/006'
-)
-def com_google_fonts_check_description_max_length(description):
-    """DESCRIPTION.en_us.html must have less than 2000 bytes."""
-    if len(description) >= 2000:
-        yield FAIL,\
-              Message("too-long",
-                      "DESCRIPTION.en_us.html must"
-                      " have size smaller than 2000 bytes.")
-    else:
-        yield PASS, "DESCRIPTION.en_us.html is smaller than 2,000 bytes."
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -322,28 +322,6 @@ def test_check_description_min_length():
                 'with 201-byte buffer...')
 
 
-def test_check_description_max_length():
-    """ DESCRIPTION.en_us.html must have less than 2000 bytes. """
-    check = CheckTester(googlefonts_profile,
-                        "com.google.fonts/check/description/max_length")
-
-    font = TEST_FILE("nunito/Nunito-Regular.ttf")
-
-    bad_length = 'a' * 2001
-    assert_results_contain(check(font, {"description": bad_length}),
-                           FAIL, "too-long",
-                           'with 2001-byte buffer...')
-
-    bad_length = 'a' * 2000
-    assert_results_contain(check(font, {"description": bad_length}),
-                           FAIL, "too-long",
-                           'with 2000-byte buffer...')
-
-    good_length = 'a' * 1999
-    assert_PASS(check(font, {"description": good_length}),
-                'with 1999-byte buffer...')
-
-
 def test_check_description_eof_linebreak():
     """ DESCRIPTION.en_us.html should end in a linebreak. """
     check = CheckTester(googlefonts_profile,


### PR DESCRIPTION
Removed from the Google Fonts Profile:
com.google.fonts/check/description_max_length

Recent requirement from GF marketing team is to remove character limit on description.
GF specimen page has been updated to allow bigger description text from designers.
(issue #3829)