### PR TITLE
new check: com.google.fonts/check/soft_hyphen (Added to the Universal profile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Universal Profile
   - **[com.google.fonts/check/interpolation_issues]:** Check for shape order or curve start point interpolation issues within a variable font. (issue #3930)
   - **[com.google.fonts/check/math_signs_width]:** Check that math signs have the same width (issue #3832)
+  - **[com.google.fonts/check/soft_hyphen]:** It was originally part of the validation on **check/contour_count**, but it was leading to confusion, so it was split out into a separate check. (issue #4046)
 
 #### Added to the Open Type Profile
   - **[com.thetypefounders/check/vendor_id]:** When a font project's Vendor ID is specified explicitely on FontBakery's configuration file, all binaries must have a matching vendor identifier value in the OS/2 table. (PR #3941)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -64,6 +64,7 @@ UNIVERSAL_PROFILE_CHECKS = \
         'com.google.fonts/check/rupee',
         'com.google.fonts/check/unreachable_glyphs',
         'com.google.fonts/check/contour_count',
+        'com.google.fonts/check/soft_hyphen',
         'com.google.fonts/check/cjk_chws_feature',
         'com.google.fonts/check/transformed_components',
         'com.google.fonts/check/dotted_circle',
@@ -1470,16 +1471,6 @@ def com_google_fonts_check_contour_count(ttFont, config):
         font_glyph_contours_by_glyphname = {f['name']: list(f['contours'])[0]
                                             for f in font_glyph_data}
 
-        if 0x00AD in font_glyph_contours_by_codepoint.keys():
-            yield WARN,\
-                  Message("softhyphen",
-                          "This font has a 'Soft Hyphen' character (codepoint 0x00AD)"
-                          " which is supposed to be zero-width and invisible, and is"
-                          " used to mark a hyphenation possibility within a word"
-                          " in the absence of or overriding dictionary hyphenation."
-                          " It is mostly an obsolete mechanism now, and the character"
-                          " is only included in fonts for legacy codepage coverage.")
-
         shared_glyphs_by_codepoint = set(desired_glyph_contours_by_codepoint) & \
                                      set(font_glyph_contours_by_codepoint)
         for glyph in sorted(shared_glyphs_by_codepoint):
@@ -1534,6 +1525,30 @@ def com_google_fonts_check_contour_count(ttFont, config):
                           f"\n")
         else:
             yield PASS, "All glyphs have the recommended amount of contours"
+
+
+@check(
+    id = 'com.google.fonts/check/soft_hyphen',
+    rationale = """
+        The 'Soft Hyphen' character (codepoint 0x00AD) is used to mark
+        a hyphenation possibility within a word in the absence of or
+        overriding dictionary hyphenation.
+
+        It is supposed to be zero-width and invisible.
+
+        It is also mostly an obsolete mechanism now, and the character
+        is typicaly only included in fonts for legacy codepage coverage.
+    """,
+    proposal = 'https://github.com/googlefonts/fontbakery/issues/4046'
+)
+def com_google_fonts_check_soft_hyphen(ttFont):
+    """Does the font contain a soft hyphen?"""
+    if 0x00AD in ttFont['cmap'].getBestCmap().keys():
+        yield WARN,\
+              Message("softhyphen",
+                      "This font has a 'Soft Hyphen' character.")
+    else:
+        yield PASS, "Looks good!"
 
 
 @check(

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -967,18 +967,25 @@ def test_check_unreachable_glyphs():
         assert glyph not in message
 
 
+def test_check_soft_hyphen(montserrat_ttFonts):
+    """Check glyphs contain the recommended contour count"""
+    check = CheckTester(universal_profile,
+                        "com.google.fonts/check/soft_hyphen")
+    for ttFont in montserrat_ttFonts:
+        # Montserrat has a softhyphen...
+        assert_results_contain(check(ttFont),
+                               WARN, 'softhyphen')
+
+        _remove_cmap_entry(ttFont, 0x00AD)
+        assert_PASS(check(ttFont))
+
+
 def test_check_contour_count(montserrat_ttFonts):
     """Check glyphs contain the recommended contour count"""
     check = CheckTester(universal_profile,
                         "com.google.fonts/check/contour_count")
-    # TODO: FAIL, "lacks-cmap"
-
-    for ttFont in montserrat_ttFonts:
-        # Montserrat which was used to assemble the glyph data,
-        # so, it should be good, except for that softhyphen...
-        # TODO: how can we test PASS then?
-        assert_results_contain(check(ttFont),
-                               WARN, 'softhyphen')
+    # TODO: test FAIL, "lacks-cmap"
+    # TODO: test PASS
 
     # Lets swap the glyf 'a' (2 contours) with glyf 'c' (1 contour)
     for ttFont in montserrat_ttFonts:


### PR DESCRIPTION
It was originally part of the validation on **check/contour_count**, but was leading to confusion, so it was split out into a separate check. (issue #4046)