### PR TITLE
Provide some guardrails around our conditions which may return None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## Upcoming release: 0.9.0 (2023-Aug-??)
 ### New Checks
+### Changes to existing checks
+#### On the Google Fonts profile
+  - **[com.google.fonts/check/vertical_metrics_regressions]:** Fix an error when the provided font did not have a Regular style. (issue #3897)
+
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/metadata/primary_script]:** New check that guesses the primary script and compares to METADATA.pb (issue #4109)
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5505,13 +5505,13 @@ def com_google_fonts_check_vertical_metrics_regressions(
     if not ttFont:
         yield FAIL, Message(
             "couldnt-find-local-regular",
-            "Could not identify a local Regular style font"
+            "Could not identify a local Regular style font",
         )
         return
     if not gf_ttFont:
         yield FAIL, Message(
             "couldnt-find-remote-regular",
-            "Could not identify a Regular style font hosted on Google Fonts"
+            "Could not identify a Regular style font hosted on Google Fonts",
         )
         return
 
@@ -5729,13 +5729,13 @@ def com_google_fonts_check_cjk_vertical_metrics_regressions(
     if not ttFont:
         yield FAIL, Message(
             "couldnt-find-local-regular",
-            "Could not identify a local Regular style font"
+            "Could not identify a local Regular style font",
         )
         return
     if not gf_ttFont:
         yield FAIL, Message(
             "couldnt-find-remote-regular",
-            "Could not identify a Regular style font hosted on Google Fonts"
+            "Could not identify a Regular style font hosted on Google Fonts",
         )
         return
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5502,6 +5502,19 @@ def com_google_fonts_check_vertical_metrics_regressions(
     gf_ttFont = regular_remote_style
     ttFont = regular_ttFont
 
+    if not ttFont:
+        yield FAIL, Message(
+            "couldnt-find-local-regular",
+            "Could not identify a local Regular style font"
+        )
+        return
+    if not gf_ttFont:
+        yield FAIL, Message(
+            "couldnt-find-remote-regular",
+            "Could not identify a Regular style font hosted on Google Fonts"
+        )
+        return
+
     upm_scale = ttFont["head"].unitsPerEm / gf_ttFont["head"].unitsPerEm
 
     gf_has_typo_metrics = typo_metrics_enabled(gf_ttFont)
@@ -5696,7 +5709,7 @@ def com_google_fonts_check_cjk_vertical_metrics(ttFont):
 
 @check(
     id="com.google.fonts/check/cjk_vertical_metrics_regressions",
-    conditions=["is_cjk_font", "regular_remote_style"],
+    conditions=["is_cjk_font", "regular_remote_style", "regular_ttFont"],
     rationale="""
         Check CJK family has the same vertical metrics as the same family
         hosted on Google Fonts.
@@ -5712,6 +5725,19 @@ def com_google_fonts_check_cjk_vertical_metrics_regressions(
 
     gf_ttFont = regular_remote_style
     ttFont = regular_ttFont
+
+    if not ttFont:
+        yield FAIL, Message(
+            "couldnt-find-local-regular",
+            "Could not identify a local Regular style font"
+        )
+        return
+    if not gf_ttFont:
+        yield FAIL, Message(
+            "couldnt-find-remote-regular",
+            "Could not identify a Regular style font hosted on Google Fonts"
+        )
+        return
 
     upm_scale = ttFont["head"].unitsPerEm / gf_ttFont["head"].unitsPerEm
 


### PR DESCRIPTION
## Description
Fixes #3897

`regular_ttFont` may return None; we need to check for that condition and provide a sensible error instead of crashing.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

