### PR TITLE
Added rationale to linegaps check & migrated it to universal profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### Added to the Adobe Fonts Profile
   - **[com.adobe.fonts/check/family/consistent_family_name]:** Verifies that family names in the name table are consistent across all fonts in a family. Checks Typographic Family name (nameID 16) if present, otherwise uses Font Family name (nameID 1). (issue #4112)
+
+### Migrations of checks
+#### Moved to the Universal profile
+  - **[com.google.fonts/check/linegaps]:** from the OpenType profile (issue #4133)
+
 ### Changes to existing checks
 #### On the Google Fonts profile
   - **[com.google.fonts/check/usweightclass]:** use the axisregistry's name builders instead of the parse module (issue #4113)
@@ -20,6 +25,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the Universal Profile
   - **[com.google.fonts/check/soft_hyphen]:** Improve wording of the rationale. (issue #4095)
+  - **[com.google.fonts/check/linegaps]:** Added rationale (issue #4133)
 
 ### BugFixes
   - Fix crash on markdown reporter by explicitly specifing UTF-8 encoding (issue #4089)

--- a/Lib/fontbakery/profiles/hhea.py
+++ b/Lib/fontbakery/profiles/hhea.py
@@ -8,35 +8,6 @@ profile_imports = [
     ('.shared_conditions', ('glyph_metrics_stats', 'is_ttf'))
 ]
 
-def _get_missing_tables(req_tables_set, ttFont):
-    """Returns a sorted list of table tags not supported by the font."""
-    return sorted(req_tables_set - set(ttFont.keys()))
-
-
-@check(
-    id = 'com.google.fonts/check/linegaps',
-    proposal = 'legacy:check/041'
-)
-def com_google_fonts_check_linegaps(ttFont):
-    """Checking Vertical Metric Linegaps."""
-    required_tables = {"hhea", "OS/2"}
-    missing_tables = _get_missing_tables(required_tables, ttFont)
-    if missing_tables:
-        for table_tag in missing_tables:
-            yield FAIL, Message("lacks-table", f"Font lacks '{table_tag}' table.")
-        return
-
-    if ttFont["hhea"].lineGap != 0:
-        yield WARN,\
-              Message("hhea",
-                      "hhea lineGap is not equal to 0.")
-    elif ttFont["OS/2"].sTypoLineGap != 0:
-        yield WARN,\
-              Message("OS/2",
-                      "OS/2 sTypoLineGap is not equal to 0.")
-    else:
-        yield PASS, "OS/2 sTypoLineGap and hhea lineGap are both 0."
-
 
 @check(
     id = 'com.google.fonts/check/maxadvancewidth',
@@ -44,8 +15,9 @@ def com_google_fonts_check_linegaps(ttFont):
 )
 def com_google_fonts_check_maxadvancewidth(ttFont):
     """MaxAdvanceWidth is consistent with values in the Hmtx and Hhea tables?"""
+
     required_tables = {"hhea", "hmtx"}
-    missing_tables = _get_missing_tables(required_tables, ttFont)
+    missing_tables = sorted(required_tables - set(ttFont.keys()))
     if missing_tables:
         for table_tag in missing_tables:
             yield FAIL,\

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -59,7 +59,6 @@ OPENTYPE_PROFILE_CHECKS = [
     'com.google.fonts/check/monospace',
     'com.google.fonts/check/xavgcharwidth',
     'com.adobe.fonts/check/fsselection_matches_macstyle',
-    'com.google.fonts/check/linegaps',
     'com.google.fonts/check/unitsperem',
     'com.google.fonts/check/dsig',
     'com.google.fonts/check/gdef_spacing_marks',

--- a/tests/profiles/hhea_test.py
+++ b/tests/profiles/hhea_test.py
@@ -8,39 +8,6 @@ from fontbakery.codetesting import (assert_PASS,
 from fontbakery.profiles import opentype as opentype_profile
 
 
-def test_check_linegaps():
-    """ Checking Vertical Metric Linegaps. """
-    check = CheckTester(opentype_profile,
-                        "com.google.fonts/check/linegaps")
-
-    # Our reference Mada Regular is know to be bad here.
-    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-
-    # But just to be sure, we first explicitely set
-    # the values we're checking for:
-    ttFont['hhea'].lineGap = 1
-    ttFont['OS/2'].sTypoLineGap = 0
-    assert_results_contain(check(ttFont),
-                           WARN, 'hhea',
-                           'with non-zero hhea.lineGap...')
-
-    # Then we run the check with a non-zero OS/2.sTypoLineGap:
-    ttFont['hhea'].lineGap = 0
-    ttFont['OS/2'].sTypoLineGap = 1
-    assert_results_contain(check(ttFont),
-                           WARN, 'OS/2',
-                           'with non-zero OS/2.sTypoLineGap...')
-
-    # And finaly we fix it by making both values equal to zero:
-    ttFont['hhea'].lineGap = 0
-    ttFont['OS/2'].sTypoLineGap = 0
-    assert_PASS(check(ttFont))
-
-    # Confirm the check yields FAIL if the font doesn't have a required table
-    del ttFont['OS/2']
-    assert_results_contain(check(ttFont), FAIL, "lacks-table")
-
-
 def test_check_maxadvancewidth():
     """ MaxAdvanceWidth is consistent with values in the Hmtx and Hhea tables? """
     check = CheckTester(opentype_profile,

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1242,3 +1242,36 @@ def test_check_math_signs_width():
     font = TEST_FILE("montserrat/Montserrat-Regular.ttf")
     assert_results_contain(check(font),
                            WARN, "width-outliers")
+
+
+def test_check_linegaps():
+    """ Checking Vertical Metric Linegaps. """
+    check = CheckTester(universal_profile,
+                        "com.google.fonts/check/linegaps")
+
+    # Our reference Mada Regular is know to be bad here.
+    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+
+    # But just to be sure, we first explicitely set
+    # the values we're checking for:
+    ttFont['hhea'].lineGap = 1
+    ttFont['OS/2'].sTypoLineGap = 0
+    assert_results_contain(check(ttFont),
+                           FAIL, 'hhea',
+                           'with non-zero hhea.lineGap...')
+
+    # Then we run the check with a non-zero OS/2.sTypoLineGap:
+    ttFont['hhea'].lineGap = 0
+    ttFont['OS/2'].sTypoLineGap = 1
+    assert_results_contain(check(ttFont),
+                           FAIL, 'OS/2',
+                           'with non-zero OS/2.sTypoLineGap...')
+
+    # And finaly we fix it by making both values equal to zero:
+    ttFont['hhea'].lineGap = 0
+    ttFont['OS/2'].sTypoLineGap = 0
+    assert_PASS(check(ttFont))
+
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont['OS/2']
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")


### PR DESCRIPTION
* check-id: **com.google.fonts/check/linegaps**
* From: `OpenType` profile
* To: `Universal` profile
(issue #4133)