### PR TITLE
Adding "ADLaM" to exception list

### DIFF
--- a/Lib/fontbakery/data/googlefonts/abbreviations_familyname_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/abbreviations_familyname_exceptions.txt
@@ -9,3 +9,4 @@ IBM
 STIX
 VT
 REM
+ADLaM

--- a/Lib/fontbakery/data/googlefonts/camelcased_familyname_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/camelcased_familyname_exceptions.txt
@@ -26,3 +26,4 @@ UnifrakturCook
 UnifrakturMaguntia
 SignWriting # seen in "Noto Sans SignWriting"
 WindSong
+ADLaM


### PR DESCRIPTION
## Description
Relates to https://github.com/google/fonts/pull/6522.

Adding "ADLaM" to the abbreviations and camelcase exception list to avoid fails against the font since "ADLaM" is the language name. 