### PR TITLE
Downgrade check/mandatory_avar_table to a mere WARN, even though it is still a high-priority one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
 #### On the Google Fonts Profile
+  - **[com.google.fonts/check/mandatory_avar_table]:** Downgrade it to a mere WARN, even though it is still a high-priority one. (issue #3100)
   - **[com.fontwerk/check/inconsistencies_between_fvar_stat]:** Do not raise an error if font is missing AxisValues (issue #3848 PR #3849)
   - **[com.adobe.fonts/check/stat_has_axis_value_tables]:** Do not raise an error if font is missing AxisValues (issue #3848 PR #3849)
   - **[com.google.fonts/check/name/familyname]:** Removed due to new `font_names` check (PR #3800)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5643,11 +5643,12 @@ def com_google_fonts_check_metadata_designer_profiles(family_metadata):
     """,
     conditions = ["is_variable_font"],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3100'
+    # NOTE: This is a high-priority WARN.
 )
 def com_google_fonts_check_mandatory_avar_table(ttFont):
     """Ensure variable fonts include an avar table."""
     if "avar" not in ttFont:
-        yield FAIL,\
+        yield WARN,\
               Message('missing-avar',
                       "This variable font does not have an avar table.")
     else:

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3805,7 +3805,7 @@ def test_check_mandatory_avar_table():
 
     del ttFont["avar"]
     assert_results_contain(check(ttFont),
-                           FAIL, "missing-avar")
+                           WARN, "missing-avar")
 
 
 def test_check_description_family_update():


### PR DESCRIPTION
**com.google.fonts/check/mandatory_avar_table**
(issue #3100)

