### PR TITLE
Add configurable check for OS/2 achVendID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Universal Profile
   - **[com.google.fonts/check/interpolation_issues]:** Check for shape order or curve start point interpolation issues within a variable font. (issue #3930)
 
+#### Added to the Open Type Profile
+  - **[com.thetypefounders/check/vendor_id]:** When a font project's Vendor ID is specified explicitely on FontBakery's configuration file, all binaries must have a matching vendor identifier value in the OS/2 table. (PR #3941)
+
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/colorfont_tables]:** Check if fonts contain the correct color tables. (issue #3886)
   - **[com.google.fonts/check/description/noto_has_article]:** Noto fonts must have an ARTICLE.en_us.html file. (issue #3841)

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -83,6 +83,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.adobe.fonts/check/varfont/same_size_instance_records',
     'com.adobe.fonts/check/varfont/distinct_instance_records',
     'com.adobe.fonts/check/stat_has_axis_value_tables',
+    'com.thetypefounders/check/vendor_id',
 ]
 
 profile.auto_register(globals())

--- a/tests/profiles/os2_test.py
+++ b/tests/profiles/os2_test.py
@@ -8,6 +8,7 @@ import fontTools.subset
 
 from fontbakery.checkrunner import (INFO, WARN, FAIL)
 from fontbakery.codetesting import (assert_PASS,
+                                    assert_SKIP,
                                     assert_results_contain,
                                     CheckTester,
                                     portable_path,
@@ -218,4 +219,27 @@ def test_check_code_pages():
     assert_results_contain(check(ttFont),
                            FAIL, "no-code-pages",
                            'with a font with no code page declared.')
+
+def test_check_vendor_id():
+    """ Check vendor id against the configured value """
+    check = CheckTester(opentype_profile,
+                        "com.thetypefounders/check/vendor_id")
+
+    ttFont = TTFont(TEST_FILE("merriweather/Merriweather-Regular.ttf"))
+    assert (ttFont['OS/2'].achVendID == 'STC ')
+
+    # If there is no configured vendor_id value, SKIP the check
+    assert_SKIP(check(ttFont))
+
+    config = { "vendor_id": "STC " }
+    assert_PASS(check({
+        "config": config,
+        "ttFont": ttFont,
+    }))
+
+    ttFont['OS/2'].achVendID = 'TEST'
+    assert_results_contain(check({
+        "config": config,
+        "ttFont": ttFont,
+    }), FAIL, "bad-vendor-id", "OS/2 VendorID is 'TEST', but should be 'STC '")
 


### PR DESCRIPTION
**com.thetypefounders/check/vendor_id**

When a font project's Vendor ID is specified explicitely on FontBakery's configuration file, all binaries must have a matching vendor identifier value in the OS/2 table.

(Followup to PR #3941)