### PR TITLE
Remove freshly added test files after test

### DIFF
--- a/tests/profiles/stat_test.py
+++ b/tests/profiles/stat_test.py
@@ -159,6 +159,9 @@ def test_check_italic_axis_in_stat():
     ]
     assert_results_contain(check(fonts),
                            FAIL, "missing-ital-axis")
+    import os
+    for font in fonts:
+        os.remove(font)
 
 
 def test_check_italic_axis_in_stat_is_boolean():


### PR DESCRIPTION
## Description
I had previously written a test where two new test files get altered and saved under a new name. Those then show up in the repo waiting to be committed when I run the unit tests locally. Too great is the danger that they'll get accidentally committed one day. Not a biggie, but unnecessary. This change deletes them right away after the test.

## To Do
- [ ] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [ ] request a review

