### PR TITLE
Fix to match familyname / fullfont check to allow for matching with nameID 16/21

### DIFF
--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -263,28 +263,6 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
                           " all related metadata look good.")
 
 
-@check(
-    id = 'com.google.fonts/check/name/match_familyname_fullfont',
-    rationale = """
-        The FULL_FONT_NAME entry in the ‘name’ table should start with the same string
-        as the Family Name (FONT_FAMILY_NAME, TYPOGRAPHIC_FAMILY_NAME or
-        WWS_FAMILY_NAME).
-
-        If the Family Name is not included as the first part of the Full Font Name, and
-        the user embeds the font in a document using a Microsoft Office app, the app
-        will fail to render the font when it opens the document again.
-
-        NOTE: Up until version 1.5, the OpenType spec included the following exception
-        in the definition of Full Font Name:
-
-            "An exception to the [above] definition of Full font name is for Microsoft
-            platform strings for CFF OpenType fonts: in this case, the Full font name
-            string must be identical to the PostScript FontName in the CFF Name INDEX."
-
-        https://docs.microsoft.com/en-us/typography/opentype/otspec150/name#name-ids
-    """,
-    proposal = 'legacy:check/068'
-)
 def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
     """Does full font name begin with the font family name?"""
 
@@ -317,6 +295,7 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
                 for family_name_id in (NameID.FONT_FAMILY_NAME,
                                        NameID.TYPOGRAPHIC_FAMILY_NAME,
                                        NameID.WWS_FAMILY_NAME):
+                    print ("family_name_id",family_name_id)
                     if name_table.getName(
                             family_name_id, plat_id, enc_id, lang_id) is None:
                         # The family_name_id wasn't found. Move on to the next
@@ -341,7 +320,6 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
                         )
                         passed = False
                         continue
-
                     try:
                         full_name = name_table.getName(
                             full_name_id, plat_id, enc_id, lang_id).toUnicode()
@@ -354,19 +332,15 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
                         passed = False
                         continue
 
-                    if not full_name.startswith(family_name):
-                        yield FAIL, Message(
-                            "mismatch-font-names",
-                            f"On the 'name' table, the full font name {full_name!r}"
-                            f" does not begin with the font family name {family_name!r}"
-                            f" in platformID {plat_id},"
-                            f" encodingID {enc_id},"
-                            f" languageID {lang_id}({lang_id:04X}),"
-                            f" and nameID {family_name_id}."
-                        )
+                    if full_name.startswith(family_name):
+                        yield PASS, "Full font name begins with the font family name."
+                        passed = True
+                        break
+                    else:
                         passed = False
+                        continue
 
-    if not names_compared:
+    if not names_compared or passed == False:
         yield FAIL, Message(
             "missing-font-names",
             f"The font's 'name' table lacks a pair of records with"

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -269,14 +269,18 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
         The FULL_FONT_NAME entry in the ‘name’ table should start with the same string
         as the Family Name (FONT_FAMILY_NAME, TYPOGRAPHIC_FAMILY_NAME or
         WWS_FAMILY_NAME).
+
         If the Family Name is not included as the first part of the Full Font Name, and
         the user embeds the font in a document using a Microsoft Office app, the app
         will fail to render the font when it opens the document again.
+
         NOTE: Up until version 1.5, the OpenType spec included the following exception
         in the definition of Full Font Name:
+
             "An exception to the [above] definition of Full font name is for Microsoft
             platform strings for CFF OpenType fonts: in this case, the Full font name
             string must be identical to the PostScript FontName in the CFF Name INDEX."
+            
         https://docs.microsoft.com/en-us/typography/opentype/otspec150/name#name-ids
     """,
     proposal = 'legacy:check/068'

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -280,7 +280,7 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
             "An exception to the [above] definition of Full font name is for Microsoft
             platform strings for CFF OpenType fonts: in this case, the Full font name
             string must be identical to the PostScript FontName in the CFF Name INDEX."
-            
+
         https://docs.microsoft.com/en-us/typography/opentype/otspec150/name#name-ids
     """,
     proposal = 'legacy:check/068'

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -263,6 +263,24 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
                           " all related metadata look good.")
 
 
+@check(
+    id = 'com.google.fonts/check/name/match_familyname_fullfont',
+    rationale = """
+        The FULL_FONT_NAME entry in the ‘name’ table should start with the same string
+        as the Family Name (FONT_FAMILY_NAME, TYPOGRAPHIC_FAMILY_NAME or
+        WWS_FAMILY_NAME).
+        If the Family Name is not included as the first part of the Full Font Name, and
+        the user embeds the font in a document using a Microsoft Office app, the app
+        will fail to render the font when it opens the document again.
+        NOTE: Up until version 1.5, the OpenType spec included the following exception
+        in the definition of Full Font Name:
+            "An exception to the [above] definition of Full font name is for Microsoft
+            platform strings for CFF OpenType fonts: in this case, the Full font name
+            string must be identical to the PostScript FontName in the CFF Name INDEX."
+        https://docs.microsoft.com/en-us/typography/opentype/otspec150/name#name-ids
+    """,
+    proposal = 'legacy:check/068'
+)
 def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
     """Does full font name begin with the font family name?"""
 
@@ -295,7 +313,6 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
                 for family_name_id in (NameID.FONT_FAMILY_NAME,
                                        NameID.TYPOGRAPHIC_FAMILY_NAME,
                                        NameID.WWS_FAMILY_NAME):
-                    print ("family_name_id",family_name_id)
                     if name_table.getName(
                             family_name_id, plat_id, enc_id, lang_id) is None:
                         # The family_name_id wasn't found. Move on to the next
@@ -320,6 +337,7 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
                         )
                         passed = False
                         continue
+
                     try:
                         full_name = name_table.getName(
                             full_name_id, plat_id, enc_id, lang_id).toUnicode()

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -333,12 +333,10 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
                         continue
 
                     if full_name.startswith(family_name):
-                        yield PASS, "Full font name begins with the font family name."
                         passed = True
                         break
                     else:
                         passed = False
-                        continue
 
     if not names_compared or passed == False:
         yield FAIL, Message(


### PR DESCRIPTION
Updating the com_google_fonts_check_name_match_familyname_fullfont check to properly consider name ID 16 / 21 rather than failing out after ID 1

## Description
The com_google_fonts_check_name_match_familyname_fullfont check, at present, appears to issue a fail if it does not match the font full name to the family name in name ID 1. However, under certain circumstances (Bold Condensed), there will be an inherent mismatch due to preserving the RIBBI quad in Name ID 1:

Name ID
1 - TestName Condensed
2 - Bold
4 - TestName Bold Condensed
16 - TestName
17 - Bold Condensed
21 - TestName
22 - Bold Condensed

This update modifies the check to evaluate Name ID 1, Name ID 16, and Name ID 21 first, and issuing a "pass" if it finds a match among any of the three. 

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

