### PR TITLE
Deprecate com.google.fonts/check/listed_on_gfonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,12 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/empty_glyph_on_gid1_for_colrv0]:** Ensure that GID 1 is empty to work around Windows 10 rendering bug ([gftools issue #609](https://github.com/googlefonts/gftools/issues/609))
   - **[com.google.fonts/check/metadata/valid_nameid25]:** Check Name ID 25 for VF Italics (issue #3024)
 
-### Deprecated check (removed from the Open Type and Adobe Profiles)
+### Deprecated checks
+#### Removed from the Open Type and Adobe Profiles
   - **[com.google.fonts/check/all_glyphs_have_codepoints]:** This check cannot ever fail with fontTools and is therefore redundant. (issue #1793)
+
+#### Removed from the Google Fonts Profile
+  - **[com.google.fonts/check/listed_on_gfonts]:** Did not pass for any new families and was not deemed to be a useful check by the onboarding team. The WARN was actually considered annoying. (issue #3220)
 
 ### Changes to existing checks
 #### On the Universal Profile

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -44,7 +44,6 @@ METADATA_CHECKS = [
     'com.google.fonts/check/metadata/unknown_designer',
     'com.google.fonts/check/metadata/multiple_designers',
     'com.google.fonts/check/metadata/designer_values',
-    'com.google.fonts/check/metadata/listed_on_gfonts',
     'com.google.fonts/check/metadata/unique_full_name_values',
     'com.google.fonts/check/metadata/unique_weight_style_pairs',
     'com.google.fonts/check/metadata/license',
@@ -1888,21 +1887,6 @@ def com_google_fonts_check_name_ascii_only_entries(ttFont):
     else:
         yield PASS, ("None of the ASCII-only NAME table entries"
                      " contain non-ASCII characteres.")
-
-
-@check(
-    id = 'com.google.fonts/check/metadata/listed_on_gfonts',
-    conditions = ['family_metadata'],
-    proposal = 'legacy:check/082'
-)
-def com_google_fonts_check_metadata_listed_on_gfonts(font, listed_on_gfonts_api):
-    """METADATA.pb: Fontfamily is listed on Google Fonts API?"""
-    if not listed_on_gfonts_api:
-        yield WARN,\
-              Message("not-found",
-                      "Family not found via Google Fonts API.")
-    else:
-        yield PASS, "Font is properly listed via Google Fonts API."
 
 
 @check(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1201,36 +1201,6 @@ def test_split_camel_case_condition():
     assert split_camel_case("LibreCaslonText") == "Libre Caslon Text"
 
 
-def test_check_metadata_listed_on_gfonts():
-    """ METADATA.pb: Fontfamily is listed on Google Fonts API? """
-    check = CheckTester(googlefonts_profile,
-                        "com.google.fonts/check/metadata/listed_on_gfonts")
-
-    font = TEST_FILE("familysans/FamilySans-Regular.ttf")
-    # Our reference FamilySans family is a just a generic example
-    # and thus is not really hosted (nor will ever be hosted) at Google Fonts servers:
-    assert_results_contain(check(font),
-                           WARN, 'not-found',
-                           f'with "{font}", from a family that\'s'
-                           f' not listed on GFonts...')
-
-    font = TEST_FILE("merriweather/Merriweather-Regular.ttf")
-    # Our reference Merriweather family is available on the Google Fonts collection:
-    assert_PASS(check(font),
-                f'with "{font}", from a family that is'
-                f' listed on Google Fonts API...')
-
-    font = TEST_FILE("abeezee/ABeeZee-Regular.ttf")
-    # This is to ensure the code handles well camel-cased familynames.
-    assert_PASS(check(font),
-                f'with "{font}", listed and with a camel-cased name...')
-
-    font = TEST_FILE("librecaslontext/LibreCaslonText[wght].ttf")
-    # And the check should also properly handle space-separated multi-word familynames.
-    assert_PASS(check(font),
-                f'with "{font}", available and with a space-separated family name...')
-
-
 def test_check_metadata_unique_full_name_values():
     """ METADATA.pb: check if fonts field only has unique "full_name" values. """
     check = CheckTester(googlefonts_profile,


### PR DESCRIPTION
Removed check from Google Fonts profile.

It did not pass for any new families and was not deemed to be a useful check by the onboarding team. The WARN was actually considered annoying.

The listed_on_gfonts_api condition remains, though, as it is still is use in other checks.
(issue #3220)