### PR TITLE
Fix parser to accept ampersand char in DESCRIPTION files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/font_names]:** Ensure font names match our specification (PR #3800)
   - **[com.google.fonts/check/fvar_instances]:** Ensure fvar instances match our specification (PR #3800)
   - **[com.google.fonts/check/STAT]:** Ensure fonts have compulsory STAT table axis values (PR #3800)
+  - **[com.google.fonts/check/description/valid_html]:** Fix parser to accept ampersand character in DESCRIPTION files. (issue #3840)
 
 ### Changes to existing checks
 #### On the Google Fonts Profile

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -407,9 +407,9 @@ def com_google_fonts_check_description_valid_html(descfile, description):
                       f" later be included in the Google Fonts"
                       f" font family specimen webpage.")
 
-    from lxml import etree
+    from lxml import html
     try:
-        etree.fromstring("<html>" + description + "</html>")
+        html.fromstring("<html>" + description + "</html>")
     except Exception as e:
         passed = False
         yield FAIL,\

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -282,13 +282,13 @@ def test_check_description_valid_html():
                            FAIL, 'html-tag',
                            'with description file that contains the <html> tag...')
 
-    bad_desc = ("<p>This example has the & caracter,"
-                " but does not escape it with an HTML entity code."
-                " It should use &amp; instead."
-                "</p>")
-    assert_results_contain(check(font, {"description": bad_desc}),
-                           FAIL, 'malformed-snippet',
-                           'with a known-bad file (not using HTML entity syntax)...')
+    good_desc = ("<p>This example has the & caracter,"
+                 " and does not escape it with an HTML entity code."
+                 " It could use &amp; instead, but that's not strictly necessary."
+                 "</p>")
+    # See discussion at https://github.com/googlefonts/fontbakery/issues/3840
+    assert_PASS(check(font, {"description": good_desc}),
+                'with a file containing ampersand char without HTML entity syntax...')
 
 
 def test_check_description_min_length():


### PR DESCRIPTION
**com.google.fonts/check/description/valid_html**
(issue #3840)

