### PR TITLE
[com.google.fonts/check/varfont/wdth_valid_range] modify to match strictness of OTSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the OpenType Profile
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]:** The check did not account for nameID 17. (issue #3895)
+  - **[com.google.fonts/check/varfont/wdth_valid_range]:** Modified (relaxed) to match the OpenType spec's valid range ("strictly greater than zero")
 
 #### On the GoogleFonts Profile
   - **[com.google.fonts/check/metadata/can_render_samples]:** Fix false-FAIL by removing '\n' and U+200B (zero width space) characteres from sample strings (issue #3990)

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -220,7 +220,7 @@ def com_google_fonts_check_varfont_wght_valid_range(ttFont):
         registered design-variation tag 'wdth' available at
         https://docs.microsoft.com/en-gb/typography/opentype/spec/dvaraxistag_wdth
 
-        On the 'wdth' (Width) axis, the valid coordinate range is 1-1000
+        On the 'wdth' (Width) axis, the valid numeric range is strictly greater than zero.
     """,
     conditions = ['is_variable_font',
                   'has_wdth_axis'],
@@ -228,18 +228,24 @@ def com_google_fonts_check_varfont_wght_valid_range(ttFont):
 )
 def com_google_fonts_check_varfont_wdth_valid_range(ttFont):
     """The variable font 'wdth' (Width) axis coordinate
-       must be within spec range of 1 to 1000 on all instances."""
+       must strictly greater than zero."""
 
     passed = True
     for instance in ttFont['fvar'].instances:
         if 'wdth' in instance.coordinates:
             value = instance.coordinates['wdth']
-            if value < 1 or value > 1000:
+            if value < 1:
                 passed = False
                 yield FAIL,\
                       Message("wdth-out-of-range",
                               f'Found a bad "wdth" coordinate with value {value}'
-                              f' outside of the valid range from 1 to 1000.')
+                              f' outside of the valid range (> 0).')
+                break
+            if value > 1000:
+                yield WARN,\
+                      Message("wdth-greater-than-1000",
+                              f'Found a "wdth" coordinate with value {value}'
+                              f' which is valid but unusual.')
                 break
 
     if passed:

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -271,7 +271,7 @@ def test_check_varfont_wght_valid_range():
 
 def test_check_varfont_wdth_valid_range():
     """ The variable font 'wdth' (Width) axis coordinate
-        must be within spec range of 1 to 1000 on all instances. """
+        must be strictly greater than zero, per the spec. """
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/varfont/wdth_valid_range")
 
@@ -287,10 +287,10 @@ def test_check_varfont_wdth_valid_range():
                            FAIL, 'wdth-out-of-range',
                            'with wght=0...')
 
-    # And yet another bad value:
+    # A valid but unusual value:
     ttFont["fvar"].instances[0].coordinates["wdth"] = 1001
     assert_results_contain(check(ttFont),
-                           FAIL, 'wdth-out-of-range',
+                           WARN, 'wdth-greater-than-1000',
                            'with wght=1001...')
 
 


### PR DESCRIPTION
## Description
This pull request addresses the problem of a too-strict check for `com.google.fonts/check/varfont/wdth_valid_range` as described at issue #3984. Specifically:
- the check now FAILs only when the `wdth` coordinate is < 1
- the check WARNs when the `wdth` coordinate is > 1000 (which is valid, but unusual)

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

