### PR TITLE
Relax some checks in the adobefonts profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/STAT_strings]:** Added a more lenient version of com.google.fonts/check/STAT_strings (allows "Italic" on 'slnt' or 'ital' axes).
   - **[com.google.fonts/check/STAT_strings]:** removed from the list of explicit checks.
   - **[com.google.fonts/check/transformed_components]**: removed from the list of explicit checks.
+  - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]**: relax `invalid-default-instance-subfamily-name` and `invalid-default-instance-postscript-name` from FAIL to WARN.
+  - **[com.adobe.fonts/check/stat_has_axis_value_tables]**: relax `missing-axis-value-table` and `format-4-axis-count` from FAIL to WARN.
+  - **[com.fontwerk/check/inconsistencies_between_fvar_stat]**: relax `missing-fvar-instance-axis-value` from FAIL to WARN.
+  - **[com.fontwerk/check/weight_class_fvar]**: relax `bad-weight-class` from FAIL to WARN.
+  - **[com.google.fonts/check/varfont/bold_wght_coord]**: relax `wght-not-700` from FAIL to WARN.
 
 #### On the Universal Profile
   - **[com.google.fonts/check/unreachable_glyphs]:** Fix handling of format 14 'cmap' table. (issue #3915)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -569,10 +569,13 @@ profile.check_log_override(
 profile.check_log_override(
     # From fvar.py
     "com.google.fonts/check/varfont/bold_wght_coord",
-    overrides=(("no-bold-instance", WARN, KEEP_ORIGINAL_MESSAGE),),
+    overrides=(
+        ("no-bold-instance", WARN, KEEP_ORIGINAL_MESSAGE),
+        ("wght-not-700", WARN, KEEP_ORIGINAL_MESSAGE),
+    ),
     reason=(
-        "Adobe doesn't require a 'Bold' named instance (but when a 'Bold' instance"
-        " is present, its coordinate on the 'wght' axis must be == 700)."
+        "Adobe strongly recommends, but does not require having a Bold instance,"
+        " and that instance should have coordinate 700 on the 'wght' axis."
     ),
 )
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -165,7 +165,7 @@ SET_EXPLICIT_CHECKS = {
     #
     # =======================================
     # From stat.py
-    "com.adobe.fonts/check/stat_has_axis_value_tables",
+    "com.adobe.fonts/check/stat_has_axis_value_tables",  # IS_OVERRIDDEN
     "com.google.fonts/check/varfont/stat_axis_record_for_each_axis",
     #
     # =======================================
@@ -221,6 +221,7 @@ ADOBEFONTS_PROFILE_CHECKS = [
 
 OVERRIDDEN_CHECKS = [
     "com.adobe.fonts/check/freetype_rasterizer",
+    "com.adobe.fonts/check/stat_has_axis_value_tables",
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
     "com.google.fonts/check/family/win_ascent_and_descent",
     "com.google.fonts/check/fontbakery_version",
@@ -580,6 +581,23 @@ profile.check_log_override(
     overrides=(
         ("invalid-default-instance-subfamily-name", WARN, KEEP_ORIGINAL_MESSAGE),
         ("invalid-default-instance-postscript-name", WARN, KEEP_ORIGINAL_MESSAGE),
+    ),
+    reason=(
+        "Adobe and the OpenType spec strongly recommend following these"
+        " guidelines, but they are not hard requirements so we are relaxing"
+        " this to WARN rather than FAIL.⏎"
+        "Fonts that do not meet these guidelines might behave inconsistently"
+        " so please carefully consider trying to meet them."
+    ),
+)
+
+
+profile.check_log_override(
+    # From stat.py
+    "com.adobe.fonts/check/stat_has_axis_value_tables",
+    overrides=(
+        ("missing-axis-value-table", WARN, KEEP_ORIGINAL_MESSAGE),
+        ("format-4-axis-count", WARN, KEEP_ORIGINAL_MESSAGE),
     ),
     reason=(
         "Adobe and the OpenType spec strongly recommend following these"

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -56,7 +56,7 @@ SET_EXPLICIT_CHECKS = {
     # "com.fontwerk/check/vendor_id",      # PERMANENTLY_EXCLUDED
     # "com.fontwerk/check/no_mac_entries",
     "com.fontwerk/check/inconsistencies_between_fvar_stat",  # IS_OVERRIDDEN
-    "com.fontwerk/check/weight_class_fvar",
+    "com.fontwerk/check/weight_class_fvar",  # IS_OVERRIDDEN
     #
     # =======================================
     # From fvar.py
@@ -224,6 +224,7 @@ OVERRIDDEN_CHECKS = [
     "com.adobe.fonts/check/stat_has_axis_value_tables",
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
     "com.fontwerk/check/inconsistencies_between_fvar_stat",
+    "com.fontwerk/check/weight_class_fvar",
     "com.google.fonts/check/family/win_ascent_and_descent",
     "com.google.fonts/check/fontbakery_version",
     "com.google.fonts/check/name/match_familyname_fullfont",
@@ -614,6 +615,20 @@ profile.check_log_override(
     # From fontwerk.py
     "com.fontwerk/check/inconsistencies_between_fvar_stat",
     overrides=(("missing-fvar-instance-axis-value", WARN, KEEP_ORIGINAL_MESSAGE),),
+    reason=(
+        "Adobe and Fontwerk strongly recommend following this"
+        " guideline, but it is not a hard requirement so we are relaxing"
+        " this to WARN rather than FAIL.⏎"
+        "Fonts that do not meet this guideline might behave inconsistently"
+        " so please carefully consider trying to meet it."
+    ),
+)
+
+
+profile.check_log_override(
+    # From fontwerk.py
+    "com.fontwerk/check/weight_class_fvar",
+    overrides=(("bad-weight-class", WARN, KEEP_ORIGINAL_MESSAGE),),
     reason=(
         "Adobe and Fontwerk strongly recommend following this"
         " guideline, but it is not a hard requirement so we are relaxing"

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -55,7 +55,7 @@ SET_EXPLICIT_CHECKS = {
     # "com.fontwerk/check/style_linking",  # PERMANENTLY_EXCLUDED
     # "com.fontwerk/check/vendor_id",      # PERMANENTLY_EXCLUDED
     # "com.fontwerk/check/no_mac_entries",
-    "com.fontwerk/check/inconsistencies_between_fvar_stat",
+    "com.fontwerk/check/inconsistencies_between_fvar_stat",  # IS_OVERRIDDEN
     "com.fontwerk/check/weight_class_fvar",
     #
     # =======================================
@@ -223,6 +223,7 @@ OVERRIDDEN_CHECKS = [
     "com.adobe.fonts/check/freetype_rasterizer",
     "com.adobe.fonts/check/stat_has_axis_value_tables",
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
+    "com.fontwerk/check/inconsistencies_between_fvar_stat",
     "com.google.fonts/check/family/win_ascent_and_descent",
     "com.google.fonts/check/fontbakery_version",
     "com.google.fonts/check/name/match_familyname_fullfont",
@@ -605,6 +606,20 @@ profile.check_log_override(
         " this to WARN rather than FAIL.⏎"
         "Fonts that do not meet these guidelines might behave inconsistently"
         " so please carefully consider trying to meet them."
+    ),
+)
+
+
+profile.check_log_override(
+    # From fontwerk.py
+    "com.fontwerk/check/inconsistencies_between_fvar_stat",
+    overrides=(("missing-fvar-instance-axis-value", WARN, KEEP_ORIGINAL_MESSAGE),),
+    reason=(
+        "Adobe and Fontwerk strongly recommend following this"
+        " guideline, but it is not a hard requirement so we are relaxing"
+        " this to WARN rather than FAIL.⏎"
+        "Fonts that do not meet this guideline might behave inconsistently"
+        " so please carefully consider trying to meet it."
     ),
 )
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -63,7 +63,7 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/varfont/distinct_instance_records",
     "com.adobe.fonts/check/varfont/same_size_instance_records",
     "com.adobe.fonts/check/varfont/valid_axis_nameid",
-    "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
+    "com.adobe.fonts/check/varfont/valid_default_instance_nameids",  # IS_OVERRIDDEN
     "com.adobe.fonts/check/varfont/valid_postscript_nameid",
     "com.adobe.fonts/check/varfont/valid_subfamily_nameid",
     "com.google.fonts/check/varfont/bold_wght_coord",  # IS_OVERRIDDEN
@@ -221,6 +221,7 @@ ADOBEFONTS_PROFILE_CHECKS = [
 
 OVERRIDDEN_CHECKS = [
     "com.adobe.fonts/check/freetype_rasterizer",
+    "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
     "com.google.fonts/check/family/win_ascent_and_descent",
     "com.google.fonts/check/fontbakery_version",
     "com.google.fonts/check/name/match_familyname_fullfont",
@@ -569,6 +570,23 @@ profile.check_log_override(
     reason=(
         "Adobe doesn't require a 'Bold' named instance (but when a 'Bold' instance"
         " is present, its coordinate on the 'wght' axis must be == 700)."
+    ),
+)
+
+
+profile.check_log_override(
+    # From fvar.py
+    "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
+    overrides=(
+        ("invalid-default-instance-subfamily-name", WARN, KEEP_ORIGINAL_MESSAGE),
+        ("invalid-default-instance-postscript-name", WARN, KEEP_ORIGINAL_MESSAGE),
+    ),
+    reason=(
+        "Adobe and the OpenType spec strongly recommend following these"
+        " guidelines, but they are not hard requirements so we are relaxing"
+        " this to WARN rather than FAIL.⏎"
+        "Fonts that do not meet these guidelines might behave inconsistently"
+        " so please carefully consider trying to meet them."
     ),
 )
 

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -400,7 +400,7 @@ def test_check_override_inconsistencies_between_fvar_stat():
                            'missing in STAT table')
 
 
-def test_check_weight_class_fvar():
+def test_check_override_weight_class_fvar():
     check = CheckTester(adobefonts_profile,
                         f'com.fontwerk/check/weight_class_fvar{OVERRIDE_SUFFIX}')
 

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -488,16 +488,21 @@ def test_check_override_trailing_spaces():
 
 
 def test_check_override_bold_wght_coord():
-    """Check that overriden test yields WARN rather than FAIL."""
+    """Check that overriden tests yield WARN rather than FAIL."""
     check = CheckTester(
         adobefonts_profile,
         f"com.google.fonts/check/varfont/bold_wght_coord{OVERRIDE_SUFFIX}",
     )
 
     ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Roman.otf"))
+    fvar_table = ttFont["fvar"]
+
+    # change the Bold instance 'wght' coord to something other than 700
+    fvar_table.instances[4].coordinates['wght'] = 725
+    msg = assert_results_contain(check(ttFont), WARN, 'wght-not-700')
+    assert msg.startswith('The "wght" axis coordinate of the "Bold" instance must be 700.')
 
     # remove "Bold" named instance
-    fvar_table = ttFont["fvar"]
     del fvar_table.instances[4]
 
     msg = assert_results_contain(check(ttFont), WARN, 'no-bold-instance')

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -400,6 +400,17 @@ def test_check_override_inconsistencies_between_fvar_stat():
                            'missing in STAT table')
 
 
+def test_check_weight_class_fvar():
+    check = CheckTester(adobefonts_profile,
+                        f'com.fontwerk/check/weight_class_fvar{OVERRIDE_SUFFIX}')
+
+    ttFont = TTFont(TEST_FILE('varfont/Oswald-VF.ttf'))
+    ttFont['OS/2'].usWeightClass = 333
+    assert_results_contain(check(ttFont),
+                           WARN, 'bad-weight-class',
+                           "but should match fvar default value.")
+
+
 @patch("freetype.Face", side_effect=ImportError)
 def test_check_override_freetype_rasterizer(mock_import_error):
     """Check that overridden test yields FAIL rather than SKIP."""

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -356,7 +356,7 @@ def test_check_override_varfont_valid_default_instance_nameids():
 
 
 def test_check_override_stat_has_axis_value_tables():
-    """Check that overriddent tests yield the right result."""
+    """Check that overridden tests yield the right result."""
     check = CheckTester(
         adobefonts_profile,
         f"com.adobe.fonts/check/stat_has_axis_value_tables{OVERRIDE_SUFFIX}",
@@ -385,6 +385,19 @@ def test_check_override_stat_has_axis_value_tables():
     ttFont['STAT'].table.AxisValueArray.AxisValue.append(f4avt)
     msg = assert_results_contain(check(ttFont), WARN, "format-4-axis-count")
     assert msg == "STAT Format 4 Axis Value table has axis count <= 1."
+
+
+def test_check_override_inconsistencies_between_fvar_stat():
+    """Check that the overridden test yields WARN rather than FAIL"""
+    check = CheckTester(adobefonts_profile,
+                        f'com.fontwerk/check/inconsistencies_between_fvar_stat{OVERRIDE_SUFFIX}')
+
+    ttFont = TTFont(TEST_FILE("bad_fonts/fvar_stat_differences/AxisLocationVAR.ttf"))
+    # add name with wrong order of name parts
+    ttFont['name'].setName('Medium Text', 277, 3, 1, 0x409)
+    assert_results_contain(check(ttFont),
+                           WARN, 'missing-fvar-instance-axis-value',
+                           'missing in STAT table')
 
 
 @patch("freetype.Face", side_effect=ImportError)


### PR DESCRIPTION
## Description
This pull request relaxes (overrides) a number of checks from FAIL to WARN when using the adobefonts profile.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

