### PR TITLE
Fix handling of cmap format 14 variation sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### BugFixes
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
+  - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)
   - Added a `--timeout` parameter and set timeouts on all network requests. (PR #3892)
   - Fix summary header in the Github Markdown reporter. (PR #3923)
   - Use `getBestFullName` for the report instead of reading name table identifier 4 directly. (PR #3924)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1325,6 +1325,15 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
     # Exclude cmapped glyphs
     all_glyphs -= set(ttFont.getBestCmap().values())
 
+    # Exclude glyphs referenced by cmap format 14 variation sequences
+    # (as discussed at https://github.com/googlefonts/fontbakery/issues/3915):
+    for table in ttFont['cmap'].tables:
+        if table.format == 14:
+            for values in table.uvsDict.values():
+                for v in list(values):
+                    if v[1] is not None:
+                        all_glyphs.discard(v[1])
+
     # and ignore these:
     all_glyphs.discard(".null")
     all_glyphs.discard(".notdef")


### PR DESCRIPTION
**com.google.fonts/check/unreachable_glyphs**
(issue #3915)