### PR TITLE
Two small Noto-related fixes

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3044,6 +3044,8 @@ def com_google_fonts_check_metadata_consistent_repo_urls(config, family_metadata
     """METADATA.pb: Check URL on copyright string is the same as in repository_url field."""
     bad_urls = []
     repo_url = family_metadata.source.repository_url
+    if repo_url.endswith(".git"):
+        repo_url = repo_url[:-4]
     for font_md in family_metadata.fonts:
         if "http" in font_md.copyright:
             link = "http" + font_md.copyright.split("http")[1]

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5770,7 +5770,7 @@ def com_google_fonts_check_metadata_escaped_strings(metadata_file):
 
         It also validates the URLs and file formats are all correctly set.
     """,
-    conditions = ['family_metadata'],
+    conditions = ['family_metadata', 'not is_noto'],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/3083'
 )
 def com_google_fonts_check_metadata_designer_profiles(family_metadata, config):


### PR DESCRIPTION
I'm producing a massive collection of Noto PRs which means that we need to keep noise to a minimum:

- Don't apply the designer check when testing a Noto font, as Noto fonts do not have designers in the designer database
- Allow .git on end of repo urls when checking the METADATA.pb against the copyright string
