### PR TITLE
Disable more FontVal checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/vendor_id]:** PYRS is a default Vendor ID entry from FontLab generated binaries. (issue #3943)
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
 
+#### On the FontVal Profile
+  - **[com.google.fonts/check/fontvalidator]:** Disable a slew of frequent false positive warnings.
+
 ### BugFixes
   - **[setup.py]:** Our protobuf files have been compiled with v3 versions of protobuf which cannot be read by v4. (PR #3946)
   - Added a `--timeout` parameter and set timeouts on all network requests. (PR #3892)


### PR DESCRIPTION
## Description
This pull request disables more spurious warnings in FontVal. We've collected them over the years.

Arguably, some of the stuff should be fixed upstream, but who's got the time?

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [ ] request a review

