### PR TITLE
Configurable fontval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)
 
 #### On the FontVal Profile
-  - **[com.google.fonts/check/fontvalidator]:** Disable a slew of frequent false positive warnings.
+  - **[com.google.fonts/check/fontvalidator]:** Disable a slew of frequent false positive warnings and make the check configurable via the configuration.
 
 ### BugFixes
   - **[setup.py]:** Our protobuf files have been compiled with v3 versions of protobuf which cannot be read by v4. (PR #3946)

--- a/Lib/fontbakery/profiles/fontval.py
+++ b/Lib/fontbakery/profiles/fontval.py
@@ -5,7 +5,7 @@ from fontbakery.status import ERROR, FAIL, INFO, PASS, WARN
 from fontbakery.section import Section
 from fontbakery.message import Message
 # used to inform get_module_profile whether and how to create a profile
-from fontbakery.fonts_profile import profile_factory # NOQA pylint: disable=unused-import
+from fontbakery.fonts_profile import profile_factory
 from .shared_conditions import is_cff, is_variable_font
 
 profile_imports = ['.shared_conditions']

--- a/Lib/fontbakery/profiles/fontval.py
+++ b/Lib/fontbakery/profiles/fontval.py
@@ -220,10 +220,6 @@ def com_google_fonts_check_fontvalidator(font):
                     grouped_msgs[msg]["details"].append(details)
 
     # ---------------------------
-    # Clean-up generated files...
-    del report_dir
-
-    # ---------------------------
     # Here we start emitting the grouped log messages
     for msg, data in grouped_msgs.items():
         # But before printing we try to make the "details" more

--- a/tests/profiles/fontval_test.py
+++ b/tests/profiles/fontval_test.py
@@ -15,10 +15,11 @@ def test_check_fontvalidator():
     check = fontval_profile.com_google_fonts_check_fontvalidator
 
     font = TEST_FILE("mada/Mada-Regular.ttf")
+    config = {}
 
     # Then we make sure that there wasn't an ERROR
     # which would mean FontValidator is not properly installed:
-    for status, message in check(font):
+    for status, message in check(font, config):
         assert status != ERROR
 
     # Simulate FontVal missing.
@@ -26,7 +27,7 @@ def test_check_fontvalidator():
     old_path = os.environ["PATH"]
     os.environ["PATH"] = ""
     with pytest.raises(OSError) as _:
-        assert_results_contain(check(font),
+        assert_results_contain(check(font, config),
                                ERROR, "fontval-not-available")
     os.environ["PATH"] = old_path
 


### PR DESCRIPTION
## Description
This pull request makes the FontValidator check configurable via the... configuration. You can select checks to report or not. I left out a way to just add checks to ignore because if you go to the trouble to make a config, you probably want to precisely control what you see 🤷 

Where do I document the configuration?

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

