### PR TITLE
Added checks to CHECKS_NOT_TO_INCLUDE

### DIFF
--- a/Lib/fontbakery/profiles/fontwerk.py
+++ b/Lib/fontbakery/profiles/fontwerk.py
@@ -39,6 +39,8 @@ def leave_this_one_out(checkid):
         "com.google.fonts/check/version_bump",
         "com.google.fonts/check/production_glyphs_similarity",
         "com.google.fonts/check/name/line_breaks",
+        "com.google.fonts/check/fontdata_namecheck",
+        "com.google.fonts/check/meta/script_lang_tags",
         # The following check they may need some improvements
         # before we decide to include it:
         "com.google.fonts/check/family/italics_have_roman_counterparts",


### PR DESCRIPTION
Adding checks to CHECKS_NOT_TO_INCLUDE which should not be tested according to Fontwerk.

## Description
This is an minor update for the fontwerk profile.


## Checklist
- [ ] update `CHANGELOG.md` Not sure if this is actually needed
- [ ] wait for the tests to pass (fontwerk profile tests passed locally)
- [ ] request a review

