### PR TITLE
Introduce italic name checks in OpenType profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### Added to the Open Type Profile
   - **[com.thetypefounders/check/vendor_id]:** When a font project's Vendor ID is specified explicitely on FontBakery's configuration file, all binaries must have a matching vendor identifier value in the OS/2 table. (PR #3941)
+  - **[com.google.fonts/check/name/italic_names]:** Implemented checks for name IDs 1, 2, 16, 17 for Italic fonts (issues #3666 and #3667)
 
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/colorfont_tables]:** Check if fonts contain the correct color tables. (issue #3886)

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -78,6 +78,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/italic_angle',
     'com.google.fonts/check/mac_style',
     'com.google.fonts/check/fsselection',
+    'com.google.fonts/check/name/italic_names',
     'com.adobe.fonts/check/varfont/valid_axis_nameid',
     'com.adobe.fonts/check/varfont/valid_subfamily_nameid',
     'com.adobe.fonts/check/varfont/valid_postscript_nameid',


### PR DESCRIPTION
## Description
This pull request addresses the problems described at issue #3666 and #3667
It checks name IDs 1, 2, 16, 17 for Italic fonts.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [x] request a review

