### PR TITLE
Update reserved_font_name_exceptions

### DIFF
--- a/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
@@ -7,3 +7,26 @@
 # actual long list of familynames we had here
 # still needs to be more carefully reviewed.
 # See https://github.com/googlefonts/fontbakery/issues/3612
+
+#SIL fonts
+Abyssinica SIL
+Akatab
+Alkalami
+Andika
+Annapurna
+Charis SIL
+David Libre
+Ezra SIL
+Gentium Book Basic
+Gentium Book Plus
+Gentium Plus
+Harmattan
+Lateef
+Mingzat
+Narnoor
+Nuosu SIL
+Padauk
+Scheherazade New
+Shimenkan
+Tagmukay
+Tai Heritage Pro

--- a/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
@@ -17,7 +17,6 @@ Annapurna
 Charis SIL
 David Libre
 Ezra SIL
-Gentium Book Basic
 Gentium Book Plus
 Gentium Plus
 Harmattan

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -475,6 +475,7 @@ def rfn_exception(familyname):
     filename = resource_filename('fontbakery', rfn_exceptions_txt)
     for exception in open(filename, "r").readlines():
         exception = exception.split('#')[0].strip()
+        exception = exception.replace(" ", "")
         if exception == "":
             continue
 


### PR DESCRIPTION
Hello!
I added a list of fonts for which the RFN can be ignored. Here it concerns SIL fonts (upgrades or new fonts).

