### PR TITLE
Make `opentype-sanitizer` an extra dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.8.14 (2023-Jun-??)
   - ...
 
+### Changes to existing checks
+#### On the Universal Profile
+  - **[com.google.fonts/check/ots]:** The **opentype-sanitizer** package is no longer installed by default, and this check will be automatically skipped because of that. To make the check not be skipped, the **opentype-sanitizer** package must be installed; this can be done explicitly with `python -m pip install opentype-sanitizer`, or implicitly with the new **ots** extra: `python -m pip install -U 'fontbakery[ots]'` (issue #4163)
+
 
 ## 0.8.13 (2023-Jun-02)
   - Fix a critical install bug. I had used wrong syntax on setup.py which made v0.8.12 impossible to install when enabling the freetype extra. Sorry! (issue #4157)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -182,6 +182,7 @@ SET_EXPLICIT_CHECKS = {
     # "com.google.fonts/check/transformed_components",
     # ---
     "com.adobe.fonts/check/freetype_rasterizer",             # IS_OVERRIDDEN
+    "com.google.fonts/check/ots",                            # IS_OVERRIDDEN
     "com.google.fonts/check/family/win_ascent_and_descent",  # IS_OVERRIDDEN
     "com.google.fonts/check/fontbakery_version",             # IS_OVERRIDDEN
     "com.google.fonts/check/name/trailing_spaces",           # IS_OVERRIDDEN
@@ -194,7 +195,6 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/family/vertical_metrics",
     "com.google.fonts/check/gpos7",
     "com.google.fonts/check/mandatory_glyphs",
-    "com.google.fonts/check/ots",
     "com.google.fonts/check/required_tables",
     "com.google.fonts/check/rupee",
     "com.google.fonts/check/ttx_roundtrip",
@@ -223,6 +223,7 @@ ADOBEFONTS_PROFILE_CHECKS = [
 
 OVERRIDDEN_CHECKS = [
     "com.adobe.fonts/check/freetype_rasterizer",
+    "com.google.fonts/check/ots",
     "com.adobe.fonts/check/stat_has_axis_value_tables",
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
     "com.fontwerk/check/inconsistencies_between_fvar_stat",
@@ -546,6 +547,14 @@ profile.check_log_override(
     # From universal.py
     "com.adobe.fonts/check/freetype_rasterizer",
     overrides=(("freetype-not-installed", FAIL, KEEP_ORIGINAL_MESSAGE),),
+    reason="For Adobe, this check is very important and should never be skipped.",
+)
+
+
+profile.check_log_override(
+    # From universal.py
+    "com.google.fonts/check/ots",
+    overrides=(("ots-not-installed", FAIL, KEEP_ORIGINAL_MESSAGE),),
     reason="For Adobe, this check is very important and should never be skipped.",
 )
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -289,10 +289,17 @@ def com_google_fonts_check_family_single_directory(fonts):
 )
 def com_google_fonts_check_ots(font):
     """Checking with ots-sanitize."""
-    import ots
-
     try:
+        import ots
         process = ots.sanitize(font, check=True, capture_output=True)
+
+    except ImportError:
+        yield SKIP,\
+              Message("ots-not-installed",
+                      "OpenType Sanitizer is not available. To fix this,"
+                      " invoke the 'ots' extra when installing Font Bakery:\n\n"
+                      "python -m pip install -U 'fontbakery[ots]'\n\n")
+
     except ots.CalledProcessError as e:
         yield FAIL,\
               Message("ots-sanitize-error",

--- a/setup.py
+++ b/setup.py
@@ -92,8 +92,6 @@ setup(
         'glyphsets>=0.5.0',
         'lxml',
         'munkres',  # for interpolation compatibility checking
-        'opentype-sanitizer>=7.1.9',  # 7.1.9 fixes caret value format = 3 bug
-                                      # (see https://github.com/khaledhosny/ots/pull/182)
         # 3.7.0 fixed a bug on parsing some METADATA.pb files.
         # We cannot use v4 because our protobuf files have been compiled with v3.
         'protobuf>=3.7.0, <4',
@@ -112,6 +110,9 @@ setup(
         ],
         'freetype': [
             'freetype-py!=2.4.0', # Avoiding 2.4.0 due to seg-fault described at https://github.com/googlefonts/fontbakery/issues/4143
+        ],
+        'ots': [
+            'opentype-sanitizer>=7.1.9',  # 7.1.9 fixes caret value format = 3 bug (see https://github.com/khaledhosny/ots/pull/182)
         ],
     },
     entry_points={

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -425,6 +425,19 @@ def test_check_override_freetype_rasterizer(mock_import_error):
     assert "FreeType is not available" in msg
 
 
+@patch("ots.sanitize", side_effect=ImportError)
+def test_check_override_ots(mock_import_error):
+    """Check that overridden test yields FAIL rather than SKIP."""
+    check = CheckTester(
+        adobefonts_profile,
+        f"com.google.fonts/check/ots{OVERRIDE_SUFFIX}",
+    )
+
+    font = TEST_FILE("cabin/Cabin-Regular.ttf")
+    msg = assert_results_contain(check(font), FAIL, "ots-not-installed")
+    assert "OpenType Sanitizer is not available" in msg
+
+
 @patch("requests.get", side_effect=ConnectionError)
 def test_check_override_fontbakery_version(mock_get):
     """Check that overridden test yields SKIP rather than FAIL."""


### PR DESCRIPTION
Makes **opentype-sanitizer** an extra dependency. Because of this, the check `com.google.fonts/check/ots` will be automatically skipped. To make the check not be skipped, the **opentype-sanitizer** package must be installed; this can be done explicitly with

    python -m pip install opentype-sanitizer

or implicitly with the new **ots** extra:

    python -m pip install -U 'fontbakery[ots]'

Relates to #3874