### PR TITLE
[commands/check_profile] fix old py2/py3 conversion issue. See 3336

### DIFF
--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -188,7 +188,7 @@ def ArgumentParser(profile, profile_arg=True):
                                       f'One of: {comma_separated}')
 
     def parse_order(arg):
-        order = filter(len, [n.strip() for n in arg.split(',')])
+        order = list(filter(len, [n.strip() for n in arg.split(',')]))
         return order or None
     comma_separated = ', '.join(iterargs)
     argument_parser.add_argument('-o','--order', default=None, type=parse_order,


### PR DESCRIPTION
The `-o, --order` cli argument doesn't work as expected, because the iterator returned by `filter` is consumed after the first section, leaving the consecutive sections sorted in default order. 

`filter` returns an iterator not a list anymore.

## Description
This pull request addresses the problems described at issue #3336

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

