### PR TITLE
Print "more info" links on terminal reporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.8.11 (2022-Dec-??)
+### Noteworthy code-changes
+  - The terminal reporter now prints out URLs for "more info" (typically github issues) where the user can learn more about how the check was originally proposed/discussed. (PR #3994)
+
 ### New Checks
 #### Added to the Universal Profile
   - **[com.google.fonts/check/interpolation_issues]:** Check for shape order or curve start point interpolation issues within a variable font. (issue #3930)

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -451,7 +451,18 @@ class TerminalReporter(TerminalProgress):
                     print("    " + self.theme["rationale-title"]("Proponent:") + f" {check.proponent}")
 
                 if check.proposal:
-                    print("    " + self.theme["rationale-title"]("More info:") + f" {check.proposal}")
+                    moreinfo = check.proposal
+                    if not isinstance(moreinfo, list):
+                       moreinfo = [moreinfo]
+
+                    # Here I remove the "legacy" entries because they lack an actual
+                    # url which the users could access to read more about the check
+                    moreinfo = [mi for mi in moreinfo if 'legacy' not in mi]
+                    if moreinfo:
+                        moreinfo_str = "    " + self.theme["rationale-title"]("More info:") + " " + moreinfo[0] + "\n"
+                        if len(moreinfo) > 1:
+                            moreinfo_str += "\n".join(["               " + i for i in moreinfo[1:]])
+                        print(moreinfo_str)
 
         # Log statuses have weights >= 0
         # log_statuses = (INFO, WARN, PASS, SKIP, FAIL, ERROR, DEBUG)


### PR DESCRIPTION
The terminal reporter now prints out URLs for "more info" (typically github issues) where the user can learn more about how the check was originally proposed/discussed.