### PR TITLE
setup.py: do not install protobuf v4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/empty_glyph_on_gid1_for_colrv0]:** Ensure that GID 1 is empty to work around Windows 10 rendering bug ([gftools issue #609](https://github.com/googlefonts/gftools/issues/609))
 
 ### BugFixes
+  - **[setup.py]:** Only install Protobuf versions 3.7.0-3.20.3 (PR #3946)
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
   - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/empty_glyph_on_gid1_for_colrv0]:** Ensure that GID 1 is empty to work around Windows 10 rendering bug ([gftools issue #609](https://github.com/googlefonts/gftools/issues/609))
 
 ### BugFixes
-  - **[setup.py]:** Only install Protobuf versions 3.7.0-3.20.3 (PR #3946)
+  - **[setup.py]:** Our protobuf files have been compiled with v3 versions of protobuf which cannot be read by v4. (PR #3946)
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
   - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,9 @@ setup(
         'opentypespec',
         'packaging',  # needed for checking Font Bakery's version
         'pip-api',    # needed for checking Font Bakery's version
-        'protobuf>=3.7.0',  # 3.7.0 fixed a bug on parsing some METADATA.pb files
+        # 3.7.0 fixed a bug on parsing some METADATA.pb files.
+        # We cannot use v4 because our protobuf files have been compiled with v3.
+        'protobuf>=3.7.0, <=3.20.3',  
                             # (see https://github.com/googlefonts/fontbakery/issues/2200)
         'PyYAML',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'pip-api',    # needed for checking Font Bakery's version
         # 3.7.0 fixed a bug on parsing some METADATA.pb files.
         # We cannot use v4 because our protobuf files have been compiled with v3.
-        'protobuf>=3.7.0, <=3.20.3',  
+        'protobuf>=3.7.0, <4',  
                             # (see https://github.com/googlefonts/fontbakery/issues/2200)
         'PyYAML',
         'requests',


### PR DESCRIPTION
Our protobuf files have been compiled with v3 versions of protobuf which cannot be read by v4.

I have done `<=3.20.3` because this is the last v3 release on pypi. v3.20.3 is still able to read our protobufs.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

