### PR TITLE
Normalize ordering of log messages on a few more checks to minimize diffs of subsequent FB reports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.8.10 (2022-Aug-??)
 ### Release Notes
   - We have updated our Code of Conduct. Please read [the updated text](CODE_OF_CONDUCT.md) which corresponds to the `Contributor Covenant version 2.1` available at https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+  - We normalized the ordering of log messages of some more checks. To avoid imprevisibility of python set iteration, we sort them before printing. This helps to reduce diffs for people that compare subsequent runs of fontbakery on automated QA setups (issue #3654)
 
 ### New Checks
 #### On the Google Fonts Profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -517,7 +517,7 @@ a - **[com.google.fonts/check/ligature_carets]:** Change 'ligature_glyphs' condi
 ## 0.7.31 (2020-Sept-24)
 ### Note-worthy code changes
   - This is a quick new release to address a silly but fatal crash (issue #3044)
-  - We normalized the ordering of log messages of some checks. To avoid imprevisibility of python set iteration, we sort them before printing. This helps to reduce diffs for people that compare subsequent runs of fontbakery on automated AQ setups (issue #3038)
+  - We normalized the ordering of log messages of some checks. To avoid imprevisibility of python set iteration, we sort them before printing. This helps to reduce diffs for people that compare subsequent runs of fontbakery on automated QA setups (issue #3038)
 
 
 ## 0.7.30 (2020-Sept-24)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3044,8 +3044,8 @@ def com_google_fonts_check_production_glyphs_similarity(ttFont, api_gfonts_ttFon
 
     if bad_glyphs:
         formatted_list = "\t* " + pretty_print_list(config,
-                                            bad_glyphs,
-                                            sep="\n\t* ")
+                                                    sorted(bad_glyphs),
+                                                    sep="\n\t* ")
 
         yield WARN, ("Following glyphs differ greatly from"
                      f" Google Fonts version:\n{formatted_list}")

--- a/Lib/fontbakery/profiles/layout.py
+++ b/Lib/fontbakery/profiles/layout.py
@@ -46,7 +46,7 @@ def com_google_fonts_check_layout_valid_feature_tags(ttFont):
         yield FAIL, \
               Message("bad-feature-tags",
                       "The following invalid feature tags were found in the font: "
-                      + ", ".join(bad_tags))
+                      + ", ".join(sorted(bad_tags)))
     else:
         yield PASS, "No invalid feature tags were found"
 
@@ -80,7 +80,7 @@ def com_google_fonts_check_layout_valid_script_tags(ttFont):
         yield FAIL, \
               Message("bad-script-tags",
                       "The following invalid script tags were found in the font: "
-                      + ", ".join(bad_tags))
+                      + ", ".join(sorted(bad_tags)))
     else:
         yield PASS, "No invalid script tags were found"
 
@@ -115,6 +115,6 @@ def com_google_fonts_check_layout_valid_language_tags(ttFont):
         yield FAIL, \
               Message("bad-language-tags",
                       "The following invalid language tags were found in the font: "
-                      + ", ".join(bad_tags))
+                      + ", ".join(sorted(bad_tags)))
     else:
         yield PASS, "No invalid language tags were found"

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1333,7 +1333,7 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
               Message("unreachable-glyphs",
                       f"The following glyphs could not be reached"
                       f" by codepoint or substitution rules:\n\n"
-                      f"{bullet_list(config, list(all_glyphs))}\n")
+                      f"{bullet_list(config, sorted(list(all_glyphs)))}\n")
     else:
         yield PASS, "Font did not contain any unreachable glyphs"
 
@@ -1657,7 +1657,7 @@ def com_google_fonts_check_dotted_circle(ttFont, config):
               Message("unattached-dotted-circle-marks",
                       f"The following glyphs could not be attached"
                       f" to the dotted circle glyph:\n\n"
-                      f"{bullet_list(config, unattached)}")
+                      f"{bullet_list(config, sorted(unattached))}")
     else:
         yield PASS, "All marks were anchored to dotted circle"
 


### PR DESCRIPTION
We normalized the ordering of log messages of some more checks. To avoid imprevisibility of python set iteration, we sort them before printing. This helps to reduce diffs for people that compare subsequent runs of fontbakery on automated QA setups 

- **com.google.fonts/check/dotted_circle**
- **com.google.fonts/check/layout_valid_script_tags**
- **com.google.fonts/check/layout_valid_language_tags**
- **com.google.fonts/check/layout_valid_feature_tags**
- **com.google.fonts/check/production_glyphs_similarity**
- **com.google.fonts/check/unreachable_glyphs**
 
(issue #3654)