### PR TITLE
Scour all cmap tables for encoded glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ A more detailed list of changes is available in the corresponding milestones for
   instance (code: `no-bold-instance`) versus having a bold instance whose wght coord != 700 (existing code `wght-not-700`). (issue #3898)
   - **[com.google.fonts/check/italic_angle]:**  Improve italic_angle check to base reporting on Italic angle as measure from outline. (PR #4031)
   - **[com.google.fonts/check/italic_axis_in_stat_is_boolean]:** Skip check if font doesn't have an ital axis. (PR #4033)
+  - **[com.google.fonts/check/kern_table]**: Scour all cmap tables for encoded glyphs.
 
 #### On the AdobeFonts Profile
   - **[com.adobe.fonts/check/stat_has_axis_value_tables]:** Added check that format 4 AxisValue tables have AxisCount (number of AxisValueRecords) > 1 (issue #3957)

--- a/Lib/fontbakery/profiles/kern.py
+++ b/Lib/fontbakery/profiles/kern.py
@@ -35,14 +35,18 @@ def com_google_fonts_check_kern_table(ttFont):
 
     kern = ttFont.get("kern")
     if kern:
-        cmap = set(ttFont.getBestCmap().values())
+        # Scour all cmap tables for encoded glyphs.
+        characterGlyphs = set()
+        for table in ttFont["cmap"].tables:
+            characterGlyphs.update(table.cmap.values())
+
         nonCharacterGlyphs = set()
         for kernTable in kern.kernTables:
             if kernTable.format == 0:
                 for leftGlyph, rightGlyph in kernTable.kernTable.keys():
-                    if leftGlyph not in cmap:
+                    if leftGlyph not in characterGlyphs:
                         nonCharacterGlyphs.add(leftGlyph)
-                    if rightGlyph not in cmap:
+                    if rightGlyph not in characterGlyphs:
                         nonCharacterGlyphs.add(rightGlyph)
         if all(kernTable.format != 0 for kernTable in kern.kernTables):
           yield WARN,\


### PR DESCRIPTION
## Description
Scour all cmap tables for encoded glyphs when looking for unencoded glyphs to report in the `kern` table.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

