### PR TITLE
WARN when monospaced fonts have hhea.numberOfHMetrics != 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.adobe.fonts/check/stat_has_axis_value_tables]:** Fixed bug that resulted in an ERROR when attempting to access `.AxisIndex` of a format 4 AxisValue table (issue #3904)
   - **[com.google.fonts/check/varfont/bold_wght_coord]:** The check was modified to distinguish between a font having no bold
   instance (code: `no-bold-instance`) versus having a bold instance whose wght coord != 700 (existing code `wght-not-700`). (issue #3898)
-  - **[com.google.fonts/check/monospace]:** The check was modified to also check that `hhea.numberOfHMetrics` equals `3` for monospaced fonts, as per [Microsoft's recommendation](https://learn.microsoft.com/en-us/typography/opentype/spec/recom#hhea-table). (PR #4025)
+  - **[com.google.fonts/check/monospace]:** The check was modified to WARN when `hhea.numberOfHMetrics` is not `3` for monospaced fonts, as per [Microsoft's recommendation](https://learn.microsoft.com/en-us/typography/opentype/spec/recom#hhea-table). (PR #4025 & PR #4074)
   - **[com.google.fonts/check/varfont/regular_wght_coord]:** The check was modified to distinguish between a font having no regular
   instance (code: `no-regular-instance`) versus having a regular instance whose wght coord != 400 (existing code `wght-not-400`). (issue #4003)
   - **[com.google.fonts/check/varfont/regular_wdth_coord]:** The check was modified to distinguish between a font having no regular

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -196,14 +196,17 @@ def com_google_fonts_check_monospace(ttFont, glyph_metrics_stats):
                           f" (meaning 'fixed width monospaced'),"
                           f" but got {ttFont['post'].isFixedPitch} instead.")
 
-        # https://learn.microsoft.com/en-us/typography/opentype/spec/recom#hhea-table
         number_of_h_metrics = ttFont['hhea'].numberOfHMetrics
         if number_of_h_metrics != 3:
             passed = False
-            yield FAIL,\
+            yield WARN,\
                   Message("bad-numberOfHMetrics",
-                          f"Value of hhea.numberOfHMetrics should be set to 3"
-                          f" but got {number_of_h_metrics} instead.")
+                          f"The OpenType spec recomments at https://learn.microsoft.com/"
+                          f"en-us/typography/opentype/spec/recom#hhea-table"
+                          f" that hhea.numberOfHMetrics be set to 3"
+                          f" but this font has {number_of_h_metrics} instead.\n"
+                          f"Please read https://github.com/fonttools/fonttools/issues/3014"
+                          f" to decide whether this makes sense for your font.")
 
         if not PANOSE_is_monospaced(ttFont['OS/2'].panose):
             passed = False


### PR DESCRIPTION
**com.google.fonts/check/monospace**

Following recommendadion from the OpenType spec

* https://learn.microsoft.com/en-us/typography/opentype/spec/recom#hhea-table
* PR #4025
* https://github.com/fonttools/fonttools/issues/3014