### PR TITLE
Rewrite os2_metrics_match_hhea rationale in a more vendor-neutral manner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## Upcoming release: 0.9.0 (2023-Aug-??)
 ### New Checks
+### Changes to existing checks
+#### On the Universal profile
+  - **[com.agoogle.fonts/check/os2_metrics_match_hhea]:** Re-worded rationale text to be vendor-neutral (issue #4206)
+
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/metadata/primary_script]:** New check that guesses the primary script and compares to METADATA.pb (issue #4109)
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -197,21 +197,12 @@ def com_google_fonts_check_family_win_ascent_and_descent(ttFont, vmetrics):
         OS/2 and hhea vertical metric values should match. This will produce the
         same linespacing on Mac, GNU+Linux and Windows.
 
-        - Mac OS X uses the hhea values.⏎
+        - Mac OS X uses the hhea values.
         - Windows uses OS/2 or Win, depending on the OS or fsSelection bit value.
 
         When OS/2 and hhea vertical metrics match, the same linespacing results on
-        macOS, GNU+Linux and Windows. Unfortunately as of 2018, Google Fonts
-        has released many fonts with vertical metrics that don't match in this way.
-        When we fix this issue in these existing families, we will create a visible
-        change in line/paragraph layout for either Windows or macOS users,
-        which will upset some of them.
-
-        But we have a duty to fix broken stuff, and inconsistent paragraph layout
-        is unacceptably broken when it is possible to avoid it.
-
-        If users complain and prefer the old broken version, they have the freedom
-        to take care of their own situation.
+        macOS, GNU+Linux and Windows. Note that fixing this issue in a previously
+        released font may cause reflow in user documents and unhappy users.
     """,
     proposal="legacy:check/042",
 )


### PR DESCRIPTION
## Description
Fixes #4206

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

