### PR TITLE
Support COLR table on check/unreachable_glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal Profile
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Relaxed the implementation to compare name values, not strictly IDs. (PR #3821)
 
+#### On the Universal Profile
+  - **[com.google.fonts/check/unreachable_glyphs]:** Do not report glyphs referenced in color fonts graphic compositions on the COLR table as missing. (issue #3837)
+
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/glyph_coverage]:** Ensure check doesn't error when font contains all required encoded glyphs (PR #3833)
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1228,7 +1228,11 @@ def com_google_fonts_check_designspace_has_consistent_codepoints(designSpace, co
     id = "com.google.fonts/check/unreachable_glyphs",
     rationale = """
         Glyphs are either accessible directly through Unicode codepoints or through
-        substitution rules. Any glyphs not accessible by either of these means
+        substitution rules.
+        
+        In Color Fonts, glyphs are also referenced by the COLR table.
+        
+        Any glyphs not accessible by either of these means
         are redundant and serve only to increase the font's file size.
     """,
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3160',
@@ -1287,6 +1291,16 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
     # Exclude cmapped glyphs
     all_glyphs -= set(ttFont.getBestCmap().values())
     all_glyphs.discard(".notdef")
+
+    if "COLR" in ttFont:
+        for paint_record in ttFont["COLR"].table.BaseGlyphList.BaseGlyphPaintRecord:
+            if hasattr(paint_record.Paint, "Glyph"):
+                all_glyphs.discard(paint_record.Paint.Glyph)
+
+        for paint in ttFont["COLR"].table.LayerList.Paint:
+            if hasattr(paint, "Glyph"):
+                all_glyphs.discard(paint.Glyph)
+
 
     if "GSUB" in ttFont and ttFont["GSUB"].table.LookupList:
         lookups = ttFont["GSUB"].table.LookupList.Lookup

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -911,8 +911,13 @@ def test_check_unreachable_glyphs():
     font = TEST_FILE("noto_sans_tamil_supplement/NotoSansTamilSupplement-Regular.ttf")
     assert_PASS(check(font))
 
+    # Also ensure it works correctly with a color font:
+    font = TEST_FILE("color_fonts/noto-glyf_colr_1.ttf")
+    assert_PASS(check(font))
+
     font = TEST_FILE("merriweather/Merriweather-Regular.ttf")
-    message = assert_results_contain(check(font), WARN, "unreachable-glyphs")
+    message = assert_results_contain(check(font),
+                                     WARN, "unreachable-glyphs")
     for glyph in [
         "Gtilde",
         "eight.dnom",


### PR DESCRIPTION
Do not report glyphs referenced in color fonts graphic compositions on the COLR table as missing.

com.google.fonts/check/unreachable_glyphs
(issue #3837)