### PR TITLE
New `Proposals` profile - to temporarily host new checks before they're ready for inclusion on other profiles

### DIFF
--- a/Lib/fontbakery/callable.py
+++ b/Lib/fontbakery/callable.py
@@ -166,6 +166,9 @@ class FontBakeryCheck(FontbakeryCallable):
                                   # Using markdown, perhaps?
                  proposal=None,  # An URL to the original proposal for this check.
                                  # This is typically a github issue or pull request.
+                 proponent=None,  # Name Surname (@github_username)
+                 suggested_profile=None,  # A suggestion of which fontbakery profile
+                                          # should this check be added to once implemented.
                  severity=None,  # numeric value from 1=min to 10=max, denoting check severity
                  configs=None,  # items from config[self.id] to inject into the check's namespace.
                  misc_metadata=None,  # Miscelaneous free-form metadata fields
@@ -232,6 +235,8 @@ class FontBakeryCheck(FontbakeryCallable):
                                                             documentation)
         self.configs = configs
         self.proposal = proposal
+        self.proponent = proponent
+        self.suggested_profile = suggested_profile
         self.severity = severity
         if not self.description:
             raise TypeError('{} needs a description.'.format(type(self).__name__))

--- a/Lib/fontbakery/cli.py
+++ b/Lib/fontbakery/cli.py
@@ -19,6 +19,7 @@ CLI_PROFILES = [
     "opentype",
     "ufo_sources",
     "universal",
+    "proposals",
 ]
 
 

--- a/Lib/fontbakery/profiles/proposals.py
+++ b/Lib/fontbakery/profiles/proposals.py
@@ -6,9 +6,11 @@ to one of the other profiles (either universal, or a vendor-specific one).
 
 from fontbakery.callable import check
 from fontbakery.section import Section
-from fontbakery.status import INFO # PASS, WARN, FAIL
+from fontbakery.status import INFO, PASS, FAIL # WARN
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.message import Message
+from .googlefonts_conditions import * # pylint: disable=wildcard-import,unused-wildcard-import
+from .shared_conditions import * # pylint: disable=wildcard-import,unused-wildcard-import
 
 profile = profile_factory(default_section=Section("Check Proposals"))
 
@@ -58,6 +60,31 @@ def com_google_fonts_check_mandatory_name_entries(ttFont):
     yield INFO,\
           Message('stub',
                   "This proposed check was not yet implemented!\n")
+
+
+@check(
+    suggested_profile = "googlefonts",
+    proponent = "Rosalie Wagner (@RosaWagner)",
+    id = 'com.google.fonts/check/metadata/empty_designer',
+    rationale = """
+        Any font published on Google Fonts must credit one or several authors,
+        foundry and/or individuals.
+
+        Ideally, all authors listed in the upstream repository's AUTHORS.txt should
+        be mentioned in the designer field.
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/3961'
+)
+def com_google_fonts_check_metadata_empty_designer(family_metadata):
+    """At least one designer is declared in METADATA.pb"""
+
+    if family_metadata.designer.strip() == "":
+        yield FAIL,\
+              Message("empty-designer",
+                      "Font designer field is empty.")
+    # TODO: Parse AUTHORS.txt and WARN if names do not match (and then maybe rename the check-id)
+    else:
+        yield PASS, "Font designer field is not empty."
 
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/proposals.py
+++ b/Lib/fontbakery/profiles/proposals.py
@@ -4,11 +4,11 @@ experimental implementations can live for a while, until they're promoted
 to one of the other profiles (either universal, or a vendor-specific one).
 """
 
-#from fontbakery.callable import check
+from fontbakery.callable import check
 from fontbakery.section import Section
-#from fontbakery.status import PASS, FAIL, INFO
+from fontbakery.status import INFO # PASS, WARN, FAIL
 from fontbakery.fonts_profile import profile_factory
-#from fontbakery.message import Message
+from fontbakery.message import Message
 
 profile = profile_factory(default_section=Section("Check Proposals"))
 
@@ -29,8 +29,35 @@ def com_<revese_domain>_check_<check_name>(ttFont):
 
     yield INFO,\
           Message('stub',
-                  "This proposed check was not yet implemented!")
+                  "This proposed check was not yet implemented!\n")
 '''
+
+
+@check(
+    suggested_profile = "googlefonts",
+    proponent = "Rosalie Wagner (@RosaWagner)",
+    id = 'com.google.fonts/check/mandatory_name_entries',
+    rationale = """
+        Any fonts checked with GF profile must contain these name IDs:
+        
+        * ID 0: Copyright string (Copyright: No complaint when everything is missing #3950)
+        
+        * ID 9: author's name
+        
+        * ID 13: License description
+        
+        * ID 14: License URL
+        
+        I think we don't care so much about Manufacturer's name, Manufacturer's URL and Designer's URL, but will confirm.
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/3963'
+)
+def com_google_fonts_check_mandatory_name_entries(ttFont):
+    """Mandatory name table entries (other than font names)"""
+
+    yield INFO,\
+          Message('stub',
+                  "This proposed check was not yet implemented!\n")
 
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/proposals.py
+++ b/Lib/fontbakery/profiles/proposals.py
@@ -1,0 +1,36 @@
+"""
+This is a temporary profile where proposed new checks with incomplete or
+experimental implementations can live for a while, until they're promoted
+to one of the other profiles (either universal, or a vendor-specific one).
+"""
+
+#from fontbakery.callable import check
+from fontbakery.section import Section
+#from fontbakery.status import PASS, FAIL, INFO
+from fontbakery.fonts_profile import profile_factory
+#from fontbakery.message import Message
+
+profile = profile_factory(default_section=Section("Check Proposals"))
+
+'''
+Please, feel free to use this template when adding new check proposals here:
+
+@check(
+    # Suggested profile: <profile-name>
+    # Proponent: <name>
+    id = 'com.<revese-domain>/check/<check-name>',
+    rationale = """
+        <insert rationale text here>
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/<issue-number>'
+)
+def com_<revese_domain>_check_<check_name>(ttFont):
+    """<insert a one-line short description here>"""
+
+    yield INFO,\
+          Message('stub',
+                  "This proposed check was not yet implemented!")
+'''
+
+
+profile.auto_register(globals())

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -444,6 +444,15 @@ class TerminalReporter(TerminalProgress):
                                       space_padding=True,
                                       text_color=self.theme["rationale-text"]))
 
+                if check.suggested_profile:
+                    print("    " + self.theme["rationale-title"]("Suggested Profile:") + f" {check.suggested_profile}")
+
+                if check.proponent:
+                    print("    " + self.theme["rationale-title"]("Proponent:") + f" {check.proponent}")
+
+                if check.proposal:
+                    print("    " + self.theme["rationale-title"]("More info:") + f" {check.proposal}")
+
         # Log statuses have weights >= 0
         # log_statuses = (INFO, WARN, PASS, SKIP, FAIL, ERROR, DEBUG)
         if status.weight >= self._log_threshold:

--- a/docs/source/fontbakery/profiles/index.rst
+++ b/docs/source/fontbakery/profiles/index.rst
@@ -5,6 +5,7 @@ profiles
 .. toctree::
    :maxdepth: 1
 
+   proposals
    opentype
    universal
    adobefonts

--- a/docs/source/fontbakery/profiles/proposals.rst
+++ b/docs/source/fontbakery/profiles/proposals.rst
@@ -1,0 +1,9 @@
+#########
+proposals
+#########
+
+This is a temporary profile where proposed new checks with incomplete or experimental implementations can live for a while, until they're promoted to one of the other profiles (either universal, or a vendor-specific one).
+
+.. automodule:: fontbakery.profiles.proposals
+   :members:
+   :undoc-members:


### PR DESCRIPTION
This is a new idea. To have new checks implemented on a temporary profile so that they don't cause trouble on production CI jobs. After a while, we can move them to other profiles such as `universal` or one of the vendor-specific ones.

At first, I think we do not need to make this "experimental" stage mandatory for all new checks. But I see this as a place to host those checks which may still be at an early stage of development and perhaps the QA policy for the specific problem being checked may not be well established yet.