### PR TITLE
disable check/italic_names prior to v0.8.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,14 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### Added to the Open Type Profile
   - **[com.thetypefounders/check/vendor_id]:** When a font project's Vendor ID is specified explicitely on FontBakery's configuration file, all binaries must have a matching vendor identifier value in the OS/2 table. (PR #3941)
-  - **[com.google.fonts/check/name/italic_names]:** Implemented checks for name IDs 1, 2, 16, 17 for Italic fonts (issues #3666 and #3667)
   - **[com.google.fonts/check/caret_slope]:** Check for hhea.caretSlopeRise and hhea.caretSlopeRun to match post.italicAngle (issues #3670 & #4039)
   - **[com.google.fonts/check/italic_axis_in_stat]:** Check that ital axis exists in STAT table (issue #2934)
   - **[com.google.fonts/check/italic_axis_in_stat_is_boolean]:** Check that STAT ital axis values are boolean (0 or 1) and flags are elided for Upright and not elided for Roman, and Roman is linked to Italic (issue #3668)
   - **[com.google.fonts/check/italic_axis_last]:** Check that STAT ital axis is last in order (issue #3669)
   - **[com.adobe.fonts/check/varfont/foundry_defined_tag_name]:** Check that foundry-defined tags begin with an uppercase letter (0x41 to 0x5A), and use only uppercase letters or digits (issue #4043)
+
+#### Proposed for future inclusion on the Open Type Profile
+  - **[com.google.fonts/check/name/italic_names]:** Implemented checks for name IDs 1, 2, 16, 17 for Italic fonts (Proposed at issues #3666 and #3667, but has problems described at issue #4061)
 
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/colorfont_tables]:** Check if fonts contain the correct color tables. (issue #3886)

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -1,4 +1,4 @@
-from fontbakery.callable import check
+from fontbakery.callable import check, disable
 from fontbakery.status import FAIL, PASS, WARN, INFO, SKIP
 from fontbakery.message import Message
 from fontbakery.constants import (NameID,
@@ -592,6 +592,11 @@ def com_adobe_fonts_check_family_max_4_fonts_per_family_name(ttFonts):
         yield PASS, ("There were no more than 4 fonts per family name.")
 
 
+# FIXME!
+# Proposed for inclusion during the 0.8.11 dev cycle.
+# But concerns were brought up at https://github.com/googlefonts/fontbakery/issues/4061
+# So we should address that before re-enabling this.
+@disable
 @check(
     id = 'com.google.fonts/check/name/italic_names',
     conditions = ['style'],
@@ -600,6 +605,7 @@ def com_adobe_fonts_check_family_max_4_fonts_per_family_name(ttFonts):
         conform to the font's Upright or Italic style,
         namely IDs 1 & 2 as well as 16 & 17 if they're present.
     """,
+    proposal = "https://github.com/googlefonts/fontbakery/issues/3666"
 )
 def com_google_fonts_check_name_italic_names(ttFont, style):
     """Check name table IDs 1, 2, 16, 17 to conform to Italic style."""

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -78,7 +78,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/italic_angle',
     'com.google.fonts/check/mac_style',
     'com.google.fonts/check/fsselection',
-    'com.google.fonts/check/name/italic_names',
+    # DISABLED 'com.google.fonts/check/name/italic_names',
     'com.adobe.fonts/check/varfont/valid_axis_nameid',
     'com.adobe.fonts/check/varfont/valid_subfamily_nameid',
     'com.adobe.fonts/check/varfont/valid_postscript_nameid',

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -495,7 +495,11 @@ def test_check_family_max_4_fonts_per_family_name():
                            FAIL, 'too-many')
 
 
-def test_check_italic_names():
+# FIXME!
+# Proposed for inclusion during the 0.8.11 dev cycle.
+# But concerns were brought up at https://github.com/googlefonts/fontbakery/issues/4061
+# So we should address that before re-enabling this.
+def DISABLED_test_check_italic_names():
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/name/italic_names")
 


### PR DESCRIPTION
* Proposed for inclusion at issue #3666
* But concerns were brought up at issue #4061
* So we should address that before re-enabling this.
