### PR TITLE
Update check/colorfont_tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/metadata/broken_links]:** We should not keep email addresses on METADATA.pb files (issue #4110)
   - **[com.google.fonts/check/description/broken_links]:** We should not keep email addresses on DESCRIPTION files (issue #4110)
   - **[com.google.fonts/check/metadata/nameid/font_name]:** Use name id 16, when present, to compute the expected font family name (issue #4086)
+  - **[com.google.fonts/check/check/colorfont_tables]:** Update checking criteria according to gf-guide (issue #4131)
 
 #### On the Universal Profile
   - **[com.google.fonts/check/soft_hyphen]:** Improve wording of the rationale. (issue #4095)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4328,26 +4328,51 @@ def test_check_override_freetype_rasterizer(mock_import_error):
 
 
 def test_check_colorfont_tables():
-    """Fonts must have neither or both the tables 'COLR' and 'SVG'."""
+    """Check font has the expected color font tables."""
     from fontTools.ttLib import newTable
+    from fontbakery.profiles.shared_conditions import is_variable_font
+
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/colorfont_tables")
 
     ttFont = TTFont(TEST_FILE("color_fonts/noto-glyf_colr_1.ttf"))
     assert 'SVG ' not in ttFont.keys()
     assert 'COLR' in ttFont.keys()
-    # Check colr v1 font has an svg table. Will fail since font
-    # doesn't have one.
+    assert ttFont["COLR"].version == 1
+    # Check colr v1 static font has an svg table (since v1 is not yet broadly supported).
+    # Will fail since font doesn't have one.
     assert_results_contain(check(ttFont),
                            FAIL, 'add-svg',
-                           'with a color font lacking SVG table')
+                           'with a static colr v1 font lacking SVG table')
+
+    # Fake a variable font by adding an fvar table.
+    ttFont["fvar"] = newTable('fvar')
+    assert 'fvar' in ttFont.keys()
+    assert is_variable_font(ttFont)
+
+    # SVG does not support OpenType Variations
+    assert_PASS(check(ttFont),
+                'with a variable color font without SVG table')
 
     # Fake an SVG table:
     ttFont["SVG "] = newTable('SVG ')
     assert 'SVG ' in ttFont.keys()
+
+    assert_results_contain(check(ttFont),
+                           FAIL, 'variable-svg',
+                           'with a variable color font with SVG table')
+
+    # Make it a static again:
+    del ttFont["fvar"]
+    assert 'fvar' not in ttFont.keys()
+    assert is_variable_font(ttFont) == False
+
+
+    assert 'SVG ' in ttFont.keys()
     assert 'COLR' in ttFont.keys()
+    assert ttFont["COLR"].version == 1
     assert_PASS(check(ttFont),
-                f'with a font containing both tables.')
+                'with a static colr v1 font containing both tables.')
 
     # Now downgrade to colr table to v0:
     ttFont["COLR"].version = 0
@@ -4364,7 +4389,7 @@ def test_check_colorfont_tables():
                            FAIL, 'add-colr',
                            'with a font which should have a COLR table')
 
-    #finally delete both color font tables
+    # Finally delete both color font tables
     del ttFont["SVG "]
     assert 'SVG ' not in ttFont.keys()
     assert 'COLR' not in ttFont.keys()


### PR DESCRIPTION
Update **check/colorfont_tables** (and corresponding code-tests) to match the color-font requirements from the Google Fonts Guide at https://googlefonts.github.io/gf-guide/color.html

* **com.google.fonts/check/check/colorfont_tables**
* `Google Fonts` profile
(issue #4131)