### PR TITLE
Fix italic angle

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -6361,8 +6361,11 @@ profile.check_log_override(
 profile.check_log_override(
     # From opentype.py
     "com.google.fonts/check/italic_angle",
-    overrides=(("over-minus30-degrees", FAIL, KEEP_ORIGINAL_MESSAGE),),
-    reason=("For Google Fonts, an Italic angle over -30° is considered a FAIL."),
+    overrides=(
+        ("positive", FAIL, KEEP_ORIGINAL_MESSAGE),
+        ("over-30-degrees", FAIL, KEEP_ORIGINAL_MESSAGE),
+    ),
+    reason=("Google Fonts has different policies on checking for italic angle."),
 )
 
 GOOGLEFONTS_PROFILE_CHECKS = add_check_overrides(

--- a/Lib/fontbakery/profiles/post.py
+++ b/Lib/fontbakery/profiles/post.py
@@ -115,8 +115,8 @@ def com_google_fonts_check_post_table_version(ttFont):
     conditions = ['style'],
     rationale = """
         The 'post' table italicAngle property should be a reasonable amount, likely
-        not more than -20°, never more than -30°, and never greater than 0°. Note that
-        in the OpenType specification, the value is negative for a lean rightwards.
+        not more than 30°. Note that
+        in the OpenType specification, the value is negative for a rightward lean.
 
         https://docs.microsoft.com/en-us/typography/opentype/spec/post
     """,
@@ -130,26 +130,35 @@ def com_google_fonts_check_italic_angle(ttFont, style):
     # Checking that italicAngle <= 0
     if value > 0:
         failed = True
-        yield FAIL,\
+        yield WARN,\
               Message("positive",
-                      (f"The value of post.italicAngle is positive, which"
-                       f" is likely a mistake and should become negative,"
-                       f" from {value} to {-value}."))
+                      ("The value of post.italicAngle is positive, which"
+                       " is likely a mistake and should become negative"
+                       " for right-leaning Italics. If this font is"
+                       " left-leaning, ignore this warning."))
+
+    # Checking that italicAngle > 90
+    if abs(value) > 90:
+        failed = True
+        yield FAIL,\
+              Message("over-90-degrees",
+                      ("The value of post.italicAngle is over 90°, which"
+                      " is surely a mistake."))
 
     # Checking that italicAngle is less than 20° (not good) or 30° (bad)
     # Also note we invert the value to check it in a clear way
     if abs(value) > 30:
         failed = True
         yield WARN,\
-              Message("over-minus30-degrees",
+              Message("over-30-degrees",
                       (f"The value of post.italicAngle ({value}) is very high"
-                       f" (over -30°!) and should be confirmed."))
+                       f" (over -30° or 30°) and should be confirmed."))
     elif abs(value) > 20:
         failed = True
         yield WARN,\
-              Message("over-minus20-degrees",
+              Message("over-20-degrees",
                       (f"The value of post.italicAngle ({value}) seems very high"
-                       f" (over -20°!) and should be confirmed."))
+                       f" (over -20° or 20°) and should be confirmed."))
 
 
     # Checking if italicAngle matches font style:
@@ -164,7 +173,7 @@ def com_google_fonts_check_italic_angle(ttFont, style):
         if ttFont["post"].italicAngle != 0:
             failed = True
             yield FAIL,\
-                  Message("non-zero-normal",
+                  Message("non-zero-upright",
                           ("Font is not italic, so post.italicAngle"
                            " should be equal to zero."))
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2277,12 +2277,13 @@ def test_check_italic_angle():
     # italic-angle, style, fail_message
     test_cases = [
         [1, "Italic", FAIL, "positive"],
-        [0, "Regular", PASS, None], # This must PASS as it is a non-italic
-        [-21, "ThinItalic", WARN, "over-minus20-degrees"],
-        [-30, "ThinItalic", WARN, "over-minus20-degrees"],
-        [-31, "ThinItalic", FAIL, "over-minus30-degrees"],
+        [0, "Regular", PASS, None],  # This must PASS as it is a non-italic
+        [-21, "ThinItalic", WARN, "over-20-degrees"],
+        [-30, "ThinItalic", WARN, "over-20-degrees"],
+        [-31, "ThinItalic", FAIL, "over-30-degrees"],
+        [-91, "ThinItalic", FAIL, "over-90-degrees"],
         [0, "Italic", FAIL, "zero-italic"],
-        [-1,"ExtraBold", FAIL, "non-zero-normal"]
+        [-1, "ExtraBold", FAIL, "non-zero-upright"],
     ]
 
     for value, style, expected_result, expected_msg in test_cases:

--- a/tests/profiles/post_test.py
+++ b/tests/profiles/post_test.py
@@ -138,13 +138,14 @@ def test_check_italic_angle():
 
     # italic-angle, style, fail_message
     test_cases = [
-        [1, "Italic", FAIL, "positive"],
-        [0, "Regular", PASS, None], # This must PASS as it is a non-italic
-        [-21, "ThinItalic", WARN, "over-minus20-degrees"],
-        [-30, "ThinItalic", WARN, "over-minus20-degrees"],
-        [-31, "ThinItalic", WARN, "over-minus30-degrees"],
+        [1, "Italic", WARN, "positive"],
+        [0, "Regular", PASS, None],  # This must PASS as it is a non-italic
+        [-21, "ThinItalic", WARN, "over-20-degrees"],
+        [-30, "ThinItalic", WARN, "over-20-degrees"],
+        [-31, "ThinItalic", WARN, "over-30-degrees"],
+        [-91, "ThinItalic", FAIL, "over-90-degrees"],
         [0, "Italic", FAIL, "zero-italic"],
-        [-1,"ExtraBold", FAIL, "non-zero-normal"]
+        [-1, "ExtraBold", FAIL, "non-zero-upright"],
     ]
 
     for value, style, expected_result, expected_msg in test_cases:


### PR DESCRIPTION
## Description
@khaledhosny noted in a comment to issue https://github.com/googlefonts/fontbakery/issues/3665 that Italics can be also left-leaning and therefore have positive `post.italicAngle` values, which is true. He may have posted the comment on the wrong issue and deleted it since, since it can't be found. But I received it by email.

I decided to downgrade the `positive` value check to WARN on the OT profile while keeping it as a FAIL override for GF profile.
I also removed all mention of negative values (`over-minus20-degrees` message to `over-20-degrees`). That check itself was already checking for `abs(value)`, so would have caught wrong values in both leaning directions, but the wording needed to catch up.

I'm leaving the `over-20-degrees` and `over-30-degrees` WARNs in place as they need to exist in order for GF profile to override them. It's reasonable to have those as WARNs in the OT profile, also the `positive` WARN. The overwhelming majority of fonts are right-leaning, and the wording "likely a mistake" already suggested that this could be a false warning. I clarified the rationales a bit.

I also added a `over-90-degrees` check.

Not updating `CHANGELOG.md` here as the check is newly introduced to the OT profile anyway which is already noted.


## To Do
- [ ] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

