### PR TITLE
Drop Python 3.7 and add support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ axisregistry==0.3.11
 beautifulsoup4==4.11.2
 beziers==0.5.0
 cmarkgfm==2022.10.27
-collidoscope==0.4.1
+collidoscope==0.5.2
 defcon==0.10.2
 dehinter==4.0.0
 fontTools[ufo,lxml,unicode]==4.38.0

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,10 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     setup_requires=[
         'setuptools>=61.2',
         'setuptools_scm[toml]>=6.2',

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,8 @@ setup(
         'beautifulsoup4',
         'beziers>=0.5.0', # Uses new fontTools glyph outline access
         'cmarkgfm',
-        'collidoscope==0.4.1', # 0.4.0 had a bug that failed to detect
-                               # an ïï collision on Nunito Black.
-                               # (see https://github.com/googlefonts/fontbakery/issues/3554)
+        'collidoscope>=0.5.2', # 0.5.1 did not yet support python 3.11
+                               # (see https://github.com/googlefonts/fontbakery/issues/3970)
         'defcon',
         'dehinter>=3.1.0', # 3.1.0 added dehinter.font.hint function
         'fontTools[ufo,lxml,unicode]>=4.36.0',  # allows for passing location to glyphsets


### PR DESCRIPTION
bump up collidoscope version on requirements.txt and setup.py to sort out issue that was not allowing users to install fontbakery on python 3.11
(issue #3970)