### PR TITLE
U+0E3F THAI CURRENCY SYMBOL BAHT can also have 5 contours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Universal Profile
   - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)
+  - **[com.google.fonts/check/contour_count]:** U+0E3F THAI CURRENCY SYMBOL BAHT can also have 5 contours (issue #3914)
 
 #### On the OpenType Profile
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)

--- a/Lib/fontbakery/glyphdata.py
+++ b/Lib/fontbakery/glyphdata.py
@@ -10618,7 +10618,8 @@ desired_glyph_data = \
         "name": "uni0E3F", 
         "unicode": 3647, 
         "contours": [
-            3
+            3,
+            5
         ]
     }, 
     {


### PR DESCRIPTION
com.google.fonts/check/contour_count
(issue #3914)