### PR TITLE
PYRS is a default Vendor ID entry from FontLab generated binaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,22 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/color_cpal_brightness]:** Warn if COLRv0 layers are colored too dark or too bright instead of foreground color. (PR #3908)
   - **[com.google.fonts/check/empty_glyph_on_gid1_for_colrv0]:** Ensure that GID 1 is empty to work around Windows 10 rendering bug ([gftools issue #609](https://github.com/googlefonts/gftools/issues/609))
 
-### Removed from the Open Type and Adobe Profiles
+### Deprecated check (removed from the Open Type and Adobe Profiles)
   - **[com.google.fonts/check/all_glyphs_have_codepoints]:** This check cannot ever fail with fontTools and is therefore redundant. (issue #1793)
+
+### Changes to existing checks
+#### On the Universal Profile
+  - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)
+
+#### On the OpenType Profile
+  - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
+
+#### On the GoogleFonts Profile
+  - **[com.google.fonts/check/vendor_id]:** PYRS is a default Vendor ID entry from FontLab generated binaries. (issue #3943)
+  - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
 
 ### BugFixes
   - **[setup.py]:** Our protobuf files have been compiled with v3 versions of protobuf which cannot be read by v4. (PR #3946)
-  - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
-  - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
-  - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)
   - Added a `--timeout` parameter and set timeouts on all network requests. (PR #3892)
   - Fix summary header in the Github Markdown reporter. (PR #3923)
   - Use `getBestFullName` for the report instead of reading name table identifier 4 directly. (PR #3924)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -922,7 +922,8 @@ def com_google_fonts_check_fstype(ttFont):
         If you registered recently, you're safe to ignore warnings emitted by this
         check, since your ID will soon be included in one of our upcoming releases.
     """,
-    proposal = 'legacy:check/018'
+    proposal = ['legacy:check/018',
+                'https://github.com/googlefonts/fontbakery/issues/3943']
 )
 def com_google_fonts_check_vendor_id(ttFont, registered_vendor_ids):
     """Checking OS/2 achVendID."""
@@ -934,7 +935,7 @@ def com_google_fonts_check_vendor_id(ttFont, registered_vendor_ids):
         " https://www.microsoft.com/typography/links/vendorlist.aspx\n")
 
     vid = ttFont['OS/2'].achVendID
-    bad_vids = ['UKWN', 'ukwn', 'PfEd']
+    bad_vids = ['UKWN', 'ukwn', 'PfEd', 'PYRS']
     if vid is None:
         yield WARN,\
               Message("not-set",

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -692,7 +692,7 @@ def test_check_vendor_id():
     # Let's start with our reference Merriweather Regular
     ttFont = TTFont(TEST_FILE("merriweather/Merriweather-Regular.ttf"))
 
-    bad_vids = ['UKWN', 'ukwn', 'PfEd']
+    bad_vids = ['UKWN', 'ukwn', 'PfEd', 'PYRS']
     for bad_vid in bad_vids:
         ttFont['OS/2'].achVendID = bad_vid
         assert_results_contain(check(ttFont),


### PR DESCRIPTION
**com.google.fonts/check/vendor_id**
(issue #3943)