### PR TITLE
AR added to the abbreviations exception list

### DIFF
--- a/Lib/fontbakery/data/googlefonts/abbreviations_familyname_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/abbreviations_familyname_exceptions.txt
@@ -10,3 +10,4 @@ STIX
 VT
 REM
 ADLaM
+AR


### PR DESCRIPTION
## Description
The incoming family [AR One Sans](https://github.com/google/fonts/issues/5487) will require this "Augmented Reality"`AR` abbreviation

(Provide a list of all the noteworthy changes you've done. Elaborate on any decisions you had to make, and include links and/or screenshots, if applicable)

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [x] request a review

