### PR TITLE
Fix error in family vertical metrics check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
   - Added a `--timeout` parameter and set timeouts on all network requests. (PR #3892)
+  - Use `getBestFullName` for the report instead of reading name table identifier 4 directly. (PR #3924)
 
 ### Changes to existing checks
 #### On the OpenType Profile

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1021,7 +1021,7 @@ def com_google_fonts_check_family_vertical_metrics(ttFonts):
                           f"{filename} lacks a 'hhea' table.")
             continue
 
-        full_font_name = ttFont['name'].getName(4, 3, 1, 1033).toUnicode()
+        full_font_name = ttFont['name'].getBestFullName()
         vmetrics['sTypoAscender'][full_font_name] = ttFont['OS/2'].sTypoAscender
         vmetrics['sTypoDescender'][full_font_name] = ttFont['OS/2'].sTypoDescender
         vmetrics['sTypoLineGap'][full_font_name] = ttFont['OS/2'].sTypoLineGap
@@ -1105,7 +1105,7 @@ def com_google_fonts_check_superfamily_vertical_metrics(superfamily_ttFonts):
 
     for family_ttFonts in superfamily_ttFonts:
         for ttFont in family_ttFonts:
-            full_font_name = ttFont['name'].getName(4, 3, 1, 1033).toUnicode()
+            full_font_name = ttFont['name'].getBestFullName()
             vmetrics['sTypoAscender'][full_font_name] = ttFont['OS/2'].sTypoAscender
             vmetrics['sTypoDescender'][full_font_name] = ttFont['OS/2'].sTypoDescender
             vmetrics['sTypoLineGap'][full_font_name] = ttFont['OS/2'].sTypoLineGap


### PR DESCRIPTION
## Description

I have an old font with only name table identifiers 0, 1, 2 and 3. While this is a bit odd, there are no OT spec requirements for which name ids are required, so it is a valid font. Unfortunately, this font causes an error in the family vertical metrics check which tries to read name id 4 (full family name) for its output message.

This PR changes the vertical metrics check to use fonttools `getBestFullName` function to get the full family name which falls back correctly to combining name table identifiers 1 and 2 if name identifier 4 is not present.

Of course, we'll fix this font (it is correctly failing the name table checks), but I feel it shouldn't error on an unrelated check.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

