### PR TITLE
Stop error in empty glyphs in italic check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal profile
   - **[com.adobe.fonts/check/freetype_rasterizer]:** Added test-code that segfaults with freetype-py version 2.4.0, so that we make sure the problem won't go unnoticed, and will enable us to know when it gets fixed (issue #4143)
 
+#### On the OpenType profile
+  - **[com.google.fonts/check/italic_angle]**: Fix an ERROR: If any of the glyphs checked (bar, vertical line, left square bracket, etc.) have no outlines, the check will now emit a WARN, because that's useful information. (PR #4187)
+
 
 ## 0.8.13 (2023-Jun-02)
   - Fix a critical install bug. I had used wrong syntax on setup.py which made v0.8.12 impossible to install when enabling the freetype extra. Sorry! (issue #4157)

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,6 @@ setup(
     entry_points={
         "console_scripts": ["fontbakery=fontbakery.cli:main"],
     },
-
     # TODO: review this and make it cross-platform:
     #    data_files=[
     #        ('/etc/bash_completion.d', ['snippets/fontbakery.bash-completion']),

--- a/tests/profiles/post_test.py
+++ b/tests/profiles/post_test.py
@@ -189,3 +189,11 @@ def test_check_italic_angle():
     assert_PASS(check(ttFont, {"style": "Italic"}))
     ttFont["post"].italicAngle *= -1
     assert_results_contain(check(ttFont, {"style": "Italic"}), WARN, "negative")
+
+    ttFont = TTFont(TEST_FILE("cairo/CairoPlay-Italic.rightslanted.ttf"))
+    assert_PASS(check(ttFont, {"style": "Italic"}))
+    ttFont["glyf"]["I"].endPtsOfContours = []
+    ttFont["glyf"]["I"].coordinates = []
+    ttFont["glyf"]["I"].flags = []
+    ttFont["glyf"]["I"].numberOfContours = 0
+    assert_results_contain(check(ttFont, {"style": "Italic"}), WARN, "empty-glyphs")


### PR DESCRIPTION
## Description

If any of the glyphs tested in the italic_angle check (bar, vertical line, left square bracket, etc.) have no outlines, the check will error. But that's useful information, so we turn that into a warn.

## To Do
- [x] update `CHANGELOG.md`
- [x] wait for all checks to pass
- [x] request a review

