### PR TITLE
Try to be stricter in caret_slope

### DIFF
--- a/Lib/fontbakery/profiles/hhea.py
+++ b/Lib/fontbakery/profiles/hhea.py
@@ -99,7 +99,9 @@ def com_google_fonts_check_caret_slope(ttFont):
     run = ttFont["hhea"].caretSlopeRun
     rise = ttFont["hhea"].caretSlopeRise
     if rise == 0:
-        yield FAIL, "caretSlopeRise must not be zero. Set it to 1 for upright fonts."
+        yield FAIL,\
+              Message("zero-rise",
+                      "caretSlopeRise must not be zero. Set it to 1 for upright fonts.")
         return
     hheaItalicAngle = math.degrees(math.tan(-1 * run / rise))
     expectedCaretSlopeRun = round(math.atan(math.radians(-1 * postItalicAngle)) * upm)

--- a/Lib/fontbakery/profiles/hhea.py
+++ b/Lib/fontbakery/profiles/hhea.py
@@ -98,9 +98,15 @@ def com_google_fonts_check_caret_slope(ttFont):
     upm = ttFont["head"].unitsPerEm
     run = ttFont["hhea"].caretSlopeRun
     rise = ttFont["hhea"].caretSlopeRise
+    if rise == 0:
+        yield FAIL, "caretSlopeRise must not be zero. Set it to 1 for upright fonts."
+        return
     hheaItalicAngle = math.degrees(math.tan(-1 * run / rise))
-    expectedCaretSlopeRise = upm
     expectedCaretSlopeRun = round(math.atan(math.radians(-1 * postItalicAngle)) * upm)
+    if expectedCaretSlopeRun == 0:
+        expectedCaretSlopeRise = 1
+    else:
+        expectedCaretSlopeRise = upm
 
     if abs(postItalicAngle - hheaItalicAngle) > .1:
         yield FAIL,\

--- a/tests/profiles/hhea_test.py
+++ b/tests/profiles/hhea_test.py
@@ -73,7 +73,8 @@ def test_check_caretslope():
     # FAIL for right-leaning
     ttFont = TTFont(TEST_FILE("shantell/ShantellSans-Italic[BNCE,INFM,SPAC,wght].ttf"))
     ttFont["post"].italicAngle = -12
-    message = assert_results_contain(check(ttFont), FAIL, 'caretslope-mismatch')
+    message = assert_results_contain(check(ttFont),
+                                     FAIL, 'caretslope-mismatch')
     assert message == (
         "hhea.caretSlopeRise and hhea.caretSlopeRun do not match with post.italicAngle.\n"
         "Got: caretSlopeRise 1000 and caretSlopeRun 190\n"
@@ -84,9 +85,18 @@ def test_check_caretslope():
     ttFont["hhea"].caretSlopeRun = 206
     assert_PASS(check(ttFont))
 
+    good_value = ttFont["hhea"].caretSlopeRise
+    ttFont["hhea"].caretSlopeRise = 0
+    assert_results_contain(check(ttFont),
+                           FAIL, 'zero-rise')
+
+    # Fix it again from backed up good value
+    ttFont["hhea"].caretSlopeRise = good_value
+
     # FAIL for left-leaning
     ttFont["post"].italicAngle = 12
-    message = assert_results_contain(check(ttFont), FAIL, 'caretslope-mismatch')
+    message = assert_results_contain(check(ttFont),
+                                     FAIL, 'caretslope-mismatch')
     assert message == (
         "hhea.caretSlopeRise and hhea.caretSlopeRun do not match with post.italicAngle.\n"
         "Got: caretSlopeRise 1000 and caretSlopeRun 206\n"


### PR DESCRIPTION
## Description
* Print a clear error message if caretSlopeRise is zero rather than Python error
* Expect a caretSlopeRise of 1 for upright fonts

## To Do
- [ ] update `CHANGELOG.md` (necessary? It's a new check)
- [ ] wait for all checks to pass
- [ ] request a review

