### PR TITLE
check/glyph_coverage: fix error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal Profile
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Relaxed the implementation to compare name values, not strictly IDs. (PR #3821)
 
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/glyph_coverage]:** Ensure check doesn't error when font contains all required encoded glyphs (PR #3833)
+
 ### Deprecated Checks
 #### Removed from the Google Fonts Profile
   - **[com.google.fonts/check/description_max_length]**: Recent requirement from GF marketing team is to remove character limit on description. GF specimen page has been updated to allow bigger description text from designers. (issue #3829)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1033,22 +1033,24 @@ def com_google_fonts_check_glyph_coverage(ttFont, font_codepoints, config):
     missing_optional_glyphs = glyph_data.missing_glyphsets_in_font(ttFont, threshold=0.8)
     passed = True
     if "GF_Latin_Core" in missing_mandatory_glyphs:
-        passed = False
         missing = missing_encoded_glyphs(missing_mandatory_glyphs["GF_Latin_Core"])
-        yield FAIL,\
-              Message("missing-codepoints",
-                      f"Missing required codepoints:\n\n"
-                      f"{bullet_list(config, missing)}")
+        if missing:
+            passed = False
+            yield FAIL,\
+                Message("missing-codepoints",
+                        f"Missing required codepoints:\n\n"
+                        f"{bullet_list(config, missing)}")
     elif len(missing_optional_glyphs) > 0 and "GF_Latin_Core" not in missing_optional_glyphs:
-        passed = False
         for glyphset_name, glyphs in missing_optional_glyphs.items():
             if glyphset_name == "GF_Latin_Core":
                 continue
             missing = missing_encoded_glyphs(glyphs)
-            yield WARN,\
-                  Message("missing-codepoints",
-                          f"{glyphset_name} is almost fulfilled. Missing codepoints:\n\n"
-                          f"{bullet_list(config, missing)}")
+            if missing:
+                passed = False
+                yield WARN,\
+                    Message("missing-codepoints",
+                            f"{glyphset_name} is almost fulfilled. Missing codepoints:\n\n"
+                            f"{bullet_list(config, missing)}")
     if passed:
         yield PASS, "OK"
 


### PR DESCRIPTION
## Description

This pull request addresses the problems described at issue https://github.com/googlefonts/fontbakery/issues/3827. The test should only raise a fail if encoded glyphs are missing.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

