### PR TITLE
Various check fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,15 +32,25 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### BugFixes
   - **[com.google.fonts/check/unreachable_glyphs]:** Fix crash by adding support for color-font legacy COLR v0 format. (issue #3850)
-  - fixed bug on fontbakery_version check so that it now understands that v0.x.9 is older than v0.x.10 (issue #3813)
-  - Fix fontbakery.profiles.shared_conditions.*_*_coord functions so they work on Italic fonts (issue #3828, PR #3834)
+  - Fixed bug on `fontbakery_version` check so that it now understands that v0.x.9 is older than v0.x.10 (issue #3813)
+  - Fixed `fontbakery.profiles.shared_conditions.*_*_coord` functions so they work on Italic fonts (issue #3828, PR #3834)
+  - **[com.fontwerk/check/weight_class_fvar]:** Fixed ERROR result as the check did not yield any status when a variable font had no `wght` axis. (PR #3866)
+  - **[com.google.fonts/check/varfont_duplicate_instance_names]:** Fixed crash caused by trying to decode a non-existant `name`-table record. (PR #3866)
+  - **[com.google.fonts/check/linegaps]:** Fixed crash by checking for the existence of tables required by the check before accessing them. (issue #3656, PR #3866)
+  - **[com.google.fonts/check/maxadvancewidth]:** Fixed crash by checking for the existence of tables required by the check before accessing them. (issue #3656, PR #3866)
+  - **[com.google.fonts/check/unexpected_subtables]:** Fixed crash by checking for the existence of `OS/2` table required by `is_cjk_font` condition before accessing it. (PR #3866)
+  - **[com.adobe.fonts/check/varfont/valid_axis_nameid]:** Fixed ERROR result as the check did not yield any status when a variable font had no `name` table. (PR #3866)
+  - **[com.adobe.fonts/check/varfont/valid_subfamily_nameid]:** Fixed ERROR result as the check did not yield any status when a variable font had no `name` table. (PR #3866)
+  - **[com.adobe.fonts/check/varfont/valid_postscript_nameid]:** Fixed ERROR result as the check did not yield any status when a variable font had no `name` table. (PR #3866)
+  - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Fixed ERROR result as the check did not yield any status when a variable font had no `name` table. (PR #3866)
+  - **[com.adobe.fonts/check/varfont/distinct_instance_records]:** Fixed ERROR result as the check did not yield any status when a variable font had no `name` table. (PR #3866)
 
 ### Migrations
 #### To the `Universal` profile
   - **[com.google.fonts/check/whitespace_widths]:** moved from `OpenType` profile. Also added rationale text. (issue #3843)
 
 ### Changes to existing checks
-#### On the Universal Profile
+#### On the OpenType Profile
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** Relaxed the implementation to compare name values, not strictly IDs. (PR #3821)
 
 #### On the Universal Profile

--- a/Lib/fontbakery/profiles/fontwerk.py
+++ b/Lib/fontbakery/profiles/fontwerk.py
@@ -113,7 +113,7 @@ def com_fontwerk_check_vendor_id(ttFont):
         According to Microsoft's OT Spec the OS/2 usWeightClass
         should match the fvar default value.
     """,
-    conditions = ["is_variable_font"],
+    conditions = ["is_variable_font", "has_wght_axis"],
     proposal = 'https://github.com/googlefonts/gftools/issues/477'
 )
 def com_fontwerk_check_weight_class_fvar(ttFont):
@@ -122,11 +122,8 @@ def com_fontwerk_check_weight_class_fvar(ttFont):
     fvar = ttFont['fvar']
     default_axis_values = {a.axisTag: a.defaultValue for a in fvar.axes}
 
-    fvar_value = default_axis_values.get('wght', None)
+    fvar_value = default_axis_values.get('wght')
     os2_value = ttFont["OS/2"].usWeightClass
-
-    if fvar_value is None:
-        return
 
     if os2_value != int(fvar_value):
         yield FAIL,\

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -290,10 +290,11 @@ def com_adobe_fonts_check_varfont_valid_axis_nameid(ttFont, has_name_table):
     """Validates that the value of axisNameID used by each VariationAxisRecord
     is greater than 255 and less than 32768."""
 
-    passed = True
     if not has_name_table:
-        return FAIL, Message("no-name", "Font has no name table")
+        yield FAIL, Message("lacks-table", "Font lacks 'name' table.")
+        return
 
+    passed = True
     name_table = ttFont["name"]
 
     font_axis_nameids = [axis.axisNameID for axis in ttFont["fvar"].axes]
@@ -332,10 +333,11 @@ def com_adobe_fonts_check_varfont_valid_subfamily_nameid(ttFont, has_name_table)
     """Validates that the value of subfamilyNameID used by each InstanceRecord
     is 2, 17, or greater than 255 and less than 32768."""
 
-    passed = True
     if not has_name_table:
-        return FAIL, Message("no-name", "Font has no name table")
+        yield FAIL, Message("lacks-table", "Font lacks 'name' table.")
+        return
 
+    passed = True
     name_table = ttFont["name"]
 
     font_subfam_nameids = [inst.subfamilyNameID for inst in ttFont["fvar"].instances]
@@ -378,9 +380,11 @@ def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont, has_name_table
     """Validates that the value of postScriptNameID used by each InstanceRecord
     is 6, 0xFFFF, or greater than 255 and less than 32768."""
 
-    passed = True
     if not has_name_table:
-        return FAIL, Message("no-name", "Font has no name table")
+        yield FAIL, Message("lacks-table", "Font lacks 'name' table.")
+        return
+
+    passed = True
     name_table = ttFont["name"]
 
     font_postscript_nameids = [
@@ -434,10 +438,11 @@ def com_adobe_fonts_check_varfont_valid_default_instance_nameids(ttFont,
     the same value as 2), and its postScriptNameID value is set to 6 (or
     something with the same value as 6)."""
 
-    passed = True
     if not has_name_table:
-        return FAIL, Message("no-name", "Font has no name table")
+        yield FAIL, Message("lacks-table", "Font lacks 'name' table.")
+        return
 
+    passed = True
     name_table = ttFont["name"]
     fvar_table = ttFont["fvar"]
 
@@ -537,10 +542,11 @@ def com_adobe_fonts_check_varfont_same_size_instance_records(ttFont):
 def com_adobe_fonts_check_varfont_distinct_instance_records(ttFont, has_name_table):
     """Validates that all of the instance records in a given font have distinct data."""
 
-    passed = True
     if not has_name_table:
-        return FAIL, Message("no-name", "Font has no name table")
+        yield FAIL, Message("lacks-table", "Font lacks 'name' table.")
+        return
 
+    passed = True
     name_table = ttFont["name"]
 
     unique_inst_recs = set()

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS, WARN, SKIP
+from fontbakery.status import FAIL, PASS, WARN
 from fontbakery.message import Message
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3768,13 +3768,14 @@ def com_google_fonts_check_aat(ttFont):
             unwanted_tables_found.append(table)
 
     if len(unwanted_tables_found) > 0:
+        unwanted_list = ''.join(f"* {tag}\n" for tag in unwanted_tables_found)
         yield FAIL,\
               Message("has-unwanted-tables",
                       f"Unwanted AAT tables were found"
                       f" in the font and should be removed, either by"
                       f" fonttools/ttx or by editing them using the tool"
-                      f" they built with:"
-                      f" {', '.join(unwanted_tables_found)}")
+                      f" they built with:\n\n"
+                      f" {unwanted_list}")
     else:
         yield PASS, "There are no unwanted AAT tables."
 

--- a/Lib/fontbakery/profiles/hhea.py
+++ b/Lib/fontbakery/profiles/hhea.py
@@ -23,7 +23,7 @@ def com_google_fonts_check_linegaps(ttFont):
     missing_tables = _get_missing_tables(required_tables, ttFont)
     if missing_tables:
         for table_tag in missing_tables:
-            yield FAIL, Message(f"lacks-table", f"Font lacks '{table_tag}' table.")
+            yield FAIL, Message("lacks-table", f"Font lacks '{table_tag}' table.")
         return
 
     if ttFont["hhea"].lineGap != 0:
@@ -48,7 +48,7 @@ def com_google_fonts_check_maxadvancewidth(ttFont):
     missing_tables = _get_missing_tables(required_tables, ttFont)
     if missing_tables:
         for table_tag in missing_tables:
-            yield FAIL, Message(f"lacks-table", f"Font lacks '{table_tag}' table.")
+            yield FAIL, Message("lacks-table", f"Font lacks '{table_tag}' table.")
         return
 
     hhea_advance_width_max = ttFont['hhea'].advanceWidthMax

--- a/Lib/fontbakery/profiles/hhea.py
+++ b/Lib/fontbakery/profiles/hhea.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS, SKIP, WARN
+from fontbakery.status import FAIL, PASS, WARN
 from fontbakery.message import Message
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import

--- a/Lib/fontbakery/profiles/hhea.py
+++ b/Lib/fontbakery/profiles/hhea.py
@@ -8,12 +8,24 @@ profile_imports = [
     ('.shared_conditions', ('glyph_metrics_stats', 'is_ttf'))
 ]
 
+def _get_missing_tables(req_tables_set, ttFont):
+    """Returns a sorted list of table tags not supported by the font."""
+    return sorted(req_tables_set - set(ttFont.keys()))
+
+
 @check(
     id = 'com.google.fonts/check/linegaps',
     proposal = 'legacy:check/041'
 )
 def com_google_fonts_check_linegaps(ttFont):
     """Checking Vertical Metric Linegaps."""
+    required_tables = {"hhea", "OS/2"}
+    missing_tables = _get_missing_tables(required_tables, ttFont)
+    if missing_tables:
+        for table_tag in missing_tables:
+            yield FAIL, Message(f"lacks-table", f"Font lacks '{table_tag}' table.")
+        return
+
     if ttFont["hhea"].lineGap != 0:
         yield WARN,\
               Message("hhea",
@@ -32,6 +44,13 @@ def com_google_fonts_check_linegaps(ttFont):
 )
 def com_google_fonts_check_maxadvancewidth(ttFont):
     """MaxAdvanceWidth is consistent with values in the Hmtx and Hhea tables?"""
+    required_tables = {"hhea", "hmtx"}
+    missing_tables = _get_missing_tables(required_tables, ttFont)
+    if missing_tables:
+        for table_tag in missing_tables:
+            yield FAIL, Message(f"lacks-table", f"Font lacks '{table_tag}' table.")
+        return
+
     hhea_advance_width_max = ttFont['hhea'].advanceWidthMax
     hmtx_advance_width_max = None
     for g in ttFont['hmtx'].metrics.values():

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -159,12 +159,6 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
     """Checking correctness of monospaced metadata."""
     from fontbakery.constants import (IsFixedWidth,
                                       PANOSE_Proportion)
-    failed = False
-    # Note: These values are read from the dict here only to
-    # reduce the max line length in the check implementation below:
-    seems_monospaced = glyph_metrics_stats["seems_monospaced"]
-    most_common_width = glyph_metrics_stats["most_common_width"]
-    width_max = glyph_metrics_stats['width_max']
 
     # Check for missing tables before indexing them
     missing_tables = False
@@ -172,12 +166,17 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
     for key in required:
         if key not in ttFont:
             missing_tables = True
-            yield FAIL,\
-                  Message(f'lacks-{key}',
-                          f"Font file lacks a '{key}' table.")
+            yield FAIL, Message(f'lacks-table', f"Font lacks '{key}' table.")
 
     if missing_tables:
         return
+
+    failed = False
+    # Note: These values are read from the dict here only to
+    # reduce the max line length in the check implementation below:
+    seems_monospaced = glyph_metrics_stats["seems_monospaced"]
+    most_common_width = glyph_metrics_stats["most_common_width"]
+    width_max = glyph_metrics_stats['width_max']
 
     if ttFont['hhea'].advanceWidthMax != width_max:
         failed = True

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -166,7 +166,7 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
     for key in required:
         if key not in ttFont:
             missing_tables = True
-            yield FAIL, Message(f'lacks-table', f"Font lacks '{key}' table.")
+            yield FAIL, Message('lacks-table', f"Font lacks '{key}' table.")
 
     if missing_tables:
         return

--- a/Lib/fontbakery/profiles/shared_conditions.py
+++ b/Lib/fontbakery/profiles/shared_conditions.py
@@ -43,6 +43,11 @@ def has_name_table(ttFont):
 
 
 @condition
+def has_os2_table(ttFont):
+    return "OS/2" in ttFont.keys()
+
+
+@condition
 def has_STAT_table(ttFont):
     return "STAT" in ttFont
 
@@ -475,6 +480,9 @@ def is_cjk_font(ttFont):
     from fontbakery.constants import (CJK_CODEPAGE_BITS,
                                       CJK_UNICODE_RANGE_BITS,
                                       CJK_UNICODE_RANGES)
+    if not has_os2_table(ttFont):
+        return
+
     os2 = ttFont["OS/2"]
 
     # OS/2 code page checks

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -668,17 +668,17 @@ def com_google_fonts_check_unwanted_tables(ttFont):
                  ' new fonts should not be using that.'),
     }
     unwanted_tables_found = []
+    unwanted_tables_tags = set(UNWANTED_TABLES)
     for table in ttFont.keys():
-        if table in UNWANTED_TABLES.keys():
+        if table in unwanted_tables_tags:
             info = UNWANTED_TABLES[table]
-            unwanted_tables_found.append(f'Table: {table}\nReason: {info}\n')
+            unwanted_tables_found.append(f'* {table} - {info}\n')
 
     if unwanted_tables_found:
-        tables = "\n".join(unwanted_tables_found)
         yield FAIL, \
               Message("unwanted-tables",
-                      f"The following unwanted font tables were found:\n"
-                      f"{tables}\n"
+                      f"The following unwanted font tables were found:\n\n"
+                      f"{''.join(unwanted_tables_found)}\n"
                       f"They can be removed with the fix-unwanted-tables"
                       f" script provided by gftools.")
     else:

--- a/tests/profiles/fontwerk_test.py
+++ b/tests/profiles/fontwerk_test.py
@@ -1,5 +1,5 @@
 from fontTools.ttLib import TTFont
-from fontbakery.checkrunner import FAIL
+from fontbakery.checkrunner import FAIL, SKIP
 from fontbakery.codetesting import (assert_PASS,
                                     assert_results_contain,
                                     CheckTester,
@@ -47,6 +47,12 @@ def test_check_weight_class_fvar():
     assert_results_contain(check(ttFont),
                            FAIL, 'bad-weight-class',
                            "but should match fvar default value.")
+
+    # Test with a variable font that doesn't have a 'wght' (Weight) axis.
+    # The check should yield SKIP.
+    ttFont = TTFont(TEST_FILE("BadGrades/BadGrades-VF.ttf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: has_wght_axis"
 
 
 def test_check_inconsistencies_between_fvar_stat():

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -360,6 +360,10 @@ def test_check_varfont_valid_axis_nameid():
         " is not greater than 255 and less than 32768."
     )
 
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['name']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")
+
 
 def test_check_varfont_valid_subfamily_nameid():
     """The value of subfamilyNameID used by each InstanceRecord must
@@ -412,6 +416,10 @@ def test_check_varfont_valid_subfamily_nameid():
         " is neither 2, 17, or greater than 255 and less than 32768."
     )
 
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['name']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")
+
 
 def test_check_varfont_valid_postscript_nameid():
     """The value of postScriptNameID used by each InstanceRecord must
@@ -463,6 +471,10 @@ def test_check_varfont_valid_postscript_nameid():
         "'Unnamed' instance has a postScriptNameID value that"
         " is neither 6, 0xFFFF, or greater than 255 and less than 32768."
     )
+
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['name']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")
 
 
 def test_check_varfont_valid_default_instance_nameids():
@@ -529,6 +541,10 @@ def test_check_varfont_valid_default_instance_nameids():
         "'Regular' instance has the same coordinates as the default instance; "
         "its postscript name should be 'Cabin-Regular', instead of 'Pablo Impallari. http://www.impallari.com Igino Marini. http://www.ikern.com'."
     )
+
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['name']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")
 
 
 def test_check_varfont_same_size_instance_records():
@@ -601,3 +617,7 @@ def test_check_varfont_distinct_instance_records():
     msg = assert_results_contain(
         check(ttFont), WARN, "repeated-instance-record:SemiBold")
     assert msg == "'SemiBold' is a repeated instance record."
+
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['name']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3561,7 +3561,7 @@ def test_check_varfont_instance_names(vf_ttFont):
 
 def test_check_varfont_duplicate_instance_names(vf_ttFont):
     check = CheckTester(googlefonts_profile,
-                        "com.google.fonts/check/fvar_instances")
+                        "com.google.fonts/check/varfont_duplicate_instance_names")
 
     assert_PASS(check(vf_ttFont),
                 'with a variable font which has unique instance names.')
@@ -3580,7 +3580,14 @@ def test_check_varfont_duplicate_instance_names(vf_ttFont):
                                platEncID=WindowsEncodingID.UNICODE_BMP,
                                langID=WindowsLanguageID.ENGLISH_USA)
     assert_results_contain(check(vf_ttFont2),
-                           FAIL, 'bad-fvar-instances')
+                           FAIL, 'duplicate-instance-names')
+
+    # Change the nameID of the 3rd named instance to 456,
+    # and don't create a name record with that nameID.
+    name_id = 456
+    vf_ttFont2['fvar'].instances[2].subfamilyNameID = name_id
+    msg = assert_results_contain(check(vf_ttFont2), FAIL, 'name-record-not-found')
+    assert f" and nameID {name_id} was not found." in msg
 
 
 def test_check_varfont_unsupported_axes():

--- a/tests/profiles/hhea_test.py
+++ b/tests/profiles/hhea_test.py
@@ -36,6 +36,10 @@ def test_check_linegaps():
     ttFont['OS/2'].sTypoLineGap = 0
     assert_PASS(check(ttFont))
 
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['OS/2']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")
+
 
 def test_check_maxadvancewidth():
     """ MaxAdvanceWidth is consistent with values in the Hmtx and Hhea tables? """
@@ -49,3 +53,6 @@ def test_check_maxadvancewidth():
     assert_results_contain(check(ttFont),
                            FAIL, 'mismatch')
 
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['hmtx']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -179,6 +179,10 @@ def test_check_monospace():
     assert (status == WARN and message.code == "mono-outliers") or \
            (status == PASS and message.code == "mono-good")
 
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont["OS/2"]
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")
+
 
 def test_check_name_match_familyname_fullfont():
     """ Does full font name begin with the font family name? """


### PR DESCRIPTION
These changes fix checks that were either crashing or didn't yield any status.
Also prettified the output of a couple checks; see before & after screenshots below.

## `com.google.fonts/check/aat`
### before
<img width="710" alt="aat-before" src="https://user-images.githubusercontent.com/2119742/185809925-3be39fd0-6a4f-4c61-b644-52472e8c7dbd.png">

### after
<img width="716" alt="aat-after" src="https://user-images.githubusercontent.com/2119742/185809929-e6d88dd6-5c61-4992-94df-3386cb734816.png">

## `com.google.fonts/check/unwanted_tables`
### before
<img width="711" alt="unwanted_tables-before" src="https://user-images.githubusercontent.com/2119742/185809983-99e34a74-0ce2-42c2-9106-47acafd0f596.png">

### after
<img width="710" alt="unwanted_tables-after" src="https://user-images.githubusercontent.com/2119742/185809995-1f80b63f-a90f-4b7b-b184-8876e91848f7.png">
