### PR TITLE
Fix false-FAIL on metadata/can_render_samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## Upcoming release: 0.8.11 (2022-Nov-??)
+## Upcoming release: 0.8.11 (2022-Dec-??)
 ### New Checks
 #### Added to the Universal Profile
   - **[com.google.fonts/check/interpolation_issues]:** Check for shape order or curve start point interpolation issues within a variable font. (issue #3930)
@@ -27,6 +27,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/STAT_strings]:** Added a more lenient version of com.google.fonts/check/STAT_strings (allows "Italic" on 'slnt' or 'ital' axes).
   - **[com.google.fonts/check/STAT_strings]:** removed from the list of explicit checks.
   - **[com.google.fonts/check/transformed_components]**: removed from the list of explicit checks.
+
 #### On the Universal Profile
   - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)
   - **[com.google.fonts/check/contour_count]:** U+0E3F THAI CURRENCY SYMBOL BAHT can also have 5 contours (issue #3914)
@@ -35,6 +36,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
 
 #### On the GoogleFonts Profile
+  - **[com.google.fonts/check/metadata/can_render_samples]:** Fix false-FAIL by removing '\n' and U+200B (zero width space) characteres from sample strings (issue #3990)
   - **[com.google.fonts/check/metadata/broken_links]:** add special handling for github url (issue #2550)
   - **[com.google.fonts/check/vendor_id]:** PYRS is a default Vendor ID entry from FontLab generated binaries. (issue #3943)
   - **[com.google.fonts/check/colorfont_tables]:** Check for four-digit 'SVG ' table instead of 'SVG' (PR #3903)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -6214,6 +6214,14 @@ def com_google_fonts_check_metadata_can_render_samples(ttFont, family_metadata):
     passed = True
     languages = LoadLanguages()
     for lang in family_metadata.languages:
+        if lang not in languages:
+            yield WARN, \
+                  Message("no-sample-string",
+                          f"Aparently there's no sample strings for"
+                          f" '{lang}' in the gflanguages package.")
+            passed = False
+            continue
+
         # Note: checking agains all samples often results in
         #       a way too verbose output. That's why I only left
         #       the "tester" string for now.

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -6227,6 +6227,10 @@ def com_google_fonts_check_metadata_can_render_samples(ttFont, family_metadata):
             #'specimen_48': languages[lang].sample_text.specimen_48
         }
         for sample_type, sample_text in SAMPLES.items():
+            # Remove line-breaks and zero width space (U+200B) characteres.
+            # For more info, see https://github.com/googlefonts/fontbakery/issues/3990
+            sample_text = sample_text.replace("\n", "").replace("\u200b", "")
+
             if not can_shape(ttFont, sample_text):
                 passed = False
                 yield FAIL,\


### PR DESCRIPTION
Fix false-FAIL by removing '\n' and U+200B (zero width space) characteres from sample strings.

**com.google.fonts/check/metadata/can_render_samples**
(issue #3990)
