### PR TITLE
New Check: com.google.fonts/check/colorfont_tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.8.11 (2022-Sep-??)
-  - ...
+### New Checks
+#### Added to the Google Fonts Profile
+  - **[com.google.fonts/check/colorfont_tables]:** Fonts must have neither or both the tables `COLR` and `SVG`. (issue #3886)
 
 
 ## 0.8.10 (2022-Aug-25)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -198,6 +198,7 @@ FONT_FILE_CHECKS = [
     'com.google.fonts/check/no_debugging_tables',
     'com.google.fonts/check/render_own_name',
     'com.google.fonts/check/STAT',
+    'com.google.fonts/check/colorfont_tables',
 ]
 
 GOOGLEFONTS_PROFILE_CHECKS = \
@@ -6145,6 +6146,39 @@ def com_google_fonts_check_metadata_category_hint(family_metadata):
                      f' METADATA.pb declares it as "{family_metadata.category}".')
     else:
        yield PASS, "OK."
+
+
+@check(
+    id = "com.google.fonts/check/colorfont_tables",
+    rationale = """
+        No one color font format supports all major user agents, but the combination
+        of COLR & SVG tables is pretty good.
+
+        A smart server could prune away one or the other based on user agent,
+        and a dumb server will at least have something that works.
+
+        Fonts that do not pass this check can be fixed with the maximum_color tool
+        available at https://github.com/googlefonts/nanoemoji
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/3886'
+)
+def com_google_fonts_check_colorfont_tables(ttFont):
+    """Fonts must have neither or both the tables 'COLR' and 'SVG'."""
+    SUGGESTED_FIX = ("To fix this, please run the font through the maximum_color tool"
+                     " that installs as part of the nanoemoji package"
+                     " (https://github.com/googlefonts/nanoemoji)")
+    if 'COLR' in ttFont.keys() and 'SVG' not in ttFont.keys():
+        yield FAIL,\
+              Message('missing-table',
+                      "This is a color font (it has a 'COLR' table)"
+                      " but it lacks an 'SVG' table. " + SUGGESTED_FIX)
+    elif 'COLR' not in ttFont.keys() and 'SVG' in ttFont.keys():
+        yield FAIL,\
+              Message('missing-table',
+                      "This is a color font (it has a 'SVG' table)"
+                      " but it lacks an 'COLR' table. " + SUGGESTED_FIX)
+    else:
+        yield PASS, "Looks good!"
 
 
 ###############################################################################

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4213,3 +4213,38 @@ def test_check_override_freetype_rasterizer(mock_import_error):
     font = TEST_FILE("cabin/Cabin-Regular.ttf")
     msg = assert_results_contain(check(font), FAIL, "freetype-not-installed")
     assert "FreeType is not available" in msg
+
+
+def test_check_colorfont_tables():
+    """Fonts must have neither or both the tables 'COLR' and 'SVG'."""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/colorfont_tables")
+
+    ttFont = TTFont(TEST_FILE("color_fonts/noto-glyf_colr_1.ttf"))
+    assert 'COLR' in ttFont.keys()
+    assert 'SVG' not in ttFont.keys()
+    assert_results_contain(check(ttFont),
+                           FAIL, 'missing-table',
+                           'with a color font lacking SVG table')
+
+    # Fake an SVG table:
+    ttFont["SVG"] = "fake!"
+    assert 'SVG' in ttFont.keys()
+    assert 'COLR' in ttFont.keys()
+    assert_PASS(check(ttFont),
+                f'with a font containing both tables.')
+
+    # Now remove the COLR one:
+    del ttFont["COLR"]
+    assert 'COLR' not in ttFont.keys()
+    assert 'SVG' in ttFont.keys()
+    assert_results_contain(check(ttFont),
+                           FAIL, 'missing-table',
+                           'with a font with SVG table but no COLR table.')
+
+    # Finally, get rid of both:
+    del ttFont["SVG"]
+    assert 'SVG' not in ttFont.keys()
+    assert 'COLR' not in ttFont.keys()
+    assert_PASS(check(ttFont),
+                f'with a good font without SVG or COLR tables.')


### PR DESCRIPTION
"Fonts must have neither or both the tables `COLR` and `SVG`."

Added to the Google Fonts Profile.
(issue #3886)
