### PR TITLE
Update com.google.fonts/check/varfont/bold_wght_coord check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ A more detailed list of changes is available in the corresponding milestones for
 ### BugFixes
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
 
+### Changes to existing checks
+  - **[com.google.fonts/check/varfont/bold_wght_coord]:** The check was modified to distinguish between a font having no bold
+  instance (code: `no-bold-instance`) versus having a bold instance whose wght coord != 700 (existing code `wght-not-700`). (issue #3898)
+#### Overridden in the Adobe Fonts Profile
+  - **[com.google.fonts/check/varfont/bold_wght_coord]:** downgrade `no-bold-instance` from FAIL to WARN.
 
 ## 0.8.10 (2022-Aug-25)
 ### Release Notes

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -26,7 +26,7 @@ profile = profile_factory(default_section=Section("Adobe Fonts"))
 SET_EXPLICIT_CHECKS = {
     # This is the set of explict checks that will be invoked
     # when fontbakery is run with the 'check-adobefonts' subcommand.
-    # The contents of this set were last updated on August 21, 2022.
+    # The contents of this set were last updated on September 14, 2022.
     #
     # =======================================
     # From adobefonts.py (this file)
@@ -66,7 +66,7 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
     "com.adobe.fonts/check/varfont/valid_postscript_nameid",
     "com.adobe.fonts/check/varfont/valid_subfamily_nameid",
-    "com.google.fonts/check/varfont/bold_wght_coord",
+    "com.google.fonts/check/varfont/bold_wght_coord",  # IS_OVERRIDDEN
     "com.google.fonts/check/varfont/regular_ital_coord",
     "com.google.fonts/check/varfont/regular_opsz_coord",
     "com.google.fonts/check/varfont/regular_slnt_coord",
@@ -226,6 +226,7 @@ OVERRIDDEN_CHECKS = [
     "com.google.fonts/check/name/trailing_spaces",
     "com.google.fonts/check/os2_metrics_match_hhea",
     "com.google.fonts/check/valid_glyphnames",
+    "com.google.fonts/check/varfont/bold_wght_coord",
     "com.google.fonts/check/whitespace_glyphs",
 ]
 
@@ -507,6 +508,16 @@ profile.check_log_override(
         "Many CFF OpenType fonts in circulation are built with the Microsoft platform"
         " Full font name string identical to the PostScript FontName in the CFF Name"
         " INDEX. This practice was documented in the OpenType spec until version 1.5.",
+    ),
+)
+
+
+profile.check_log_override(
+    # From fvar.py
+    "com.google.fonts/check/varfont/bold_wght_coord",
+    overrides=(("no-bold-instance", WARN, KEEP_ORIGINAL_MESSAGE),),
+    reason=(
+        "Adobe doesn't require a 'Bold' named instance."
     ),
 )
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -517,7 +517,8 @@ profile.check_log_override(
     "com.google.fonts/check/varfont/bold_wght_coord",
     overrides=(("no-bold-instance", WARN, KEEP_ORIGINAL_MESSAGE),),
     reason=(
-        "Adobe doesn't require a 'Bold' named instance."
+        "Adobe doesn't require a 'Bold' named instance (but when a 'Bold' instance"
+        " is present, its coordinate on the 'wght' axis must be == 700)."
     ),
 )
 

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -169,7 +169,7 @@ def com_google_fonts_check_varfont_bold_wght_coord(ttFont, bold_wght_coord):
     if bold_wght_coord is None:
         yield FAIL,\
               Message("no-bold-instance",
-                      'A "Bold" instance was not found.')
+                      '"Bold" instance not present.')
     elif bold_wght_coord == 700:
         yield PASS, "Bold:wght is 700."
     else:

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -155,7 +155,9 @@ def com_google_fonts_check_varfont_regular_opsz_coord(ttFont, regular_opsz_coord
         does not specify a required value for the 'Bold' instance of a variable font.
 
         But Dave Crossland suggested that we should enforce
-        a required value of 700 in this case.
+        a required value of 700 in this case (NOTE: a distinction
+        is made between "no bold instance present" vs "bold instance is present
+        but its wght coordinate is not == 700").
     """,
     conditions = ['is_variable_font',
                   'has_wght_axis'],
@@ -164,7 +166,11 @@ def com_google_fonts_check_varfont_regular_opsz_coord(ttFont, regular_opsz_coord
 def com_google_fonts_check_varfont_bold_wght_coord(ttFont, bold_wght_coord):
     """The variable font 'wght' (Weight) axis coordinate must be 700 on the 'Bold' instance."""
 
-    if bold_wght_coord == 700:
+    if bold_wght_coord is None:
+        yield FAIL,\
+              Message("no-bold-instance",
+                      'A "Bold" instance was not found.')
+    elif bold_wght_coord == 700:
         yield PASS, "Bold:wght is 700."
     else:
         yield FAIL,\

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -395,3 +395,20 @@ def test_check_override_trailing_spaces():
                        WindowsLanguageID.ENGLISH_USA)
     msg = assert_results_contain(check(ttFont), WARN, "trailing-space")
     assert msg.endswith("'This Font [...]Software. '")
+
+
+def test_check_override_bold_wght_coord():
+    """Check that overriden test yields WARN rather than FAIL."""
+    check = CheckTester(
+        adobefonts_profile,
+        f"com.google.fonts/check/varfont/bold_wght_coord{OVERRIDE_SUFFIX}",
+    )
+
+    ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Roman.otf"))
+
+    # remove "Bold" named instance
+    fvar_table = ttFont["fvar"]
+    del fvar_table.instances[4]
+
+    msg = assert_results_contain(check(ttFont), WARN, 'no-bold-instance')
+    assert msg == '"Bold" instance not present.'


### PR DESCRIPTION
## Description
This pull request addresses issue #3898 as follows:
 - Adds a separate test/result code for the case of "no bold instance present". N.B. this does not change the outcome of the base test at all, it simply separates the FAIL conditions to enable overriding.
 - Adobe Fonts profile overrides com.google.fonts/check/varfont/bold_wght_coord, relaxing FAIL on code `no-bold-instance` to WARN. If a bold instance is present but its 'wght' coordinate is not 700, it will still FAIL as before.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass **Note:** the pylint failures are due to the missing-timeout errors which will be fixed by https://github.com/googlefonts/fontbakery/pull/3892.
- [x] request a review

