### PR TITLE
Remove test that cannot fail with fontTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/empty_glyph_on_gid1_for_colrv0]:** Ensure that GID 1 is empty to work around Windows 10 rendering bug ([gftools issue #609](https://github.com/googlefonts/gftools/issues/609))
 
 ### Removed from the Open Type and Adobe Profiles
-
- - **[com.google.fonts/check/all_glyphs_have_codepoints]:** This check cannot fail with fontTools and is therefore redundant.
+  - **[com.google.fonts/check/all_glyphs_have_codepoints]:** This check cannot ever fail with fontTools and is therefore redundant. (issue #1793)
 
 ### BugFixes
   - **[setup.py]:** Our protobuf files have been compiled with v3 versions of protobuf which cannot be read by v4. (PR #3946)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/color_cpal_brightness]:** Warn if COLRv0 layers are colored too dark or too bright instead of foreground color. (PR #3908)
   - **[com.google.fonts/check/empty_glyph_on_gid1_for_colrv0]:** Ensure that GID 1 is empty to work around Windows 10 rendering bug ([gftools issue #609](https://github.com/googlefonts/gftools/issues/609))
 
+### Removed from the Open Type and Adobe Profiles
+
+ - **[com.google.fonts/check/all_glyphs_have_codepoints]:** This check cannot fail with fontTools and is therefore redundant.
+
 ### BugFixes
   - **[setup.py]:** Our protobuf files have been compiled with v3 versions of protobuf which cannot be read by v4. (PR #3946)
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -43,7 +43,6 @@ SET_EXPLICIT_CHECKS = {
     #
     # =======================================
     # From cmap.py
-    "com.google.fonts/check/all_glyphs_have_codepoints",
     "com.google.fonts/check/family/equal_unicode_encodings",
     #
     # =======================================

--- a/Lib/fontbakery/profiles/cmap.py
+++ b/Lib/fontbakery/profiles/cmap.py
@@ -32,24 +32,3 @@ def com_google_fonts_check_family_equal_unicode_encodings(ttFonts):
                       "Fonts have different unicode encodings.")
     else:
         yield PASS, "Fonts have equal unicode encodings."
-
-
-@check(
-    id = 'com.google.fonts/check/all_glyphs_have_codepoints',
-    proposal = 'https://github.com/googlefonts/fontbakery/issues/735'
-)
-def com_google_fonts_check_all_glyphs_have_codepoints(ttFont):
-    """Check all glyphs have codepoints assigned."""
-    failed = False
-    for subtable in ttFont['cmap'].tables:
-        if subtable.isUnicode():
-            for item in subtable.cmap.items():
-                codepoint = item[0]
-                if codepoint is None:
-                    failed = True
-                    yield FAIL,\
-                          Message("glyph-lacks-codepoint",
-                                  f"Glyph {codepoint} lacks a unicode"
-                                  f" codepoint assignment.")
-    if not failed:
-        yield PASS, "All glyphs have a codepoint value assigned."

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -71,7 +71,6 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/maxadvancewidth',
     'com.google.fonts/check/points_out_of_bounds',
     'com.google.fonts/check/glyf_non_transformed_duplicate_components',
-    'com.google.fonts/check/all_glyphs_have_codepoints',
     'com.google.fonts/check/code_pages',
     'com.google.fonts/check/layout_valid_feature_tags',
     'com.google.fonts/check/layout_valid_script_tags',

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -59,7 +59,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 80
+    assert len(SET_EXPLICIT_CHECKS) == 79
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/cmap_test.py
+++ b/tests/profiles/cmap_test.py
@@ -47,25 +47,3 @@ def test_check_family_equal_unicode_encodings(mada_ttFonts):
     assert_results_contain(check(bad_ttFonts),
                            FAIL, 'mismatch',
                            'with fonts that diverge on unicode encoding.')
-
-
-# Note: I am not aware of any real-case of a font that FAILs this check.
-def test_check_all_glyphs_have_codepoints():
-    """ Check all glyphs have codepoints assigned. """
-    check = CheckTester(opentype_profile,
-                        "com.google.fonts/check/all_glyphs_have_codepoints")
-
-    # our reference Mada SemiBold is know to be good here.
-    ttFont = TTFont(TEST_FILE("mada/Mada-SemiBold.ttf"))
-    assert_PASS(check(ttFont),
-                'with a good font.')
-
-    # This is a silly way to break the font.
-    # A much better test would rather use a real font file that has the problem.
-    ttFont['cmap'].tables[0].cmap[None] = "foo"
-
-    assert_results_contain(check(ttFont),
-                           FAIL, 'glyph-lacks-codepoint',
-                           'with a font in which a glyph'
-                           ' lacks a unicode codepoint assignment.')
-

--- a/tests/profiles/external_profile_test.py
+++ b/tests/profiles/external_profile_test.py
@@ -54,7 +54,6 @@ def test_profile_imports():
     ]
     # Probe some tests
     expected_tests = [
-        "com.google.fonts/check/all_glyphs_have_codepoints", # in cmap
         "com.google.fonts/check/unitsperem"  # in head
     ]
     _test(profile_imports, expected_tests)
@@ -82,7 +81,6 @@ def test_profile_imports():
     )
     # Probe some tests
     expected_tests = [
-        "com.google.fonts/check/all_glyphs_have_codepoints", # in cmap
         "com.google.fonts/check/unitsperem"  # in head
     ]
     _test(profile_imports, expected_tests)
@@ -106,7 +104,6 @@ def test_profile_imports():
     )
     # Probe some tests
     expected_tests = [
-        "com.google.fonts/check/all_glyphs_have_codepoints", # in cmap
         "com.google.fonts/check/unitsperem"  # in head
     ]
     _test(profile_imports, expected_tests)


### PR DESCRIPTION
## Description

Closes https://github.com/googlefonts/fontbakery/issues/1793 by removing the check, which cannot fail with fontTools.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [ ] request a review

