### PR TITLE
FAIL when we find email addresses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Google Fonts profile
   - **[com.google.fonts/check/usweightclass]:** use the axisregistry's name builders instead of the parse module (issue #4113)
+  - **[com.google.fonts/check/metadata/broken_links]:** We should not keep email addresses on METADATA.pb files (issue #4110)
+  - **[com.google.fonts/check/description/broken_links]:** We should not keep email addresses on DESCRIPTION files (issue #4110)
 
 #### On the Universal Profile
   - **[com.google.fonts/check/soft_hyphen]:** Improve wording of the rationale. (issue #4095)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -260,7 +260,8 @@ def com_google_fonts_check_canonical_filename(ttFont):
         family webpage on the Google Fonts website. For that reason, all hyperlinks
         in it must be properly working.
     """,
-    proposal = 'legacy:check/003'
+    proposal = ['legacy:check/003',
+                'https://github.com/googlefonts/fontbakery/issues/4110']
 )
 def com_google_fonts_check_description_broken_links(description_html):
     """Does DESCRIPTION file contain broken links?"""
@@ -279,7 +280,7 @@ def com_google_fonts_check_description_broken_links(description_html):
         if link.startswith("mailto:") and \
            "@" in link and \
            "." in link.split("@")[1]:
-            yield INFO,\
+            yield FAIL,\
                   Message("email",
                           f"Found an email address: {link}")
             continue
@@ -588,7 +589,8 @@ def com_google_fonts_check_metadata_designer_values(family_metadata):
 @check(
     id = 'com.google.fonts/check/metadata/broken_links',
     conditions = ['family_metadata'],
-    proposal = "https://github.com/googlefonts/fontbakery/issues/2550"
+    proposal = ["https://github.com/googlefonts/fontbakery/issues/2550",
+                "https://github.com/googlefonts/fontbakery/issues/4110"]
 )
 def com_google_fonts_check_metadata_broken_links(family_metadata):
     """Does METADATA.pb copyright field contain broken links?"""
@@ -604,7 +606,7 @@ def com_google_fonts_check_metadata_broken_links(family_metadata):
                 continue
 
             unique_links.append(copyright)
-            yield INFO,\
+            yield FAIL,\
                   Message("email",
                           f"Found an email address: {copyright}")
             continue

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -234,7 +234,7 @@ def test_check_description_broken_links():
 
     good_desc += "<a href='mailto:juca@members.fsf.org'>An example mailto link</a>"
     assert_results_contain(check(font, {"description": good_desc}),
-                           INFO, "email",
+                           FAIL, "email",
                            'with a description file containing "mailto" links...')
 
     assert_PASS(check(font, {"description": good_desc}),
@@ -633,7 +633,7 @@ def test_check_metadata_broken_links():
     #check = CheckTester(googlefonts_profile,
     #                    "com.google.fonts/check/metadata/broken_links")
     # TODO: Implement-me!
-    # INFO, "email"
+    # FAIL, "email"
     # WARN, "timeout"
     # FAIL, "broken-links"
 


### PR DESCRIPTION
We should not keep email addresses on DESCRIPTION or METADATA.pb files.

Checks updated on the Google Fonts profile:
- com.google.fonts/check/metadata/broken_links
- com.google.fonts/check/description/broken_links

(issue #4110)