### PR TITLE
Proposal: Configurable check for OS/2 achVendID.

### DIFF
--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -83,6 +83,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/varfont/same_size_instance_records',
     'com.adobe.fonts/check/varfont/distinct_instance_records',
     'com.adobe.fonts/check/stat_has_axis_value_tables',
+    'com.thetypefounders/check/vendor_id',
 ]
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/os2.py
+++ b/Lib/fontbakery/profiles/os2.py
@@ -339,7 +339,7 @@ def com_google_fonts_check_code_pages(ttFont):
         Add the `vendor_id` key to the configuration file to enable
         this check.
     """,
-    proposal =  'https://github.com/googlefonts/fontbakery/issues/287348'
+    proposal =  'https://github.com/googlefonts/fontbakery/pull/3941'
 )
 def com_thetypefounders_check_vendor_id(config, ttFont):
     """Checking OS/2 achVendID against configuration."""

--- a/Lib/fontbakery/profiles/os2.py
+++ b/Lib/fontbakery/profiles/os2.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS, WARN, INFO
+from fontbakery.status import FAIL, PASS, WARN, INFO, SKIP
 from fontbakery.message import Message
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import
@@ -329,3 +329,37 @@ def com_google_fonts_check_code_pages(ttFont):
                       " ulCodePageRange1 and CodePageRange2 fields.")
     else:
         yield PASS, "At least one code page is defined."
+
+@check(
+    id = 'com.thetypefounders/check/vendor_id',
+    rationale = """
+        Vendor ID must match the vendor identifier in the fontbakery
+        configuration file.
+
+        Add the `vendor_id` key to the configuration file to enable
+        this check.
+    """,
+    proposal =  'https://github.com/googlefonts/fontbakery/issues/287348'
+)
+def com_thetypefounders_check_vendor_id(config, ttFont):
+    """Checking OS/2 achVendID against configuration."""
+
+    if "vendor_id" not in config:
+        yield SKIP, "OS/2 achVendID `vendor_id` not defined in configuration file."
+        return
+
+    if "OS/2" not in ttFont:
+        yield FAIL,\
+                Message("lacks-OS/2",
+                        "The required OS/2 table is missing.")
+        return
+
+    config_vendor_id = config['vendor_id']
+    font_vendor_id = ttFont['OS/2'].achVendID
+
+    if config_vendor_id != font_vendor_id:
+        yield FAIL,\
+                Message("bad-vendor-id",
+                        f"OS/2 VendorID is '{font_vendor_id}', but should be '{config_vendor_id}'.")
+    else:
+        yield PASS, f"OS/2 VendorID '{font_vendor_id}' is correct."

--- a/tests/profiles/os2_test.py
+++ b/tests/profiles/os2_test.py
@@ -8,6 +8,7 @@ import fontTools.subset
 
 from fontbakery.checkrunner import (INFO, WARN, FAIL)
 from fontbakery.codetesting import (assert_PASS,
+                                    assert_SKIP,
                                     assert_results_contain,
                                     CheckTester,
                                     portable_path,
@@ -218,4 +219,27 @@ def test_check_code_pages():
     assert_results_contain(check(ttFont),
                            FAIL, "no-code-pages",
                            'with a font with no code page declared.')
+
+def test_check_vendor_id():
+    """ Check vendor id against the configured value """
+    check = CheckTester(opentype_profile,
+                        "com.thetypefounders/check/vendor_id")
+
+    ttFont = TTFont(TEST_FILE("merriweather/Merriweather-Regular.ttf"))
+    assert (ttFont['OS/2'].achVendID == 'STC ')
+
+    # If there is no configured vendor_id value, SKIP the check
+    assert_SKIP(check(ttFont))
+
+    config = { "vendor_id": "STC " }
+    assert_PASS(check({
+        "config": config,
+        "ttFont": ttFont,
+    }))
+
+    ttFont['OS/2'].achVendID = 'TEST'
+    assert_results_contain(check({
+        "config": config,
+        "ttFont": ttFont,
+    }), FAIL, "bad-vendor-id", "OS/2 VendorID is 'TEST', but should be 'STC '")
 


### PR DESCRIPTION
## Description
We manage fonts for multiple foundries and would like to use a check for the OS/2 achVendID (vendor ID) value. We often see cases where some families have the correct vendor ID, while other families (or even styles) within the same foundry have a different vendor id. Rather than creating a profile and checks for each of our foundries, it seems sensible to make the vendor id check configurable. That way, each foundry can have a `.fontbakery.yaml` file (or similar) that configures its own vendor ID. The check is skipped if the configuration value is not found.

This is different from `com.google.fonts/check/vendor_id` (which checks if the vendor id is not set to a default value and registered) and `com.fontwerk/check/vendor_id` (which checks for a single foundry). I've added it to the opentype/universal profile since it seems generally useful to other foundries, but please let me know if you prefer to keep it in a (new) `thetypefounders` profile.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

