### PR TITLE
fix tests to work with ufo2ft >= 2.29.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ toml==0.10.2
 ufolint==1.2.0
 unicodedata2==15.0.0
 vharfbuzz==0.2.0
-ufo2ft==2.28.0  # Temporarily fixed at this version to workaround issue #3940
+ufo2ft==2.30.0

--- a/tests/profiles/gdef_test.py
+++ b/tests/profiles/gdef_test.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import otTables
 
@@ -21,6 +22,10 @@ def get_test_font():
     test_ttf = ufo2ft.compileTTF(test_ufo)
 
     # Make the CheckTester class happy... :-P
+    stream = BytesIO()
+    test_ttf.save(stream)
+    stream.seek(0)
+    test_ttf = TTFont(stream)
     test_ttf.reader.file.name = "in-memory-data.ttf"
     return test_ttf
 


### PR DESCRIPTION
## Description
Fixes #3940 using the workaround suggested in that issue.

I'm not too sure if this is a complete solution -- this patch only puts the workaround in the tests, I'm not sure if elsewhere in the real code the `.reader` attribute may be missing. But the tests pass with this change.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

