### PR TITLE
Fix Markdown formatting in ghmarkdown reporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
   - Added a `--timeout` parameter and set timeouts on all network requests. (PR #3892)
+  - Fix summary header in the Github Markdown reporter. (PR #3923)
 
 ### Changes to existing checks
 #### On the OpenType Profile

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -128,7 +128,7 @@ class GHMarkdownReporter(SerializeReporter):
                                          "".join(map(self.check_md, checks[filename])) + "<br>")
 
         if num_checks != 0:
-            summary_table = "### Summary\n\n" + \
+            summary_table = "\n### Summary\n\n" + \
                 ("| {} " + " | {} ".join(LOGLEVELS) + " |\n").format(*[self.emoticon(k)
                                                                        for k in LOGLEVELS]) + \
                 ("|:-----:|:----:|:----:|:----:|:----:|:----:|:----:|\n"


### PR DESCRIPTION
## Description
The Github markdown reporter has a small issue when it generates the summary header. It doesn't add a newline before the header, so Github interprets it as regular text. The "fix" is to add a newline before the header.

Before:
![Screenshot from 2022-10-13 09-44-19](https://user-images.githubusercontent.com/114871/195535071-f0cd257d-0b41-4f2c-ab19-15d19bd37620.png)

After:
![Screenshot from 2022-10-13 09-44-02](https://user-images.githubusercontent.com/114871/195535109-d31e511e-3f35-4f41-ac0b-f1db8058d7b0.png)


## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

