### PR TITLE
Add new check: [name] consistent_family_name check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Open Type Profile
   - **[com.google.fonts/check/name/italic_names]:** Implemented checks for name IDs 1, 2, 16, 17 for Italic fonts (issues #3666 and #3667)
 
+#### Added to the Adobe Fonts Profile
+  - **[com.adobe.fonts/check/family/consistent_family_name]:** Verifies that family names in the name table are consistent across all fonts in a family. Checks Typographic Family name (nameID 16) if present, otherwise uses Font Family name (nameID 1). (issue #4112)
 ### Changes to existing checks
 #### On the Google Fonts profile
   - **[com.google.fonts/check/usweightclass]:** use the axisregistry's name builders instead of the parse module (issue #4113)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -26,7 +26,7 @@ profile = profile_factory(default_section=Section("Adobe Fonts"))
 SET_EXPLICIT_CHECKS = {
     # This is the set of explict checks that will be invoked
     # when fontbakery is run with the 'check-adobefonts' subcommand.
-    # The contents of this set were last updated on February 2, 2023.
+    # The contents of this set were last updated on April 19, 2023.
     #
     # =======================================
     # From adobefonts.py (this file)
@@ -130,6 +130,7 @@ SET_EXPLICIT_CHECKS = {
     # "com.google.fonts/check/name/no_copyright_on_description",  # PERMANENTLY_EXCLUDED # noqa
     "com.google.fonts/check/name/match_familyname_fullfont",  # IS_OVERRIDDEN
     "com.adobe.fonts/check/family/max_4_fonts_per_family_name",
+    "com.adobe.fonts/check/family/consistent_family_name",
     "com.adobe.fonts/check/name/empty_records",
     "com.adobe.fonts/check/name/postscript_name_consistency",
     "com.adobe.fonts/check/name/postscript_vs_cff",

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -592,6 +592,72 @@ def com_adobe_fonts_check_family_max_4_fonts_per_family_name(ttFonts):
         yield PASS, ("There were no more than 4 fonts per family name.")
 
 
+
+@check(
+    id = 'com.adobe.fonts/check/family/consistent_family_name',
+    rationale = """
+        Per the OpenType spec:
+        Fonts within a font family all must have consistent names 
+        in the Typographic Family name (nameID 16)
+        or Font Family name (nameID 1), depending on which it uses.
+        
+        Inconsistent font/typographic family names across fonts in a family
+        can result in unexpected behaviors, such as broken style linking.
+    """,
+)
+def com_adobe_fonts_check_consistent_font_family_name(ttFonts):
+    """Verify that family names in the name table are consistent across all fonts in the family.
+       Checks Typographic Family name (nameID 16) if present, 
+       otherwise uses Font Family name (nameID 1)
+    """
+    from fontbakery.utils import get_name_entry_strings
+    from collections import defaultdict
+    import os
+
+    name_dict = defaultdict(list)
+    for ttFont in ttFonts:
+        filename = os.path.basename(ttFont.reader.file.name)
+        # try nameID 16
+        nameID = NameID.TYPOGRAPHIC_FAMILY_NAME
+        names_list = get_name_entry_strings(ttFont,
+                                            NameID.TYPOGRAPHIC_FAMILY_NAME,
+                                            PlatformID.WINDOWS,
+                                            WindowsEncodingID.UNICODE_BMP,
+                                            WindowsLanguageID.ENGLISH_USA)
+        if len(names_list) == 0:
+            # use nameID 1 instead
+            nameID = NameID.FONT_FAMILY_NAME
+            names_list = get_name_entry_strings(ttFont,
+                                                NameID.FONT_FAMILY_NAME,
+                                                PlatformID.WINDOWS,
+                                                WindowsEncodingID.UNICODE_BMP,
+                                                WindowsLanguageID.ENGLISH_USA)
+        name_dict[frozenset(names_list)].append((filename, nameID))
+
+    if len(name_dict) > 1:
+        diff_names = []
+        detail_str_arr = []
+        for name_set, font_tuple_list in name_dict.items():
+            fonts_str = ""
+            detail_str = ""
+            diff_names += list(name_set)
+            if len(font_tuple_list) == 0:
+                continue
+            detail_str += "\n* '" + ", ".join(list(name_set)) + "' found in: "
+            for ft in font_tuple_list:
+                comma = ", " if fonts_str != "" else ""
+                fonts_str += f"{comma}{str(ft[0])} (nameID {ft[1]})"
+            detail_str_arr.append(detail_str + fonts_str)
+
+        quoted_diff_names = [f"'{name}'" for name in diff_names]
+        msg = f"Fonts in family has inconsistent font family names: " \
+              f"{str(', '.join(quoted_diff_names))}. " + "".join(detail_str_arr)
+        yield FAIL, \
+                Message("inconsistent-family-name", msg)
+    else:
+        yield PASS, ("Font family names are consistent across the family.")
+
+
 @check(
     id = 'com.google.fonts/check/name/italic_names',
     conditions = ['style'],

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -650,7 +650,7 @@ def com_adobe_fonts_check_consistent_font_family_name(ttFonts):
         detail_str_arr = []
         indent = "\n  - "
         for name_set, font_tuple_list in name_dict.items():
-            detail_str = f"\n\n* {next(iter(name_set))!r} was found in:"
+            detail_str = f"\n\n* '{next(iter(name_set), '')}' was found in:"
 
             fonts_str_arr = []
             for ft in font_tuple_list:

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -662,25 +662,6 @@ def com_adobe_fonts_check_consistent_font_family_name(ttFonts):
         msg = (f"{len(name_dict)} different Font Family names were found:"
                f"{''.join(detail_str_arr)}")
         yield FAIL, Message("inconsistent-family-name", msg)
-        diff_names = []
-        detail_str_arr = []
-        for name_set, font_tuple_list in name_dict.items():
-            fonts_str = ""
-            detail_str = ""
-            diff_names.extend(list(name_set))
-            if len(font_tuple_list) == 0:
-                continue
-            detail_str += f"\n* '{', '.join(list(name_set))}' found in: "
-            for ft in font_tuple_list:
-                comma = ", " if fonts_str != "" else ""
-                fonts_str += f"{comma}{str(ft[0])} (nameID {ft[1]})"
-            detail_str_arr.append(detail_str + fonts_str)
-
-        quoted_diff_names = [f"{name!r}" for name in diff_names]
-        msg = (f"Fonts in family has inconsistent font family names: "
-               f"{str(', '.join(quoted_diff_names))}. {''.join(detail_str_arr)}")
-        yield FAIL, \
-                Message("inconsistent-family-name", msg)
     else:
         yield PASS, ("Font family names are consistent across the family.")
 

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -650,20 +650,20 @@ def com_adobe_fonts_check_consistent_font_family_name(ttFonts):
         diff_names = []
         detail_str_arr = []
         for name_set, font_tuple_list in name_dict.items():
-            fonts_str = f""
-            detail_str = f""
+            fonts_str = ""
+            detail_str = ""
             diff_names.extend(list(name_set))
             if len(font_tuple_list) == 0:
                 continue
-            detail_str += f"\n* ' {f', '.join(list(name_set))} ' found in: "
+            detail_str += f"\n* ' {', '.join(list(name_set))} ' found in: "
             for ft in font_tuple_list:
-                comma = f", " if fonts_str != f"" else f""
+                comma = ", " if fonts_str != "" else ""
                 fonts_str += f"{comma}{str(ft[0])} (nameID {ft[1]})"
             detail_str_arr.append(detail_str + fonts_str)
 
         quoted_diff_names = [f"{name!r}" for name in diff_names]
         msg = (f"Fonts in family has inconsistent font family names: "
-               f"{str(', '.join(quoted_diff_names))}. {f''.join(detail_str_arr)}")
+               f"{str(', '.join(quoted_diff_names))}. {''.join(detail_str_arr)}")
         yield FAIL, \
                 Message("inconsistent-family-name", msg)
     else:

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -655,7 +655,7 @@ def com_adobe_fonts_check_consistent_font_family_name(ttFonts):
             diff_names.extend(list(name_set))
             if len(font_tuple_list) == 0:
                 continue
-            detail_str += f"\n* ' {', '.join(list(name_set))} ' found in: "
+            detail_str += f"\n* '{', '.join(list(name_set))}' found in: "
             for ft in font_tuple_list:
                 comma = ", " if fonts_str != "" else ""
                 fonts_str += f"{comma}{str(ft[0])} (nameID {ft[1]})"

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -647,6 +647,21 @@ def com_adobe_fonts_check_consistent_font_family_name(ttFonts):
         name_dict[frozenset(names_list)].append((filename, nameID))
 
     if len(name_dict) > 1:
+        detail_str_arr = []
+        indent = "\n  - "
+        for name_set, font_tuple_list in name_dict.items():
+            detail_str = f"\n\n* {next(iter(name_set))!r} was found in:"
+
+            fonts_str_arr = []
+            for ft in font_tuple_list:
+                fonts_str_arr.append(f"{ft[0]} (nameID {ft[1]})")
+
+            detail_str_arr.append(
+                f"{detail_str}{indent}{indent.join(fonts_str_arr)}")
+
+        msg = (f"{len(name_dict)} different Font Family names were found:"
+               f"{''.join(detail_str_arr)}")
+        yield FAIL, Message("inconsistent-family-name", msg)
         diff_names = []
         detail_str_arr = []
         for name_set, font_tuple_list in name_dict.items():

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -597,10 +597,22 @@ def com_adobe_fonts_check_family_max_4_fonts_per_family_name(ttFonts):
     id = 'com.adobe.fonts/check/family/consistent_family_name',
     rationale = """
         Per the OpenType spec:
+            * "...many existing applications that use this pair of names assume that a
+              Font Family name is shared by at most four fonts that form a font
+              style-linking group"
+            * "For extended typographic families that includes fonts other than the 
+              four basic styles(regular, italic, bold, bold italic), it is strongly
+              recommended that name IDs 16 and 17 be used in fonts to create an extended,
+              typographic grouping."
+            * "If name ID 16 is absent, then name ID 1 is considered to be the typographic
+               family name."
+
+        https://learn.microsoft.com/en-us/typography/opentype/spec/name
+
         Fonts within a font family all must have consistent names 
         in the Typographic Family name (nameID 16)
         or Font Family name (nameID 1), depending on which it uses.
-        
+
         Inconsistent font/typographic family names across fonts in a family
         can result in unexpected behaviors, such as broken style linking.
     """,
@@ -638,20 +650,20 @@ def com_adobe_fonts_check_consistent_font_family_name(ttFonts):
         diff_names = []
         detail_str_arr = []
         for name_set, font_tuple_list in name_dict.items():
-            fonts_str = ""
-            detail_str = ""
-            diff_names += list(name_set)
+            fonts_str = f""
+            detail_str = f""
+            diff_names.extend(list(name_set))
             if len(font_tuple_list) == 0:
                 continue
-            detail_str += "\n* '" + ", ".join(list(name_set)) + "' found in: "
+            detail_str += f"\n* ' {f', '.join(list(name_set))} ' found in: "
             for ft in font_tuple_list:
-                comma = ", " if fonts_str != "" else ""
+                comma = f", " if fonts_str != f"" else f""
                 fonts_str += f"{comma}{str(ft[0])} (nameID {ft[1]})"
             detail_str_arr.append(detail_str + fonts_str)
 
-        quoted_diff_names = [f"'{name}'" for name in diff_names]
-        msg = f"Fonts in family has inconsistent font family names: " \
-              f"{str(', '.join(quoted_diff_names))}. " + "".join(detail_str_arr)
+        quoted_diff_names = [f"{name!r}" for name in diff_names]
+        msg = (f"Fonts in family has inconsistent font family names: "
+               f"{str(', '.join(quoted_diff_names))}. {f''.join(detail_str_arr)}")
         yield FAIL, \
                 Message("inconsistent-family-name", msg)
     else:

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -34,6 +34,7 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/family/equal_font_versions',
     'com.adobe.fonts/check/family/bold_italic_unique_for_nameid1',
     'com.adobe.fonts/check/family/max_4_fonts_per_family_name',
+    'com.adobe.fonts/check/family/consistent_family_name',
     'com.adobe.fonts/check/name/postscript_vs_cff',
     'com.adobe.fonts/check/name/postscript_name_consistency',
     'com.adobe.fonts/check/name/empty_records',

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -34,7 +34,6 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/family/equal_font_versions',
     'com.adobe.fonts/check/family/bold_italic_unique_for_nameid1',
     'com.adobe.fonts/check/family/max_4_fonts_per_family_name',
-    'com.adobe.fonts/check/family/consistent_family_name',
     'com.adobe.fonts/check/name/postscript_vs_cff',
     'com.adobe.fonts/check/name/postscript_name_consistency',
     'com.adobe.fonts/check/name/empty_records',

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -75,6 +75,7 @@ UNIVERSAL_PROFILE_CHECKS = \
         'com.google.fonts/check/whitespace_widths',
         'com.google.fonts/check/interpolation_issues',
         'com.google.fonts/check/math_signs_width',
+        'com.adobe.fonts/check/family/consistent_family_name',
     ]
 
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -75,7 +75,6 @@ UNIVERSAL_PROFILE_CHECKS = \
         'com.google.fonts/check/whitespace_widths',
         'com.google.fonts/check/interpolation_issues',
         'com.google.fonts/check/math_signs_width',
-        'com.adobe.fonts/check/family/consistent_family_name',
     ]
 
 

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -50,6 +50,7 @@ def test_get_family_checks():
         f"com.google.fonts/check/family/win_ascent_and_descent{OVERRIDE_SUFFIX}",
         "com.google.fonts/check/family/vertical_metrics",
         "com.google.fonts/check/family/single_directory",
+        "com.adobe.fonts/check/family/consistent_family_name",
         # should it be included here? or should we have
         # a get_superfamily_checks() method?
         # 'com.google.fonts/check/superfamily/vertical_metrics',
@@ -60,7 +61,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 79
+    assert len(SET_EXPLICIT_CHECKS) == 80
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -496,60 +496,61 @@ def test_check_family_max_4_fonts_per_family_name():
 
 
 def test_check_consistent_font_family_name():
-  check = CheckTester(opentype_profile,
-                      "com.adobe.fonts/check/family/consistent_family_name")
+    check = CheckTester(opentype_profile,
+                        "com.adobe.fonts/check/family/consistent_family_name")
 
-  base_path = portable_path("data/test/source-sans-pro/OTF")
+    base_path = portable_path("data/test/source-sans-pro/OTF")
 
-  font_names = [
-      'SourceSansPro-Black.otf',
-      'SourceSansPro-BlackItalic.otf',
-      'SourceSansPro-Bold.otf',
-      'SourceSansPro-BoldItalic.otf',
-      'SourceSansPro-ExtraLight.otf',
-      'SourceSansPro-ExtraLightItalic.otf',
-      'SourceSansPro-Italic.otf',
-      'SourceSansPro-Light.otf',
-      'SourceSansPro-LightItalic.otf',
-      'SourceSansPro-Regular.otf',
-      'SourceSansPro-Semibold.otf',
-      'SourceSansPro-SemiboldItalic.otf']
+    font_names = [
+        'SourceSansPro-Black.otf',
+        'SourceSansPro-BlackItalic.otf',
+        'SourceSansPro-Bold.otf',
+        'SourceSansPro-BoldItalic.otf',
+        'SourceSansPro-ExtraLight.otf',
+        'SourceSansPro-ExtraLightItalic.otf',
+        'SourceSansPro-Italic.otf',
+        'SourceSansPro-Light.otf',
+        'SourceSansPro-LightItalic.otf',
+        'SourceSansPro-Regular.otf',
+        'SourceSansPro-Semibold.otf',
+        'SourceSansPro-SemiboldItalic.otf',
+    ]
 
-  font_paths = [os.path.join(base_path, n) for n in font_names]
+    font_paths = [os.path.join(base_path, n) for n in font_names]
 
-  test_fonts = [TTFont(x) for x in font_paths]
+    test_fonts = [TTFont(x) for x in font_paths]
 
-  # try fonts with consistent family names
-  assert_PASS(check(test_fonts))
+    # try fonts with consistent family names
+    assert_PASS(check(test_fonts))
 
-  # now set 5 of the fonts to have different family names.
-  name_records = test_fonts[1]['name'].names
-  for name_record in name_records:
-    if name_record.nameID == 1:
-      name_record.string = 'wrong-name'.encode('utf-16be')
+    # now set 5 of the fonts to have different family names
+    for i in range(1, 6):
+        if i in [1, 2, 3]:
+            target_nameID = 1
+        elif i in [4, 5]:
+            target_nameID = 16
+        name_records = test_fonts[i]['name'].names
+        wrong_name = f"wrong-name-{9 % i}"
+        for name_record in name_records:
+            if name_record.nameID == target_nameID:
+                name_record.string = wrong_name.encode('utf-16be')
 
-  name_records = test_fonts[2]['name'].names
-  for name_record in name_records:
-    if name_record.nameID == 1:
-      name_record.string = 'wrong-name-2'.encode('utf-16be')
+    msg = assert_results_contain(check(test_fonts),
+                                 FAIL, 'inconsistent-family-name')
 
-  name_records = test_fonts[3]['name'].names
-  for name_record in name_records:
-    if name_record.nameID == 1:
-      name_record.string = 'wrong-name'.encode('utf-16be')
+    assert msg in (f"Fonts in family has inconsistent font family names: "
+                   f"'Source Sans Pro', 'wrong-name-1', 'wrong-name-0', "
+                   f"'wrong-name-4'. \n* 'Source Sans Pro' found in: "
+                   f"SourceSansPro-Black.otf (nameID 16), SourceSansPro-BlackItalic.otf"
+                   f" (nameID 16), SourceSansPro-Italic.otf (nameID 1), SourceSansPro-Light.otf"
+                   f" (nameID 16), SourceSansPro-LightItalic.otf (nameID 16), "
+                   f"SourceSansPro-Regular.otf (nameID 1), SourceSansPro-Semibold.otf "
+                   f"(nameID 16), SourceSansPro-SemiboldItalic.otf (nameID 16)\n* 'wrong-name-1'"
+                   f" found in: SourceSansPro-Bold.otf (nameID 1), SourceSansPro-ExtraLight.otf"
+                   f" (nameID 16)\n* 'wrong-name-0' found in: SourceSansPro-BoldItalic.otf (nameID 1)"
+                   f"\n* 'wrong-name-4' found in: SourceSansPro-ExtraLightItalic.otf (nameID 16)"
+                  )
 
-  name_records = test_fonts[4]['name'].names
-  for name_record in name_records:
-    if name_record.nameID == 16:
-      name_record.string = 'wrong-name-2'.encode('utf-16be')
-
-  name_records = test_fonts[5]['name'].names
-  for name_record in name_records:
-    if name_record.nameID == 16:
-      name_record.string = 'wrong-name-3'.encode('utf-16be')
-
-    assert_results_contain(check(test_fonts),
-                           FAIL, 'inconsistent-family-name')
 
 def test_check_italic_names():
     check = CheckTester(opentype_profile,

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -495,6 +495,62 @@ def test_check_family_max_4_fonts_per_family_name():
                            FAIL, 'too-many')
 
 
+def test_check_consistent_font_family_name():
+  check = CheckTester(opentype_profile,
+                      "com.adobe.fonts/check/family/consistent_family_name")
+
+  base_path = portable_path("data/test/source-sans-pro/OTF")
+
+  font_names = [
+      'SourceSansPro-Black.otf',
+      'SourceSansPro-BlackItalic.otf',
+      'SourceSansPro-Bold.otf',
+      'SourceSansPro-BoldItalic.otf',
+      'SourceSansPro-ExtraLight.otf',
+      'SourceSansPro-ExtraLightItalic.otf',
+      'SourceSansPro-Italic.otf',
+      'SourceSansPro-Light.otf',
+      'SourceSansPro-LightItalic.otf',
+      'SourceSansPro-Regular.otf',
+      'SourceSansPro-Semibold.otf',
+      'SourceSansPro-SemiboldItalic.otf']
+
+  font_paths = [os.path.join(base_path, n) for n in font_names]
+
+  test_fonts = [TTFont(x) for x in font_paths]
+
+  # try fonts with consistent family names
+  assert_PASS(check(test_fonts))
+
+  # now set 5 of the fonts to have different family names.
+  name_records = test_fonts[1]['name'].names
+  for name_record in name_records:
+    if name_record.nameID == 1:
+      name_record.string = 'wrong-name'.encode('utf-16be')
+
+  name_records = test_fonts[2]['name'].names
+  for name_record in name_records:
+    if name_record.nameID == 1:
+      name_record.string = 'wrong-name-2'.encode('utf-16be')
+
+  name_records = test_fonts[3]['name'].names
+  for name_record in name_records:
+    if name_record.nameID == 1:
+      name_record.string = 'wrong-name'.encode('utf-16be')
+
+  name_records = test_fonts[4]['name'].names
+  for name_record in name_records:
+    if name_record.nameID == 16:
+      name_record.string = 'wrong-name-2'.encode('utf-16be')
+
+  name_records = test_fonts[5]['name'].names
+  for name_record in name_records:
+    if name_record.nameID == 16:
+      name_record.string = 'wrong-name-3'.encode('utf-16be')
+
+    assert_results_contain(check(test_fonts),
+                           FAIL, 'inconsistent-family-name')
+
 def test_check_italic_names():
     check = CheckTester(opentype_profile,
                         "com.google.fonts/check/name/italic_names")

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -537,19 +537,9 @@ def test_check_consistent_font_family_name():
 
     msg = assert_results_contain(check(test_fonts),
                                  FAIL, 'inconsistent-family-name')
-
-    assert msg in (f"Fonts in family has inconsistent font family names: "
-                   f"'Source Sans Pro', 'wrong-name-1', 'wrong-name-0', "
-                   f"'wrong-name-4'. \n* 'Source Sans Pro' found in: "
-                   f"SourceSansPro-Black.otf (nameID 16), SourceSansPro-BlackItalic.otf"
-                   f" (nameID 16), SourceSansPro-Italic.otf (nameID 1), SourceSansPro-Light.otf"
-                   f" (nameID 16), SourceSansPro-LightItalic.otf (nameID 16), "
-                   f"SourceSansPro-Regular.otf (nameID 1), SourceSansPro-Semibold.otf "
-                   f"(nameID 16), SourceSansPro-SemiboldItalic.otf (nameID 16)\n* 'wrong-name-1'"
-                   f" found in: SourceSansPro-Bold.otf (nameID 1), SourceSansPro-ExtraLight.otf"
-                   f" (nameID 16)\n* 'wrong-name-0' found in: SourceSansPro-BoldItalic.otf (nameID 1)"
-                   f"\n* 'wrong-name-4' found in: SourceSansPro-ExtraLightItalic.otf (nameID 16)"
-                  )
+    assert "4 different Font Family names were found" in msg
+    assert "'Source Sans Pro' was found" in msg
+    assert "'wrong-name-1' was found" in msg
 
 
 def test_check_italic_names():


### PR DESCRIPTION
## Description
This pull request adds a new check that verifies if family names in the name table are consistent across all fonts in the family. It checks Typographic Family name (nameID 16) if present, otherwise uses Font Family name (nameID 1).

More details in #4112

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

