### PR TITLE
Updates to the AdobeFonts profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the AdobeFonts Profile
   - **[com.adobe.fonts/check/stat_has_axis_value_tables]:** Added check that format 4 AxisValue tables have AxisCount (number of AxisValueRecords) > 1 (issue #3957)
   - **[com.adobe.fonts/check/stat_has_axis_value_tables]:** Improved overall check to FAIL when an unknown AxisValue.Format is encountered.
+  - **[com.adobe.fonts/check/STAT_strings]:** Added a more lenient version of com.google.fonts/check/STAT_strings (allows "Italic" on 'slnt' or 'ital' axes).
+  - **[com.google.fonts/check/STAT_strings]:** removed from the list of explicit checks.
+  - **[com.google.fonts/check/transformed_components]**: removed from the list of explicit checks.
 #### On the Universal Profile
   - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)
   - **[com.google.fonts/check/contour_count]:** U+0E3F THAI CURRENCY SYMBOL BAHT can also have 5 contours (issue #3914)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -177,6 +177,7 @@ SET_EXPLICIT_CHECKS = {
     # "com.google.fonts/check/dotted_circle",
     # "com.google.fonts/check/unreachable_glyphs",
     # "com.google.fonts/check/STAT_strings",
+    # "com.google.fonts/check/transformed_components",
     # ---
     "com.adobe.fonts/check/freetype_rasterizer",             # IS_OVERRIDDEN
     "com.google.fonts/check/family/win_ascent_and_descent",  # IS_OVERRIDDEN
@@ -194,7 +195,6 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/ots",
     "com.google.fonts/check/required_tables",
     "com.google.fonts/check/rupee",
-    "com.google.fonts/check/transformed_components",
     "com.google.fonts/check/ttx_roundtrip",
     "com.google.fonts/check/unique_glyphnames",
     "com.google.fonts/check/whitespace_widths",

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -59,7 +59,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 79
+    assert len(SET_EXPLICIT_CHECKS) == 78
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -412,3 +412,24 @@ def test_check_override_bold_wght_coord():
 
     msg = assert_results_contain(check(ttFont), WARN, 'no-bold-instance')
     assert msg == '"Bold" instance not present.'
+
+
+def test_check_STAT_strings():
+    """Check com.adobe.fonts/check/STAT_strings."""
+    check = CheckTester(
+        adobefonts_profile,
+        "com.adobe.fonts/check/STAT_strings",
+    )
+
+    # This should FAIL (like com.google.fonts/check/STAT_strings that
+    # it is based on) because it uses "Italic" in names for 'wght' and 'wdth' axes.
+    ttFont = TTFont(TEST_FILE("ibmplexsans-vf/IBMPlexSansVar-Italic.ttf"))
+    msg = assert_results_contain(check(ttFont), FAIL, 'bad-italic')
+    assert 'The following AxisValue entries in the STAT table should not contain "Italic"' in msg
+
+    # Now set up a font using "Italic" for the 'slnt' axis
+    ttFont = TTFont(TEST_FILE("slant_direction/Cairo_correct_slnt_axis.ttf"))
+    ttFont['name'].setName("Italic", 286, 3, 1, 1033)
+    # This should PASS with our check
+    msg = assert_results_contain(check(ttFont), PASS, 'bad-italic')
+    assert msg == 'Looks good!'


### PR DESCRIPTION
## Description
- Add a new check, com.adobe.fonts/check/STAT_strings which allows "Italic" for either 'slnt' or 'ital' axes (based on com.google.fonts/check/STAT_strings which only allows "Italic" for 'ital' axis).
- Removed 2 checks from the adobefonts profile's explicit checks:
    - com.google.fonts/check/STAT_strings
    - com.google.fonts/check/transformed_components

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

