### PR TITLE
Update assert_results_contain() to correctly check for expected_msgcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - Overriden checks now also properly inherit conditions. (issue #3952)
   - Updated style condition to correctly handle VFs (PR #4007)
   - Do not include an "And" on the last item of bullet lists. (issue #4006)
+  - Correctly process expected messages when they are plain strings in assert_results_contain()
 
 ### New Checks
 #### Added to the Universal Profile

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -229,7 +229,7 @@ def assert_results_contain(check_results,
                 f"(Bare string: {msg!r})")
 
         if status == expected_status and (
-            isinstance(msg, str)
+            isinstance(msg, str) and msg == expected_msgcode
             or (isinstance(msg, Message) and msg.code == expected_msgcode)
         ):
             if isinstance(msg, Message):

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -526,5 +526,5 @@ def test_check_STAT_strings():
     ttFont = TTFont(TEST_FILE("slant_direction/Cairo_correct_slnt_axis.ttf"))
     ttFont['name'].setName("Italic", 286, 3, 1, 1033)
     # This should PASS with our check
-    msg = assert_results_contain(check(ttFont), PASS, 'bad-italic')
+    msg = assert_results_contain(check(ttFont), PASS, 'Looks good!')
     assert msg == 'Looks good!'


### PR DESCRIPTION
## Description
When `expected_msgcode` are plain strings in `assert_results_contain()`, they weren't getting processed properly; a simple oversight. This PR fixes that.
As a result, one code test needed updating where the expected code was actually getting ignored (and was therefore wrongly set in the code test).

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

