### PR TITLE
Noto fonts must contain article/ARTICLE.en_us.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New Checks
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/colorfont_tables]:** Fonts must have neither or both the tables `COLR` and `SVG`. (issue #3886)
+  - **[com.google.fonts/check/description/noto_has_article]:** Noto fonts must have an ARTICLE.en_us.html file. (issue #3841)
 
 
 ## 0.8.10 (2022-Aug-25)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -97,7 +97,8 @@ DESCRIPTION_CHECKS = [
     'com.google.fonts/check/description/git_url',
     'com.google.fonts/check/description/eof_linebreak',
     'com.google.fonts/check/description/family_update',
-    'com.google.fonts/check/description/urls'
+    'com.google.fonts/check/description/urls',
+    'com.google.fonts/check/description/noto_has_article'
 ]
 
 FAMILY_CHECKS = [
@@ -6179,6 +6180,26 @@ def com_google_fonts_check_colorfont_tables(ttFont):
                       " but it lacks an 'COLR' table. " + SUGGESTED_FIX)
     else:
         yield PASS, "Looks good!"
+
+@check(
+    id = 'com.google.fonts/check/description/noto_has_article',
+    conditions = ['is_noto'],
+    rationale = """
+        Noto fonts are displayed in a different way on the fonts.google.com
+         web site, and so must also contain an article about them.
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/3841'
+)
+def com_google_fonts_check_description_noto_has_article(font):
+    """Noto fonts must have an ARTICLE.en_us.html file"""
+    directory = os.path.dirname(font)
+    descfilepath = os.path.join(directory, "article", "ARTICLE.en_us.html")
+    if os.path.exists(descfilepath):
+        yield PASS, "ARTICLE.en_us.html exists"
+    else:
+        yield FAIL,\
+              Message('missing-article',
+                      "This is a Noto font but it lacks an ARTICLE.en_us.html file")
 
 
 ###############################################################################

--- a/data/test/notosanskhudawadi/article/ARTICLE.en_us.html
+++ b/data/test/notosanskhudawadi/article/ARTICLE.en_us.html
@@ -1,0 +1,24 @@
+<p>
+  Noto Sans Khudawadi is an unmodulated (“sans serif”) design for texts in the
+  historical Indic <em>Khudawadi</em> script.
+</p>
+<p>
+  Noto Sans Khudawadi contains 110 glyphs, 5 OpenType features, and supports 90
+  characters from 2 Unicode blocks: Khudawadi, Common Indic Number Forms.
+</p>
+<h3>Supported writing systems</h3>
+<h4>Khudawadi</h4>
+<p>
+  Khudawadi (Sindhi, <span class="autonym">𑊻𑋩𑋣𑋏𑋠𑋔𑋠𑋏𑋢</span>) is a historical
+  Indic abugida, written left-to-right. Was used in the Sindh province of
+  Pakistan and in India for the Sindhi language (20 million speakers). Now
+  replaced by Nastaliq in Pakistan, and by Devanagari in India. Needs software
+  support for complex text layout (shaping). Read more on
+  <a href="https://scriptsource.org/scr/Sind">ScriptSource</a>,
+  <a href="https://www.unicode.org/versions/Unicode13.0.0/ch15.pdf#G80879"
+    >Unicode</a
+  >, <a href="https://en.wikipedia.org/wiki/ISO_15924:Sind">Wikipedia</a>,
+  <a href="https://en.wiktionary.org/wiki/Category:Khudawadi_script"
+    >Wiktionary</a
+  >, <a href="https://r12a.github.io/scripts/links?iso=Sind">r12a</a>.
+</p>

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4248,3 +4248,17 @@ def test_check_colorfont_tables():
     assert 'COLR' not in ttFont.keys()
     assert_PASS(check(ttFont),
                 f'with a good font without SVG or COLR tables.')
+
+
+def test_check_noto_has_article():
+    """Noto fonts must have an ARTICLE.en_us.html file"""
+    check = CheckTester(googlefonts_profile,
+                        "com.google.fonts/check/description/noto_has_article")
+
+    ttFont = TTFont(TEST_FILE("notosanskhudawadi/NotoSansKhudawadi-Regular.ttf"))
+    assert_PASS(check(ttFont), "with a good font")
+
+    ttFont = TTFont(TEST_FILE("noto_sans_tamil_supplement/NotoSansTamilSupplement-Regular.ttf"))
+    assert_results_contain(check(ttFont),
+                           FAIL, 'missing-article',
+                           "with a bad font")


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #3841

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

