### PR TITLE
Fix fontv rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.9.0 (2023-Aug-??)
-### New Checks
 ### Changes to existing checks
 #### On the Universal profile
   - **[com.agoogle.fonts/check/os2_metrics_match_hhea]:** Re-worded rationale text to be vendor-neutral (issue #4206)
 
 #### On the Google Fonts profile
+  - **[com.google.fonts/check/font-v]:** Change rationale to reflect the fact that this check emits an INFO (issue #4067)
   - **[com.google.fonts/check/vertical_metrics_regressions]:** Fix an error when the provided font did not have a Regular style. (issue #3897)
 
+### New Checks
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/metadata/primary_script]:** New check that guesses the primary script and compares to METADATA.pb (issue #4109)
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3890,7 +3890,7 @@ def com_google_fonts_check_fontdata_namecheck(ttFont, familyname):
     rationale="""
         The git sha1 tagging and dev/release features of Source Foundry `font-v` tool
         are awesome and we would love to consider upstreaming the approach into
-        fontmake someday. For now we only emit a WARN if a given font does not yet
+        fontmake someday. For now we only emit an INFO if a given font does not yet
         follow the experimental versioning style, but at some point we may start
         enforcing it.
     """,


### PR DESCRIPTION
## Description
Fixes #4067

This corrects the rationale text of the check/fontv check to reflect the fact that we emit an INFO message. I chose to change the text rather than change the behaviour (to emit a WARN) because (a) it's a less invasive and hopefully uncontroversial change and (b) the rationale explicitly states that we don't enforce this behaviour currently.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

